### PR TITLE
Return error code when docker build runs into problems

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -68,6 +68,10 @@ function build {
     # build image
     cd ../
     docker build --squash --platform linux/$ARCH -f ./docker/Dockerfile.build -t ${ARCH}/${NAME}:${VERSION} .
+    if [ "$?" != "0" ]; then
+        echo "Docker build failed."
+        exit 1
+    fi
     cd docker
 
     # cleanup


### PR DESCRIPTION
Makes sure scripts returns with an error when docker build fails, so Jenkins notices and doesn't start archiving stale docker images