### PR TITLE
Feature/better image compression

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ node('docker') {
             '''
         }
         stage ('Archive') {
-            archiveArtifacts artifacts: 'artifacts/*.bz2' 
+            archiveArtifacts artifacts: 'artifacts/*.xz' 
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,9 +28,9 @@ node('docker') {
         }
         stage('Collect') {
 			sh '''
-            sudo docker save $(sudo docker images --filter "reference=amd64/kuksa-val*"  --format "{{.Repository}}:{{.Tag}}" | head -1) | bzip2 -9 > artifacts/kuksa-val-amd64.tar.bz2
-			sudo docker save $(sudo docker images --filter "reference=arm64/kuksa-val*"  --format "{{.Repository}}:{{.Tag}}" | head -1) | bzip2 -9 > artifacts/kuksa-val-arm64.tar.bz2
-			sudo docker save kuksa-val-dev:ubuntu20.04 | bzip2 -9 > artifacts/kuksa-val-dev-ubuntu20.04.tar.bz2
+            sudo docker save $(sudo docker images --filter "reference=amd64/kuksa-val*"  --format "{{.Repository}}:{{.Tag}}" | head -1) | xz -T 0 > artifacts/kuksa-val-amd64.tar.xz
+			sudo docker save $(sudo docker images --filter "reference=arm64/kuksa-val*"  --format "{{.Repository}}:{{.Tag}}" | head -1) | xz -T 0 > artifacts/kuksa-val-arm64.tar.xz
+			sudo docker save kuksa-val-dev:ubuntu20.04 | xz -T 0 > artifacts/kuksa-val-dev-ubuntu20.04.tar.xz
             '''
         }
         stage ('Archive') {


### PR DESCRIPTION
This switches docker image format to xz instead of bzip. Advantages

 - The compressors is multithreaded, so actually compression is faster during build
 - The images are smaller
 - xz also directly supported by docker load, so no disadvantages