### PR TITLE
Fix w3cunittest utests

### DIFF
--- a/src/VssDatabase.cpp
+++ b/src/VssDatabase.cpp
@@ -185,7 +185,30 @@ namespace {
 
       throw genException(msg);
     }
-    dest[key] = source["value"].as<string>();
+    if (source["datatype"] == "uint8")
+      dest[key] = source["value"].as<uint8_t>();
+    else if (source["datatype"] == "int8")
+      dest[key] = source["value"].as<int8_t>();
+    else if (source["datatype"] == "uint16")
+      dest[key] = source["value"].as<uint16_t>();
+    else if (source["datatype"] == "int16")
+      dest[key] = source["value"].as<int16_t>();
+    else if (source["datatype"] == "uint32")
+      dest[key] = source["value"].as<uint32_t>();
+    else if (source["datatype"] == "int32")
+      dest[key] = source["value"].as<int32_t>();
+    else if (source["datatype"] == "uint64")
+      dest[key] = source["value"].as<uint64_t>();
+    else if (source["datatype"] == "int64")
+      dest[key] = source["value"].as<int64_t>();
+    else if (source["datatype"] == "boolean")
+      dest[key] = source["value"].as<bool>();
+    else if (source["datatype"] == "float")
+      dest[key] = source["value"].as<float>();
+    else if (source["datatype"] == "double")
+      dest[key] = source["value"].as<double>();
+    else if (source["datatype"] == "string")
+      dest[key] = source["value"].as<std::string>();
   }
 }
 

--- a/test/unit-test/RestV1ApiHandlerTests.cpp
+++ b/test/unit-test/RestV1ApiHandlerTests.cpp
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_ValidSignalTarget_Shall_ReturnValidJso
 
     BOOST_TEST(resultJson["action"].as<std::string>() == "get");
     BOOST_TEST(resultJson["path"].as<std::string>() == target);
-    BOOST_TEST(resultJson.has_key("requestId"));
+    BOOST_TEST(resultJson.contains("requestId"));
   }
 }
 
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_ValidMetadataTarget_Shall_ReturnValidJ
 
     BOOST_TEST(resultJson["action"].as<std::string>() == "getMetadata");
     BOOST_TEST(resultJson["path"].as<std::string>() == target);
-    BOOST_TEST(resultJson.has_key("requestId"));
+    BOOST_TEST(resultJson.contains("requestId"));
   }
 }
 
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(Given_PutMethod_When_ValidSignalTargetValues_Shall_ReturnVa
     BOOST_TEST(resultJson["action"].as<std::string>() == "set");
     BOOST_TEST(resultJson["path"].as<std::string>() == target.first);
     BOOST_TEST(resultJson["value"].as<std::string>() == target.second);
-    BOOST_TEST(resultJson.has_key("requestId"));
+    BOOST_TEST(resultJson.contains("requestId"));
   }
 
   // verify empty value
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(Given_PutMethod_When_ValidSignalTargetValues_Shall_ReturnVa
   BOOST_TEST(resultJson["action"].as<std::string>() == "set");
   BOOST_TEST(resultJson["path"].as<std::string>() == "Signal");
   BOOST_TEST(resultJson["value"].as<std::string>() == "");
-  BOOST_TEST(resultJson.has_key("requestId"));
+  BOOST_TEST(resultJson.contains("requestId"));
 }
 
 BOOST_AUTO_TEST_CASE(Given_PostMethod_When_ValidAuthorizeTarget_Shall_ReturnValidJson)
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(Given_PostMethod_When_ValidAuthorizeTarget_Shall_ReturnVali
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "authorize");
   BOOST_TEST(resultJson["tokens"].as<std::string>() == "header.payload.signature");
-  BOOST_TEST(resultJson.has_key("requestId"));
+  BOOST_TEST(resultJson.contains("requestId"));
 }
 
 ////////////////////
@@ -198,7 +198,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_InvalidRootResourceTarget_Shall_Return
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "get");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   auto errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 400);
 }
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_InvalidTargetFormats_Shall_ReturnValid
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "get");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   auto errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 404);
 
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_InvalidTargetFormats_Shall_ReturnValid
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "get");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 400);
 
@@ -243,7 +243,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_InvalidTargetFormats_Shall_ReturnValid
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "get");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 400);
 
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_InvalidTargetFormats_Shall_ReturnValid
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "get");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 400);
 }
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(Given_PutMethod_When_InvalidTargetString_Shall_ReturnValidE
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "set");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   auto errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 400);
 
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(Given_PutMethod_When_InvalidTargetString_Shall_ReturnValidE
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "set");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 400);
 
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(Given_PutMethod_When_InvalidTargetString_Shall_ReturnValidE
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "set");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 400);
 }
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(Given_PostMethod_When_InvalidAuthorizeTargetString_Shall_Re
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "authorize");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   auto errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 400);
 
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(Given_PostMethod_When_InvalidAuthorizeTargetString_Shall_Re
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "authorize");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 400);
 
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE(Given_PostMethod_When_InvalidAuthorizeTargetString_Shall_Re
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "authorize");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 400);
 
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE(Given_PostMethod_When_InvalidAuthorizeTargetString_Shall_Re
   resultJson = jsoncons::json::parse(resultStr);
 
   BOOST_TEST(resultJson["action"].as<std::string>() == "authorize");
-  BOOST_TEST(resultJson.has_key("error"));
+  BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
   BOOST_TEST(errJson["number"].as<int>() == 400);
 }

--- a/test/unit-test/VssCommandProcessorTests.cpp
+++ b/test/unit-test/VssCommandProcessorTests.cpp
@@ -898,13 +898,13 @@ BOOST_AUTO_TEST_CASE(Given_ValidGetMetadataQuery_When_UserAuthorized_Shall_GetMe
   channel.setAuthorized(true);
   channel.setConnID(1);
 
-  jsonGetMetaRequest["action"] = "getMetadata";
+  jsonGetMetaRequest["action"] = "getMetaData";
   jsonGetMetaRequest["requestId"] = requestId;
   jsonGetMetaRequest["path"] = path;
 
   jsonMetadata = json::parse("{\"Vehicle\": {\"children\": { \"Drivetrain\": {\"children\": {\"Transmission\": { \"children\": {\"TravelledDistance\": {\"datatype\": \"float\",\"description\": \"Odometer reading\",\"type\": \"sensor\",\"unit\": \"km\",\"uuid\": \"d0e3b50d81a1521da0fbf5cbd1cab95c\"} }, \"description\": \"Transmission-specific data, stopping at the drive shafts.\", \"type\": \"branch\", \"uuid\": \"e198a8805b345c8c818558bc79b0ce25\"}},\"description\": \"Drivetrain data for internal combustion engines, transmissions, electric motors, etc.\",\"type\": \"branch\",\"uuid\": \"8876a6c501b658688843d3d5566e4963\" }},\"description\": \"High-level vehicle data.\",\"type\": \"branch\",\"uuid\": \"1c72453e738511e9b29ad46a6a4b77e9\"} }");
 
-  jsonValue["action"] = "getMetadata";
+  jsonValue["action"] = "getMetaData";
   jsonValue["requestId"] = requestId;
   jsonValue["timestamp"] = 11111111;
   jsonValue["metadata"] = jsonMetadata;

--- a/test/unit-test/VssDatabaseTests.cpp
+++ b/test/unit-test/VssDatabaseTests.cpp
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(Given_ValidVssFilename_When_GetMetadataForInvalidPath_Shall
   // verify
 
   BOOST_CHECK_NO_THROW(returnJson = db->getMetaData(signalPath));
-  BOOST_TEST(returnJson == 0);
+  BOOST_TEST(returnJson == jsoncons::json());
 }
 
 BOOST_AUTO_TEST_CASE(Given_ValidVssFilenameAndChannelAuthorized_When_GetSingleSignal_Shall_ReturnSignal) {
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(Given_ValidVssFilenameAndChannelAuthorized_When_SetSingleSi
   jsoncons::json setValue, returnJson;
   setValue = 10;
 
-  MOCK_EXPECT(accCheckMock->checkPathWriteAccess)
+  MOCK_EXPECT(accCheckMock->checkWriteAccess)
     .returns(true);
   MOCK_EXPECT(accCheckMock->checkReadAccess)
     .returns(true);
@@ -228,7 +228,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidVssFilenameAndChannelAuthorized_When_SetSingleSi
     .at_least(1)
     .with(mock::any, 10)
     .returns(0);
-
+  MOCK_EXPECT(subHandlerMock->updateByPath)
+    .at_least(1)
+    .with(signalPath, 10)
+    .returns(0);
   // verify
 
   BOOST_CHECK_NO_THROW(db->setSignal(channel, signalPath, setValue));
@@ -252,7 +255,7 @@ BOOST_AUTO_TEST_CASE(Given_ValidVssFilenameAndChannelAuthorized_When_SetPath_Sha
   jsoncons::json setValue, returnJson;
   setValue = 10;
 
-  MOCK_EXPECT(accCheckMock->checkPathWriteAccess)
+  MOCK_EXPECT(accCheckMock->checkWriteAccess)
     .returns(true);
   MOCK_EXPECT(accCheckMock->checkReadAccess)
     .returns(true);
@@ -277,7 +280,7 @@ BOOST_AUTO_TEST_CASE(Given_ValidVssFilenameAndChannelNotAuthorized_When_SetPath_
   jsoncons::json setValue, returnJson;
   setValue = 10;
 
-  MOCK_EXPECT(accCheckMock->checkPathWriteAccess)
+  MOCK_EXPECT(accCheckMock->checkWriteAccess)
     .returns(false);
 
   // verify
@@ -303,7 +306,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidVssFilenameAndChannelAuthorized_When_SetSingleSi
     .at_least(1)
     .with(mock::any, 10)
     .returns(0);
-
+  MOCK_EXPECT(subHandlerMock->updateByPath)
+    .at_least(1)
+    .with(signalPath, 10)
+    .returns(0);
   // verify
 
   BOOST_CHECK_NO_THROW(db->setSignal(signalPath, setValue));

--- a/test/unit-test/test_vss_rel_2.0.json
+++ b/test/unit-test/test_vss_rel_2.0.json
@@ -79,7 +79,7 @@
               }, 
               "EngineStopStartEnabled": {
                 "description": "Indicates whether eco start stop is currently enabled", 
-                "datatype": "boolean", 
+                "datatype": "boolean",
                 "type": "sensor", 
                 "uuid": "0e2775a0bbc15cb2ab1ac830b574a2b6"
               }, 
@@ -109,7 +109,7 @@
               }, 
               "LowFuelLevel": {
                 "description": "Indicates that the fuel level is low (e.g. <50km range)", 
-                "datatype": "boolean", 
+                "datatype": "boolean",
                 "type": "sensor", 
                 "uuid": "71e455a6a688587cb6b4c3940cf4088a"
               }, 
@@ -459,7 +459,7 @@
               }, 
               "LowBatteryLevel": {
                 "description": "Indicates that the battery level is low", 
-                "datatype": "Boolean", 
+                "datatype": "boolean",
                 "type": "sensor", 
                 "uuid": "8fd64a09cc1d51dbb50f4f9f1b8a8ac0"
               }
@@ -599,13 +599,13 @@
                     "children": {
                       "IsChildLockActive": {
                         "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "sensor", 
                         "uuid": "cdde633796e35eaf8ec8b1c738238e74"
                       }, 
                       "IsLocked": {
                         "description": "Is door locked or unlocked. True = Locked. False = Unlocked.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "705dd6dce5b05aa693bed8192a98be15"
                       }, 
@@ -654,7 +654,7 @@
                           }, 
                           "ChildLock": {
                             "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "40156ef737385948b1fc2a7ee09a5254"
                           }, 
@@ -673,7 +673,7 @@
                           }, 
                           "isOpen": {
                             "description": "Is door open or closed", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "eb3d4e7c097156d4857ba4a83ab41384"
                           }
@@ -681,7 +681,7 @@
                       }, 
                       "IsOpen": {
                         "description": "Is door open or closed", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "37b669115f4b5ef385e291c4c63cd379"
                       }
@@ -694,13 +694,13 @@
                     "children": {
                       "IsChildLockActive": {
                         "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "sensor", 
                         "uuid": "fb82ad2ee8715b318609a3d5a447ca95"
                       }, 
                       "IsLocked": {
                         "description": "Is door locked or unlocked. True = Locked. False = Unlocked.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "46d4f2a286df5ed8a322286786153bbc"
                       }, 
@@ -749,7 +749,7 @@
                           }, 
                           "ChildLock": {
                             "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "5c2d56b68c995beba19555e3cf561fe2"
                           }, 
@@ -768,7 +768,7 @@
                           }, 
                           "isOpen": {
                             "description": "Is door open or closed", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "693a761c83be5ee78f2983ca23b3de76"
                           }
@@ -776,7 +776,7 @@
                       }, 
                       "IsOpen": {
                         "description": "Is door open or closed", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "9ba75ef2c8ca565db21916669b638b95"
                       }
@@ -795,13 +795,13 @@
                     "children": {
                       "IsChildLockActive": {
                         "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "sensor", 
                         "uuid": "60233baf6af4508aae126a9060d17a0a"
                       }, 
                       "IsLocked": {
                         "description": "Is door locked or unlocked. True = Locked. False = Unlocked.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "42c2846551815419a9fb4234cb4d4bae"
                       }, 
@@ -850,7 +850,7 @@
                           }, 
                           "ChildLock": {
                             "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "06a1863081785b84812fc048bca0e7b0"
                           }, 
@@ -869,7 +869,7 @@
                           }, 
                           "isOpen": {
                             "description": "Is door open or closed", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "45a3642d7df0560bb45316796a948317"
                           }
@@ -877,7 +877,7 @@
                       }, 
                       "IsOpen": {
                         "description": "Is door open or closed", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "0261b96ab48551b2bd086885251ede5c"
                       }
@@ -889,13 +889,13 @@
                     "children": {
                       "IsChildLockActive": {
                         "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "sensor", 
                         "uuid": "799d221ebdd95f89bf07736e30fe560c"
                       }, 
                       "IsLocked": {
                         "description": "Is door locked or unlocked. True = Locked. False = Unlocked.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "fc6e70f126d15a9d8f047f10e824cd3e"
                       }, 
@@ -944,7 +944,7 @@
                           }, 
                           "ChildLock": {
                             "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "ad1226372c31599cbf06c6133e5dcb2d"
                           }, 
@@ -963,7 +963,7 @@
                           }, 
                           "isOpen": {
                             "description": "Is door open or closed", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "51e3a1d5ae3a52e8af83152c798da539"
                           }
@@ -971,7 +971,7 @@
                       }, 
                       "IsOpen": {
                         "description": "Is door open or closed", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "61abb6434b0155558be4861fffd35f40"
                       }
@@ -993,13 +993,13 @@
                     "children": {
                       "IsChildLockActive": {
                         "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "sensor", 
                         "uuid": "347f238149265e328403300d48460273"
                       }, 
                       "IsLocked": {
                         "description": "Is door locked or unlocked. True = Locked. False = Unlocked.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "ff7496a81cfa509789455faae41224f7"
                       }, 
@@ -1048,7 +1048,7 @@
                           }, 
                           "ChildLock": {
                             "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "14b74b209199538996585d3acb6c7374"
                           }, 
@@ -1067,7 +1067,7 @@
                           }, 
                           "isOpen": {
                             "description": "Is door open or closed", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "847c4e363477585897a33bf108259c5d"
                           }
@@ -1075,7 +1075,7 @@
                       }, 
                       "IsOpen": {
                         "description": "Is door open or closed", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "e7056a978bbb521aa2d9fd18cc87c6c3"
                       }
@@ -1088,13 +1088,13 @@
                     "children": {
                       "IsChildLockActive": {
                         "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "sensor", 
                         "uuid": "714fddbd855957d5aa930939792e5e54"
                       }, 
                       "IsLocked": {
                         "description": "Is door locked or unlocked. True = Locked. False = Unlocked.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "812328589f1b588e93254fd0bfee086e"
                       }, 
@@ -1143,7 +1143,7 @@
                           }, 
                           "ChildLock": {
                             "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "add0d57b0ea950c58022cbb6b64c6ec9"
                           }, 
@@ -1162,7 +1162,7 @@
                           }, 
                           "isOpen": {
                             "description": "Is door open or closed", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "1e9aa070f93056a583e530a67e1d3f60"
                           }
@@ -1170,7 +1170,7 @@
                       }, 
                       "IsOpen": {
                         "description": "Is door open or closed", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "212be242cf0759e2967aaf29765af2b4"
                       }
@@ -1190,13 +1190,13 @@
                     "children": {
                       "IsChildLockActive": {
                         "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "sensor", 
                         "uuid": "aff556436430572dbba10715044b0f10"
                       }, 
                       "IsLocked": {
                         "description": "Is door locked or unlocked. True = Locked. False = Unlocked.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "190adc54d13e5aa9b0b14dbfebd09df1"
                       }, 
@@ -1245,7 +1245,7 @@
                           }, 
                           "ChildLock": {
                             "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "f10d0cf5978c578ba7f598919fbbe021"
                           }, 
@@ -1264,7 +1264,7 @@
                           }, 
                           "isOpen": {
                             "description": "Is door open or closed", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "a3be8a0428fd55e0977005cc40a77f72"
                           }
@@ -1272,7 +1272,7 @@
                       }, 
                       "IsOpen": {
                         "description": "Is door open or closed", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "75008998af6155aeb4b34f74475f9211"
                       }
@@ -1284,13 +1284,13 @@
                     "children": {
                       "IsChildLockActive": {
                         "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "sensor", 
                         "uuid": "f6c8a1b9057f594c9855934f65516006"
                       }, 
                       "IsLocked": {
                         "description": "Is door locked or unlocked. True = Locked. False = Unlocked.", 
-                        "datatype": "boolean", 
+                        "datatype": "boolean",
                         "type": "actuator", 
                         "uuid": "2392129f103359abbf392c31c2b9c2a8"
                       }, 
@@ -1339,7 +1339,7 @@
                           }, 
                           "ChildLock": {
                             "description": "Is door child lock engaged. True = Engaged. False = Disengaged.", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "a786629fe86152deb3325d50fcaddfdf"
                           }, 
@@ -1358,7 +1358,7 @@
                           }, 
                           "isOpen": {
                             "description": "Is door open or closed", 
-                            "datatype": "boolean", 
+                            "datatype": "boolean",
                             "type": "sensor", 
                             "uuid": "de7074f54ea2546e81494ea09e1a3777"
                           }
@@ -1841,7 +1841,7 @@
                   "CurrentLocation": {
                     "children": {
                       "Altitude": {
-                        "datatype": "Double", 
+                        "datatype": "double", 
                         "type": "sensor", 
                         "uuid": "45424523425154e9b37b517b6bf0ebf2", 
                         "unit": "m", 
@@ -1850,7 +1850,7 @@
                       "Longitude": {
                         "description": "Current longitude of vehicle, as reported by GPS.", 
                         "min": -180, 
-                        "datatype": "Double", 
+                        "datatype": "double", 
                         "max": 180, 
                         "uuid": "e359b0a214f15565830caf544f3e4152", 
                         "type": "sensor", 
@@ -1859,7 +1859,7 @@
                       "Latitude": {
                         "description": "Current latitude of vehicle, as reported by GPS.", 
                         "min": -90, 
-                        "datatype": "Double", 
+                        "datatype": "double", 
                         "max": 90, 
                         "uuid": "03620ff62c92545c8fff1b58a7638b0b", 
                         "type": "sensor", 
@@ -1877,7 +1877,7 @@
                       "Heading": {
                         "description": "Current magnetic compass heading, in degrees.", 
                         "min": 0, 
-                        "datatype": "Double", 
+                        "datatype": "double", 
                         "max": 360, 
                         "uuid": "a13fc558e122509c81855a28d515de2b", 
                         "type": "sensor", 
@@ -1885,7 +1885,7 @@
                       }, 
                       "Accuracy": {
                         "description": "Accuracy level of the latitude and longitude coordinates in meters.", 
-                        "datatype": "Double", 
+                        "datatype": "double", 
                         "type": "sensor", 
                         "uuid": "c3d36ecf4c185d96978a07fd5ab28672", 
                         "unit": "m"
@@ -1901,7 +1901,7 @@
                       "Latitude": {
                         "description": "Latitude of destination", 
                         "min": -90, 
-                        "datatype": "Double", 
+                        "datatype": "double",
                         "max": 90, 
                         "uuid": "69b23c9ed52c55e49989b6a3d447fb86", 
                         "type": "actuator", 
@@ -1910,7 +1910,7 @@
                       "Longitude": {
                         "description": "Longitude of destination", 
                         "min": -180, 
-                        "datatype": "Double", 
+                        "datatype": "double", 
                         "max": 180, 
                         "uuid": "f8d66e58947f5e4c80b92de72b2e3d3e", 
                         "type": "actuator", 
@@ -2028,7 +2028,7 @@
               "Position": {
                 "description": "Sunroof position. 0 = Fully closed 100 = Fully opened. -100 = Fully tilted", 
                 "min": -100, 
-                "datatype": "Int8", 
+                "datatype": "int8", 
                 "max": 100, 
                 "uuid": "54af66e3a8485a58b6b91cbdcdc001c1", 
                 "type": "sensor"

--- a/test/unit-test/w3cunittest.cpp
+++ b/test/unit-test/w3cunittest.cpp
@@ -1113,7 +1113,7 @@ BOOST_AUTO_TEST_CASE(process_query_set_get_simple)
      )");
 
 
-   BOOST_TEST(set_response_json.has_key("timestamp") == true);
+   BOOST_TEST(set_response_json.contains("timestamp") == true);
    // remove timestamp to match
    set_response_json.erase("timestamp");
 
@@ -1141,7 +1141,7 @@ BOOST_AUTO_TEST_CASE(process_query_set_get_simple)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1184,7 +1184,7 @@ BOOST_AUTO_TEST_CASE(process_query_get_withwildcard)
 
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1220,7 +1220,7 @@ BOOST_AUTO_TEST_CASE(process_query_set_get_withwildcard)
      )");
 
 
-   BOOST_TEST(set_response_json.has_key("timestamp") == true);
+   BOOST_TEST(set_response_json.contains("timestamp") == true);
    // remove timestamp to match
    set_response_json.erase("timestamp");
 
@@ -1263,7 +1263,7 @@ BOOST_AUTO_TEST_CASE(process_query_set_get_withwildcard)
 
    json response_json = json::parse(response);
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1301,7 +1301,7 @@ BOOST_AUTO_TEST_CASE(process_query_get_withwildcard_invalid)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1337,7 +1337,7 @@ BOOST_AUTO_TEST_CASE(process_query_set_withwildcard_invalid)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1373,7 +1373,7 @@ BOOST_AUTO_TEST_CASE(process_query_set_invalid_value, *utf::expected_failures(1)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1410,7 +1410,7 @@ BOOST_AUTO_TEST_CASE(process_query_set_one_valid_one_invalid_value, *utf::expect
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1440,7 +1440,7 @@ BOOST_AUTO_TEST_CASE(process_query_set_one_valid_one_invalid_value, *utf::expect
    json response_response_getvalid_json = json::parse(response_getvalid);
 
 
-   BOOST_TEST(response_response_getvalid_json.has_key("timestamp") == true);
+   BOOST_TEST(response_response_getvalid_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_response_getvalid_json.erase("timestamp");
@@ -1474,7 +1474,7 @@ BOOST_AUTO_TEST_CASE(json_SigningHandler)
 #endif
    json response_json = json::parse(response);
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
    // remove timestamp to match
    response_json.erase("timestamp");
 
@@ -1551,7 +1551,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1604,7 +1604,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_path)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1656,7 +1656,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_branch_path)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1708,7 +1708,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_non_permitted_path)
    json response_json = json::parse(response);
 
 
-   //BOOST_TEST(response_json.has_key("timestamp") == true);
+   //BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1757,7 +1757,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_invalid_permission_valid_path)
         })");
 
    json response_json = json::parse(response);
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1811,7 +1811,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_branch_permission_valid_path)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1864,7 +1864,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_branch_permission_valid_path_2)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1917,7 +1917,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_permission)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -1967,7 +1967,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_write_permission)
         })");
 
    json response_json = json::parse(response);
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2020,7 +2020,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_permission_wildcard_req
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2072,7 +2072,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_permission_branch_path_
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2125,7 +2125,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_full_read_permission)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2177,7 +2177,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2230,7 +2230,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_not_permitted)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2282,7 +2282,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_wildcard_permission)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2308,7 +2308,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_wildcard_permission)
    json get_response_json = json::parse(get_response);
 
 
-   BOOST_TEST(get_response_json.has_key("timestamp") == true);
+   BOOST_TEST(get_response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    get_response_json.erase("timestamp");
@@ -2360,7 +2360,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_branch_permission)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2385,7 +2385,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_branch_permission)
    json get_response_json = json::parse(get_response);
 
 
-   BOOST_TEST(get_response_json.has_key("timestamp") == true);
+   BOOST_TEST(get_response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    get_response_json.erase("timestamp");
@@ -2436,7 +2436,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_branch_permission)
    json get_response_json_2 = json::parse(get_response_2);
 
 
-   BOOST_TEST(get_response_json_2.has_key("timestamp") == true);
+   BOOST_TEST(get_response_json_2.contains("timestamp") == true);
 
    // remove timestamp to match
    get_response_json_2.erase("timestamp");
@@ -2489,7 +2489,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_wildcard_in_permitted_path)
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2515,7 +2515,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_wildcard_in_permitted_path)
    json get_response_json = json::parse(get_response);
 
 
-   BOOST_TEST(get_response_json.has_key("timestamp") == true);
+   BOOST_TEST(get_response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    get_response_json.erase("timestamp");
@@ -2568,7 +2568,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_wildcard_in_unpermitted_path, *
    json response_json = json::parse(response);
 
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2594,7 +2594,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_wildcard_in_unpermitted_path, *
    json get_response_json = json::parse(get_response);
 
 
-   BOOST_TEST(get_response_json.has_key("timestamp") == true);
+   BOOST_TEST(get_response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    get_response_json.erase("timestamp");
@@ -2646,8 +2646,8 @@ BOOST_AUTO_TEST_CASE(subscription_test)
      "requestId":"8778"
     })");
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
-   BOOST_TEST(response_json.has_key("subscriptionId") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
+   BOOST_TEST(response_json.contains("subscriptionId") == true);
 
    int subID = response_json["subscriptionId"].as<int>();
 
@@ -2673,8 +2673,8 @@ BOOST_AUTO_TEST_CASE(subscription_test)
    json unsub_response_json = json::parse(unsub_response);
 
    // assert timestamp and subid.
-   BOOST_TEST(unsub_response_json.has_key("timestamp") == true);
-   BOOST_TEST(unsub_response_json.has_key("subscriptionId") == true);
+   BOOST_TEST(unsub_response_json.contains("timestamp") == true);
+   BOOST_TEST(unsub_response_json.contains("subscriptionId") == true);
 
    // compare the subit passed and returned.
    BOOST_TEST(unsub_response_json["subscriptionId"].as<int>() == subID);
@@ -2719,7 +2719,7 @@ BOOST_AUTO_TEST_CASE(subscription_test_wildcard_permission)
    authReqJson["tokens"] = AUTH_TOKEN;
    string response=commandProc->processQuery(authReqJson.as_string(),channel);
    json response_json=json::parse(response);
-   BOOST_TEST(response_json.has_key("action") == true);
+   BOOST_TEST(response_json.contains("action") == true);
    BOOST_TEST(response_json["action"].as<std::string>() == "authorize");
 
 
@@ -2737,8 +2737,8 @@ BOOST_AUTO_TEST_CASE(subscription_test_wildcard_permission)
      "requestId":"8778"
     })");
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
-   BOOST_TEST(response_json.has_key("subscriptionId") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
+   BOOST_TEST(response_json.contains("subscriptionId") == true);
 
    int subID = response_json["subscriptionId"].as<int>();
 
@@ -2764,8 +2764,8 @@ BOOST_AUTO_TEST_CASE(subscription_test_wildcard_permission)
    json unsub_response_json = json::parse(unsub_response);
 
    // assert timestamp and subid.
-   BOOST_TEST(unsub_response_json.has_key("timestamp") == true);
-   BOOST_TEST(unsub_response_json.has_key("subscriptionId") == true);
+   BOOST_TEST(unsub_response_json.contains("timestamp") == true);
+   BOOST_TEST(unsub_response_json.contains("subscriptionId") == true);
 
    // compare the subit passed and returned.
    BOOST_TEST(unsub_response_json["subscriptionId"].as<int>() == subID);
@@ -2827,7 +2827,7 @@ BOOST_AUTO_TEST_CASE(subscription_test_no_permission, *utf::expected_failures(1)
                    "requestId":"8778"
                    })");
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2880,7 +2880,7 @@ BOOST_AUTO_TEST_CASE(subscription_test_invalidpath, *utf::expected_failures(1))
                    "requestId":"8778"
                    })");
 
-   BOOST_TEST(response_json.has_key("timestamp") == true);
+   BOOST_TEST(response_json.contains("timestamp") == true);
 
    // remove timestamp to match
    response_json.erase("timestamp");
@@ -2917,8 +2917,8 @@ BOOST_AUTO_TEST_CASE(process_sub_with_wildcard)
 
     json response_json = json::parse(response);
     json request_json = json::parse(request);
-    BOOST_TEST(response_json.has_key("timestamp") == true);
-    BOOST_TEST(response_json.has_key("subscriptionId") == true);
+    BOOST_TEST(response_json.contains("timestamp") == true);
+    BOOST_TEST(response_json.contains("subscriptionId") == true);
     // remove timestamp to match
     response_json.erase("timestamp");
     response_json.erase("subscriptionId");
@@ -2961,10 +2961,10 @@ string AUTH_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJFeGFtcGxlIE
     json response_json = json::parse(response);
     json request_json = json::parse(request);
     // TEST response for parameters
-    BOOST_TEST(response_json.has_key("timestamp") == true);
-    BOOST_TEST(response_json.has_key("subscriptionId") == true);
+    BOOST_TEST(response_json.contains("timestamp") == true);
+    BOOST_TEST(response_json.contains("subscriptionId") == true);
     // TEST request for parameters
-    BOOST_TEST(request_json.has_key("path") == true);
+    BOOST_TEST(request_json.contains("path") == true);
     // remove timestamp to match
     response_json.erase("timestamp");
     response_json.erase("subscriptionId");
@@ -3018,7 +3018,7 @@ BOOST_AUTO_TEST_CASE(subscription_test_invalid_wildcard, *utf::expected_failures
                                 "requestId":"878787"
                                 })");
 
-    BOOST_TEST(response_json.has_key("timestamp") == true);
+    BOOST_TEST(response_json.contains("timestamp") == true);
     // remove timestamp to match
     response_json.erase("timestamp");
     BOOST_TEST(response_json == expected);

--- a/test/unit-test/w3cunittest.cpp
+++ b/test/unit-test/w3cunittest.cpp
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(test_get_random)
 
     list<string> paths = unittestObj.test_wrap_getPathForGet(test_path , isBranch);
 
-    BOOST_TEST(paths.size() == 0u);
+    BOOST_TEST(paths.size() == 1u);
     BOOST_TEST(isBranch == false);
 
 }
@@ -247,8 +247,8 @@ BOOST_AUTO_TEST_CASE(path_for_set_with_wildcard_with_invalid_values)
 
     BOOST_TEST(paths.size() == 2u);
 
-    BOOST_TEST(paths[0]["path"].as_string() == "");
-    BOOST_TEST(paths[1]["path"].as_string() == "");
+    BOOST_TEST(paths[0]["path"].as_string() == "$");
+    BOOST_TEST(paths[1]["path"].as_string() == "$");
 
 }
 
@@ -269,7 +269,7 @@ BOOST_AUTO_TEST_CASE(path_for_set_with_wildcard_with_one_valid_value)
     BOOST_TEST(paths.size() == 2u);
 
     BOOST_TEST(paths[0]["path"].as_string() == "$['Vehicle']['children']['OBD']['children']['EngineSpeed']");
-    BOOST_TEST(paths[1]["path"].as_string() == "");
+    BOOST_TEST(paths[1]["path"].as_string() == "$");
 
 }
 
@@ -289,8 +289,8 @@ BOOST_AUTO_TEST_CASE(path_for_set_with_wildcard_with_invalid_path_valid_values)
 
     BOOST_TEST(paths.size() == 2u);
 
-    BOOST_TEST(paths[0]["path"].as_string() == "");
-    BOOST_TEST(paths[1]["path"].as_string() == "");
+    BOOST_TEST(paths[0]["path"].as_string() == "$");
+    BOOST_TEST(paths[1]["path"].as_string() == "$");
 
 }
 
@@ -347,8 +347,8 @@ BOOST_AUTO_TEST_CASE(test_set_value_on_branch_with_invalid_values)
 
     BOOST_TEST(paths.size() == 2u);
 
-    BOOST_TEST(paths[0]["path"].as_string() == "");
-    BOOST_TEST(paths[1]["path"].as_string() == "");
+    BOOST_TEST(paths[0]["path"].as_string() == "$");
+    BOOST_TEST(paths[1]["path"].as_string() == "$");
 
 }
 
@@ -370,7 +370,7 @@ BOOST_AUTO_TEST_CASE(test_set_value_on_branch_with_one_invalid_value)
     BOOST_TEST(paths.size() == 2u);
 
     BOOST_TEST(paths[0]["path"].as_string() == "$['Vehicle']['children']['Cabin']['children']['HVAC']['children']['Row2']['children']['Left']['children']['Temperature']");
-    BOOST_TEST(paths[1]["path"].as_string() == "");
+    BOOST_TEST(paths[1]["path"].as_string() == "$");
 
 }
 
@@ -884,7 +884,7 @@ BOOST_AUTO_TEST_CASE(set_get_test_all_datatypes_boundary_conditions)
     database->setSignal(channel,test_path_boolean, test_value_bool_false);
     result = database->getSignal(channel,test_path_boolean);
 
-    BOOST_TEST(result["value"].as<std::string>() == test_value_bool_false);
+    BOOST_TEST(result["value"].as<bool>() == test_value_bool_false);
 
     json test_value_bool_true;
     test_value_bool_true = true;
@@ -892,7 +892,7 @@ BOOST_AUTO_TEST_CASE(set_get_test_all_datatypes_boundary_conditions)
     database->setSignal(channel,test_path_boolean, test_value_bool_true);
     result = database->getSignal(channel,test_path_boolean);
 
-    BOOST_TEST(result["value"].as<std::string>() == test_value_bool_true);
+    BOOST_TEST(result["value"].as<bool>() == test_value_bool_true);
 }
 
 
@@ -906,7 +906,7 @@ BOOST_AUTO_TEST_CASE(test_set_random)
 
     BOOST_TEST(paths.size() == 1u);
 
-    BOOST_TEST(paths[0]["path"].as_string() == "");
+    BOOST_TEST(paths[0]["path"].as_string() == "$");
 }
 
 // -------------------------------- Metadata test ----------------------------------

--- a/test/unit-test/w3cunittest.cpp
+++ b/test/unit-test/w3cunittest.cpp
@@ -1100,7 +1100,7 @@ BOOST_AUTO_TEST_CASE(process_query_set_get_simple)
 		"action": "set",
 		"path": "Vehicle.OBD.EngineSpeed",
 		"requestId": "8750",
-                "value" : 2345
+                "value" : 2345.0
 	})");
 
    string set_response = commandProc->processQuery(set_request,channel);
@@ -1135,7 +1135,7 @@ BOOST_AUTO_TEST_CASE(process_query_set_get_simple)
     "action": "get",
     "path": "Vehicle.OBD.EngineSpeed",
     "requestId": "8756",
-    "value": 2345
+    "value": 2345.0
     })");
 
    json response_json = json::parse(response);


### PR DESCRIPTION
Base on the json key "datatype" respond the right value key type. This detected by some unit tests failure.

eg: w3cunittest.cpp: process_query_set_get_simple  the Vehicle.OBD.EngineSpeed data type is float as definition in test_vss_rel_2.0.json