### PR TITLE
Disable MQTT in default/unit-test config

### DIFF
--- a/unit-test/config.ini
+++ b/unit-test/config.ini
@@ -4,5 +4,5 @@ log-level = ALL
 cert-path = .
 
 [mqtt]
-    publish = *
+    publish = 
     topic-prefix = vss


### PR DESCRIPTION
Disable MQTT feature in default config, as there are no MQTT unit tests at the moment and this file is also copied into the build folder. Starting kuksa.val server with MQTT enabled and no MQTT broker present, leads to unnecessary errors


Can be merged @rohoet  @daschubert 