### PR TITLE
Multiarch production docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,54 +1,43 @@
-FROM ubuntu:disco
+FROM arm64v8/alpine:3.11 as build
 
-LABEL maintainer="Bojan Miladinovic <bojan.kv.ns@gmail.com>"
+LABEL maintainer="Sebastian Schildt <sebastian.schildt@de.bosch.com>"
 
-RUN apt-get -qq update \
-    && apt-get -qq install -y --no-install-recommends \
-       sudo=1.* \
-       wget=1.* \
-       git=1:2.* \
-       libc6-dev=2.* \
-       g++-9-multilib \
-       clang \
-       clang-tools \
-       llvm \
-       nasm=2.* \
-       libssl-dev=1.* \
-       pkg-config=0.* \
-       zlib1g-dev=1:1.* \
-       libbz2-dev=1.* \
-       curl=7.* \
-       liblzma-dev=5.* \
-       libboost1.67-all-dev \
-       make=4.* \
-       libglib2.0-dev \
-       net-tools \
-       python3-pip \
-       vim \
-    && pip3 install setuptools \
-    && pip3 install gcovr \
-    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 100 \
-    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-9 100 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 \
-    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-9 100 \
-    && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-9 100 \
-    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
-    && rm -rf /var/lib/apt/lists/* \
-    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
-    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
-       --exclude=bin/cmake-gui \
-       --exclude=doc/cmake \
-       --exclude=share/cmake-3.12/Help \
-    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
-    && rm -rf cmake-3.15.3-Linux-x86_64 \
-    && rm cmake-3.15.3-Linux-x86_64.tar.gz
 
-WORKDIR /home
+COPY docker/qemu-aarch64-static /usr/bin/qemu-aarch64-static
 
-COPY build-gcc-default.sh /home
-COPY build-gcc-coverage.sh /home
+RUN apk update && apk add cmake wget alpine-sdk glib-dev openssl-dev libstdc++
 
-COPY build-clang-default.sh /home
-COPY build-clang-coverage.sh /home
 
-EXPOSE 8090
+#Build Boost 1.67
+RUN mkdir /buildboost
+WORKDIR /buildboost
+RUN wget   https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
+RUN tar xvjf boost_1_67_0.tar.bz2
+WORKDIR /buildboost/boost_1_67_0
+RUN ./bootstrap.sh
+RUN ./b2 install
+
+
+ADD . /kuksa.val
+RUN  rm -rf /kuksa.val/build  && mkdir  /kuksa.val/build 
+WORKDIR /kuksa.val/build
+RUN cmake ..
+RUN make
+RUN ls
+RUN /kuksa.val/docker/collect-deployment-artifacts.sh
+
+
+FROM arm64v8/alpine:3.11
+
+COPY --from=build /deploy /kuksa.val
+WORKDIR /kuksa.val
+
+ENV LOG_LEVEL=INFO
+#Usually you want this to be 0.0.0.0 when using porter port expose via -p. 
+ENV BIND_ADDRESS=0.0.0.0
+
+EXPOSE 8090/tcp
+
+CMD /kuksa.val/startkuksaval.sh
+
+

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,40 @@
+# Copyright Robert Bosch GmbH, 2020. Part of the Eclipse Kuksa Project.
+#
+# All rights reserved. This configuration file is provided to you under the
+# terms and conditions of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, and is available at
+# http://www.eclipse.org/org/documents/edl-v10.php
+# Quick docker for doing development
+
+FROM ubuntu:bionic as build
+
+RUN apt-get  update 
+RUN apt-get -y install libssl-dev  \
+                        libglib2.0-dev \
+                        pkg-config \
+                        build-essential \
+                        gnupg2 \ 
+                        wget \ 
+                        software-properties-common
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null |  apt-key add -
+RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+RUN apt  update && apt -y install cmake
+
+#Build Boost 1.67
+RUN mkdir /buildboost
+WORKDIR /buildboost
+RUN wget   https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
+RUN tar xvjf boost_1_67_0.tar.bz2
+WORKDIR /buildboost/boost_1_67_0
+RUN ./bootstrap.sh
+RUN ./b2 install
+
+
+ADD . /kuksa.val
+RUN  rm -rf /kuksa.val/build  && mkdir  /kuksa.val/build 
+WORKDIR /kuksa.val/build
+RUN cmake ..
+RUN make
+
+CMD /bin/bash
+

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,0 +1,54 @@
+FROM ubuntu:disco
+
+LABEL maintainer="Bojan Miladinovic <bojan.kv.ns@gmail.com>"
+
+RUN apt-get -qq update \
+    && apt-get -qq install -y --no-install-recommends \
+       sudo=1.* \
+       wget=1.* \
+       git=1:2.* \
+       libc6-dev=2.* \
+       g++-9-multilib \
+       clang \
+       clang-tools \
+       llvm \
+       nasm=2.* \
+       libssl-dev=1.* \
+       pkg-config=0.* \
+       zlib1g-dev=1:1.* \
+       libbz2-dev=1.* \
+       curl=7.* \
+       liblzma-dev=5.* \
+       libboost1.67-all-dev \
+       make=4.* \
+       libglib2.0-dev \
+       net-tools \
+       python3-pip \
+       vim \
+    && pip3 install setuptools \
+    && pip3 install gcovr \
+    && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 100 \
+    && update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-9 100 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100 \
+    && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-9 100 \
+    && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-9 100 \
+    && ln -s /usr/include/locale.h /usr/include/xlocale.h \
+    && rm -rf /var/lib/apt/lists/* \
+    && wget --no-check-certificate --quiet https://cmake.org/files/v3.15/cmake-3.15.3-Linux-x86_64.tar.gz \
+    && tar -xzf cmake-3.15.3-Linux-x86_64.tar.gz \
+       --exclude=bin/cmake-gui \
+       --exclude=doc/cmake \
+       --exclude=share/cmake-3.12/Help \
+    && cp -fR cmake-3.15.3-Linux-x86_64/* /usr \
+    && rm -rf cmake-3.15.3-Linux-x86_64 \
+    && rm cmake-3.15.3-Linux-x86_64.tar.gz
+
+WORKDIR /home
+
+COPY build-gcc-default.sh /home
+COPY build-gcc-coverage.sh /home
+
+COPY build-clang-default.sh /home
+COPY build-clang-coverage.sh /home
+
+EXPOSE 8090

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -1,0 +1,76 @@
+#  Dockerfiles
+
+
+Dockerfiles.test ist for setting up an environment to play/develop VSS
+
+## Development Docker
+Not optimized a t all, just gets  Ubuntu installed and does a first compile. Will drop you to a shell
+
+To build go to kuksa.val main dir and do
+
+```
+docker build -f docker/Dockerfile.dev -t kuksavaltest . 
+```
+
+To run
+
+```
+docker run -it --net=host kuksavaltest:latest 
+```
+
+## Production docker
+To run kuksa.val on target hardware use an optimized docker build based on alpine. It is built the "Kuksa-way" allowing easy builds for different architectures.
+
+### Build prerequisites
+
+1. Enable docker experimental feature.
+
+Create a daemon.json file in /etc/docker/ and add 
+
+```
+{
+  "experimental" : true
+}
+```
+
+and restart docker daemon using  `sudo systemctl restart docker`
+
+https://github.com/docker/docker-ce/blob/master/components/cli/experimental/README.md
+
+2. install  qemu-user-static package on the host machine
+
+ use 
+ 
+ ```sudo apt-get install qemu-user-static```
+
+### Build
+
+The `Dockerfile` is supposed to 
+be run through the magic build.sh wrapper.
+
+To build for amd64 do
+
+`./build.sh amd64`
+
+To build for ARM64 (armv8) do
+
+`/build.sh arm64`
+
+This image can also run on a Raspberry _if_ you installed a 64 bit operating system.
+
+For vanilla Raspbian try (untested) the `arm32v6` parameter
+
+Please note that building for ARM is MUCH slower on an x64 amchien as it is uses qemu emulation. THe created container does not use qemu and therefore can only be run on the correct target hardware
+
+
+### Run build docker
+To start it run e.g.
+
+
+```
+docker run -it  -p 127.0.0.1:8090:8090 --mount type=bind,source=/path/to/myconfig,target=/config amd64/kuksa-val:0.1.1
+```
+
+ `/path/to/myconfig ` is a folder where a `vss.json` datamodel is expected and a subdirectory `/path/to/myconfig/certs` containing at least the server key (`Server.key`) and certificate (`Server.pem`). If those files do not exist default files will be copied automatically
+
+

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+########################################################################
+# Copyright (c) 2018-2020 Robert Bosch GmbH
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+
+VERSION="0.1.1"
+NAME="kuksa-val"
+
+if [ -z "$VERSION" ]; then
+    echo "Failed to extract version string" 1>&2
+    exit 1
+fi
+
+EXPERIMENTAL=`docker version | grep Experimental | tail -n 1 | xargs`
+if [ "$EXPERIMENTAL" != "Experimental: true" ]; then
+    echo "Please enable the docker engine's experimental features" 1>&2
+    exit 1
+fi
+
+function build {
+    ARCH=$1
+
+    # generate Dockerfile.build
+    case ${ARCH} in
+    'amd64')
+        sed -e "s/arm64v8/amd64/g" Dockerfile > Dockerfile.build
+        sed -i -e "s/^.*qemu-aarch64-static.*$//g" Dockerfile.build
+        ;;
+    'arm64')
+        cp /usr/bin/qemu-aarch64-static ./
+        if [ "$?" != "0" ]; then
+            echo "Please install the qemu-user-static package" 1>&2
+            exit 1
+        fi
+        cp Dockerfile Dockerfile.build
+        ;;
+     'arm32v7')
+        cp /usr/bin/qemu-arm-static ./
+        if [ "$?" != "0" ]; then
+            echo "Please install the qemu-user-static package" 1>&2
+            exit 1
+        fi
+        sed -e "s/arm64v8/arm32v7/g" Dockerfile > Dockerfile.build
+        sed -i -e "s/qemu-aarch64-static/qemu-arm-static/g" Dockerfile.build
+        ;;
+    'arm32v6')
+        cp /usr/bin/qemu-arm-static ./
+        if [ "$?" != "0" ]; then
+            echo "Please install the qemu-user-static package" 1>&2
+            exit 1
+        fi
+        sed -e "s/arm64v8/arm32v6/g" Dockerfile > Dockerfile.build
+        sed -i -e "s/qemu-aarch64-static/qemu-arm-static/g" Dockerfile.build
+        ;;
+    *)
+        echo "Unsupported architecture: $ARCH" 1>&2
+        exit 1
+        ;;
+    esac
+
+    # build image
+    cd ../
+    docker build --squash --platform linux/$ARCH -f ./docker/Dockerfile.build -t ${ARCH}/${NAME}:${VERSION} .
+    cd docker
+
+    # cleanup
+    rm -f Dockerfile.build
+    rm -f qemu-aarch64-static
+    rm -f qemu-arm-static
+}
+
+MYDIR=$(dirname "$0")
+cd $MYDIR
+
+ARCHS="$@"
+if [ -z "$ARCHS" ]; then
+    ARCHS="amd64 arm64 arm32v6"
+fi
+
+for ARCH in $ARCHS; do
+    build $ARCH
+done
+
+cd $OLDDIR

--- a/docker/collect-deployment-artifacts.sh
+++ b/docker/collect-deployment-artifacts.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+#
+# Copyright Robert Bosch GmbH, 2020. Part of the Eclipse Kuksa Project.
+#
+# All rights reserved. This configuration file is provided to you under the
+# terms and conditions of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, and is available at
+# http://www.eclipse.org/org/documents/edl-v10.php
+#
+# Helper script to collect executables, config and libraries needed for minimal docker
+
+mkdir /deploy
+cp /kuksa.val/build/src/w3c-visserver /deploy
+
+cp /kuksa.val/docker/startkuksaval.sh /deploy
+
+ldd /kuksa.val/build/src/w3c-visserver | grep "=>" | awk '{print $3}' |   xargs -I '{}' cp -v '{}' /deploy
+
+mkdir /deploy/exampleconfig
+mkdir /deploy/exampleconfig/certs
+
+cp /kuksa.val/build/src/vss_rel_2.0.json  /deploy/exampleconfig/vss.json
+cp /kuksa.val/build/src/Server.key /deploy/exampleconfig/kuksa.val.key
+cp /kuksa.val/certificates/* /deploy/exampleconfig/certs/

--- a/docker/startkuksaval.sh
+++ b/docker/startkuksaval.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# 
+# Copyright Robert Bosch GmbH, 2020. Part of the Eclipse Kuksa Project.
+#
+# All rights reserved. This configuration file is provided to you under the
+# terms and conditions of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, and is available at
+# http://www.eclipse.org/org/documents/edl-v10.php
+#
+# Script for starting kuksa.val inside docker
+
+echo "Starting kuksa.val"
+
+
+if [ -e /config/vss.json ]
+then
+    echo "Using existing vss tree"
+else
+    echo "No VSS tree, initilaize with example"
+    cp /kuksa.val/exampleconfig/vss.json /config/
+fi
+
+mkdir -p /config/certs
+
+if [ -e /config/certs/Server.key ]
+then
+    echo "Using existing server keys"
+else
+    echo "No server keys configured, initialize with example"
+    cp /kuksa.val/exampleconfig/certs/Server.key /config/certs/
+    cp /kuksa.val/exampleconfig/certs/Server.pem /config/certs/
+fi
+
+
+LD_LIBRARY_PATH=./ ./w3c-visserver --vss /config/vss.json --cert-path /config/certs --log-level $LOG_LEVEL --address $BIND_ADDRESS


### PR DESCRIPTION
I began cleaning & making useful dockers

- A new "effcient" small docker that can be deployed and is prepared for multiarch builds using kuksa magic
 - A more "sane", i.e. standard docker for quick testing/development based on stable ubuntu

For know I left Bojans test docker, as it includes some fancy stuff for compiling with clang etc., that still might be helpful for catching bugs

In both cases server starts, haven't spent so much time in setting up keys & stuff, still waiting for @tspreck updated docs/scripts...

@tspreck Please test, that you can at least build the amd64 "production" docker, everything esl is optional for now

@rohoet @daschubert  I am pretty sure there are no new dependencies... But I said that before, so please take a quick glance.... "New" docker build scripts are basically from kuksa.apps
