### PR TITLE
Fix docker image tagging in  jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,8 +27,8 @@ node('docker') {
         }
         stage('Collect') {
 			sh '''
-            sudo docker save $(sudo docker images --filter "reference=amd64/kuksa-val*" -q | head -1) | bzip2 -9 > artifacts/kuksa-val-amd64.tar.bz2
-			sudo docker save $(sudo docker images --filter "reference=arm64/kuksa-val*" -q | head -1) | bzip2 -9 > artifacts/kuksa-val-arm64.tar.bz2
+            sudo docker save $(sudo docker images --filter "reference=amd64/kuksa-val*"  --format "{{.Repository}}:{{.Tag}}" | head -1) | bzip2 -9 > artifacts/kuksa-val-amd64.tar.bz2
+			sudo docker save $(sudo docker images --filter "reference=amd64/kuksa-val*"  --format "{{.Repository}}:{{.Tag}}" | head -1) | bzip2 -9 > artifacts/kuksa-val-arm64.tar.bz2
 			sudo docker save kuksa-val-dev:ubuntu20.04 | bzip2 -9 > artifacts/kuksa-val-dev-ubuntu20.04.tar.bz2
             '''
         }

--- a/README.md
+++ b/README.md
@@ -280,14 +280,14 @@ sudo docker build . --build-arg  http_proxy=$http_proxy --build-arg https_proxy=
 Once Docker image is built, we can run it by using the  run command:
 
 ```
-sudo docker run -it -v $HOME/kuksaval.config:/config -e LOG_LEVEL=ALL amd64/kuksa-val:0.1.1
+sudo docker run -it -v $HOME/kuksaval.config:/config  -p 127.0.0.1:8090:8090 -e LOG_LEVEL=ALL amd64/kuksa-val:0.1.1
 ```
 where `$HOME/kuksaval.config` is a directory on your host machine containing the KUKSA.VAL configuration. The directory can be empty, then it will be populated with an exmple configuration during start.
 
 The environment variable `KUKSAVAL_OPTARGS` can be used to add arbitrary command line arguments e.g.
 
 ```
-sudo docker run -it -v $HOME/kuksaval.config:/config -e LOG_LEVEL=ALL -e KUKSAVAL_OPTARGS="--insecure" amd64/kuksa-val:0.1.1
+sudo docker run -it -v $HOME/kuksaval.config:/config  -p 127.0.0.1:8090:8090 -e LOG_LEVEL=ALL -e KUKSAVAL_OPTARGS="--insecure" amd64/kuksa-val:0.1.1
 
 ```
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -10,7 +10,7 @@
 # SPDX-License-Identifier: EPL-2.0
 ########################################################################
 
-VERSION="0.1.1"
+VERSION="0.1.2"
 NAME="kuksa-val"
 
 if [ -z "$VERSION" ]; then


### PR DESCRIPTION
Our "production" dockers did not have tags attached when "loading" them, because we saved them basing on SHA Hash (see here https://github.com/moby/moby/issues/3877 )  

This has been fixed.

Also the docu was missing to expose a port.

@wenwenchenbosch This fix couldn't possibly go wrong, but pls. check if it still builds/works for you 😄 