### PR TITLE
add autocompletion and colored output

### DIFF
--- a/vss-testclient/Pipfile
+++ b/vss-testclient/Pipfile
@@ -8,6 +8,7 @@ verify_ssl = true
 [packages]
 cmd2 = "*"
 websockets = "*"
+pygments = "*"
 
 [requires]
 python_version = "3.8"

--- a/vss-testclient/Pipfile.lock
+++ b/vss-testclient/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f31971a334aed46bae7d2a414e52f2f9cfd637ead14751e821080061104c27c8"
+            "sha256": "da15ceef7f9592dd623787d80e562f3040fd9d7b22afe120567ca2c9188a5d7d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,25 +18,35 @@
     "default": {
         "attrs": {
             "hashes": [
-                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
-                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+                "sha256:0ef97238856430dcf9228e07f316aefc17e8939fc8507e18c6501b761ef1a42a",
+                "sha256:2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff"
             ],
-            "version": "==19.3.0"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==20.1.0"
         },
         "cmd2": {
             "hashes": [
-                "sha256:5a5d3361fadada16cae0c99b65eba5d49d587fc2e02b3afb058da1872871e7a9",
-                "sha256:f48bac4352b4c710664570fe753eeab568ccc4a438fb482081df79a3df13442c"
+                "sha256:a0a8705dfd7443cc4a371c8f84608b2f8119bb6693976e6442d2c7099474b270",
+                "sha256:b6f6254def8ba479088702f97bca1b999c12e0c38ac5d82dc50a44db93c7108c"
             ],
             "index": "pypi",
-            "version": "==1.2.1"
+            "version": "==1.3.8"
         },
         "colorama": {
             "hashes": [
                 "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff",
                 "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.4.3"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44",
+                "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"
+            ],
+            "index": "pypi",
+            "version": "==2.6.1"
         },
         "pyperclip": {
             "hashes": [


### PR DESCRIPTION
add the following feature:
- autocompletion path for `getValue`, `setValue` and `getMetaData`
- autocompletion files only `.token` file
- colored json output

unfortunately, cmd2 does not support coloring input and autocompletion text. @SebastianSchildt & @nayakned : If you can some thing about it, pls let me know