### PR TITLE
Fix docker container and jenkins build

### DIFF
--- a/docker/collect-deployment-artifacts.sh
+++ b/docker/collect-deployment-artifacts.sh
@@ -21,4 +21,4 @@ mkdir /deploy/exampleconfig/certs
 
 cp /kuksa.val/build/src/vss_rel_2.0.json  /deploy/exampleconfig/vss.json
 cp /kuksa.val/build/src/Server.key /deploy/exampleconfig/kuksa.val.key
-cp /kuksa.val/certificates/* /deploy/exampleconfig/certs/
+cp -r  /kuksa.val/certificates/* /deploy/exampleconfig/certs/

--- a/src/Authenticator.cpp
+++ b/src/Authenticator.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <list>
 #include <string>
+#include <unistd.h>
 
 #include <jwt-cpp/jwt.h>
 #include <jsoncons/json.hpp>
@@ -31,11 +32,16 @@ using jsoncons::json;
 string Authenticator::getPublicKeyFromFile(string fileName, std::shared_ptr<ILogger> logger) {
   logger->Log(LogLevel::VERBOSE, "Try reading JWT pub key from "+fileName);
 
-   std::ifstream fileStream(fileName);
-   if (fileStream.fail()) {
+  if ( access(fileName.c_str(),F_OK) != 0 )
+  {
+    logger->Log(LogLevel::ERROR, "Unable to find JWT pub key "+fileName);
+    return "";
+  }
+  std::ifstream fileStream(fileName);
+  if (fileStream.fail()) {
     logger->Log(LogLevel::ERROR, "Unable to open JWT pub key "+fileName);
-   }
-   std::string key((std::istreambuf_iterator<char>(fileStream)),
+  }
+  std::string key((std::istreambuf_iterator<char>(fileStream)),
                    (std::istreambuf_iterator<char>()));
   return key;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,7 +305,7 @@ int main(int argc, const char *argv[]) {
     // older by having API versioning through URIs
     std::string docRoot{"/vss/api/v1/"};
 
-    string jwtPubkey=Authenticator::getPublicKeyFromFile("jwt.key.pub",logger);
+    string jwtPubkey=Authenticator::getPublicKeyFromFile(variables["cert-path"].as<string>()+"/jwt.key.pub",logger);
     if (jwtPubkey == "" ) {
         logger->Log(LogLevel::ERROR, "Could not read valid JWT pub key. Terminating.");
         return -1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -305,12 +305,17 @@ int main(int argc, const char *argv[]) {
     // older by having API versioning through URIs
     std::string docRoot{"/vss/api/v1/"};
 
+    string jwtPubkey=Authenticator::getPublicKeyFromFile("jwt.key.pub",logger);
+    if (jwtPubkey == "" ) {
+        logger->Log(LogLevel::ERROR, "Could not read valid JWT pub key. Terminating.");
+        return -1;
+    }
+
     auto rest2JsonConverter =
         std::make_shared<RestV1ApiHandler>(logger, docRoot);
     auto httpServer = std::make_shared<WebSockHttpFlexServer>(
         logger, std::move(rest2JsonConverter));
 
-    string jwtPubkey=Authenticator::getPublicKeyFromFile("jwt.key.pub",logger);
     auto tokenValidator =
         std::make_shared<Authenticator>(logger, jwtPubkey, "RS256");
     auto accessCheck = std::make_shared<AccessChecker>(tokenValidator);


### PR DESCRIPTION
This is a simple fix with no additonal dependenices

 - fix jenkins: It wasn't able to create containers due to a script collecting the artifacts failing
 - make sure the jwt.key is searched in the certificate directory and not in the cwd (otherwise it can not be easily configured in dockers
 - Terminate if jwt key can not be loaded on startup (without a valid JWT key you can not do anything anyway)

tested by a colleague (who needed this fix) 

@daschubert  or @rohoet no dependencies, IMO can be merged directly