### PR TITLE
Dockerized test client

### DIFF
--- a/clients/common/clientComm.py
+++ b/clients/common/clientComm.py
@@ -21,14 +21,13 @@ class VSSClientComm(threading.Thread):
         self.sendMsgQueue = sendMsgQueue
         self.recvMsgQueue = recvMsgQueue
         scriptDir= os.path.dirname(os.path.realpath(__file__))
-        certDir = os.path.join(scriptDir, "../../certificates/")
         self.serverIP = config.get('ip', "127.0.0.1")
         self.serverPort = config.get('port', 8090)
         try:
             self.insecure = config.getboolean('insecure', False)
         except AttributeError:
             self.insecure = config.get('insecure', False)
-        self.cacertificate = config.get('cacertificate', os.path.join(certDir, "CA.pem"))
+        self.cacertificate = config.get('cacertificate', os.path.join(scriptDir, "CA.pem"))
         self.certificate = config.get('certificate', os.path.join(scriptDir, "Client.pem"))
         self.keyfile = config.get('key', os.path.join(scriptDir, "Client.key"))
         self.runComm = True

--- a/clients/vss-testclient/Dockerfile
+++ b/clients/vss-testclient/Dockerfile
@@ -7,7 +7,7 @@
 #
 
 # This dockerfile needs to be executed one lelvel above to have access to common
-# and it expects a topken folder (where you can preload some security tokens)
+# and it expects a token folder (where you can preload some security tokens)
 # see build.sh for an example how to run this
 
 FROM python:3.8-alpine AS build-env
@@ -16,10 +16,12 @@ FROM python:3.8-alpine AS build-env
 RUN mkdir /app
 RUN mkdir /app/vssclient
 COPY vss-testclient/testclient.py /app/vssclient/
+COPY vss-testclient/requirements.txt /app/vssclient/
 ADD vss-testclient/tokens /app/vssclient/tokens
 ADD common /app/common
 WORKDIR /app/vssclient
-RUN pip install --target=./ --no-cache-dir websockets cmd2 pygments
+RUN pip install --target=./ --no-cache-dir -r requirements.txt
+RUN rm requirements.txt
 
 
 FROM python:3.8-alpine

--- a/clients/vss-testclient/Dockerfile
+++ b/clients/vss-testclient/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright Robert Bosch GmbH, 2020. Part of the Eclipse Kuksa Project.
+#
+# All rights reserved. This configuration file is provided to you under the
+# terms and conditions of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, and is available at
+# http://www.eclipse.org/org/documents/edl-v10.php
+#
+
+# This dockerfile needs to be executed one lelvel above to have access to common
+# and it expects a topken folder (where you can preload some security tokens)
+# see build.sh for an example how to run this
+
+FROM python:3.8-alpine AS build-env
+
+
+RUN mkdir /app
+RUN mkdir /app/vssclient
+COPY vss-testclient/testclient.py /app/vssclient/
+ADD vss-testclient/tokens /app/vssclient/tokens
+ADD common /app/common
+WORKDIR /app/vssclient
+RUN pip install --target=./ --no-cache-dir websockets cmd2 pygments
+
+
+FROM python:3.8-alpine
+COPY --from=build-env /app /app
+
+ENV PYTHONUNBUFFERED=yes
+WORKDIR /app/vssclient
+CMD ["/usr/local/bin/python", "testclient.py"]

--- a/clients/vss-testclient/README.md
+++ b/clients/vss-testclient/README.md
@@ -20,7 +20,7 @@ pipenv run python testclient.py
 ### Without Pipenv
 Ensure all the dependencies are installed.
 ```sh
-pip3 install websockets cmd2
+pip3 install websockets cmd2 pygments
 python3 testclient.py
 ```
 
@@ -35,3 +35,17 @@ Refer help for further issues
 ```
 VSS Client> help -v
 ```
+
+### Docker
+You can build a docker image of the testclient. Not the most effcient way to pack a small python script, but it is easy to get started. The Dockerfile needs to be executed on the parent directory (so it include the common library), and it expects a folder "tokens" to be there.
+See the  `builddocker.sh` script for an example how to build a docker including the default authorization tokens.
+
+To run it use somehting like this
+
+```
+sudo docker run --rm -it --net=host <image-id-from docker-build>
+```
+
+`--rm` ensures we do not keep the docker continer lying aroind after closing the vss-testclient and `--net=host` makes sure you can reach locally running kuksa.val-server or kuksa-val docker with port forwarding on the host using the default `127.0.0.1` address.
+
+

--- a/clients/vss-testclient/README.md
+++ b/clients/vss-testclient/README.md
@@ -20,7 +20,7 @@ pipenv run python testclient.py
 ### Without Pipenv
 Ensure all the dependencies are installed.
 ```sh
-pip3 install websockets cmd2 pygments
+pip3 install -r requirements.txt
 python3 testclient.py
 ```
 

--- a/clients/vss-testclient/builddocker.sh
+++ b/clients/vss-testclient/builddocker.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright Robert Bosch GmbH, 2020. Part of the Eclipse Kuksa Project.
+#
+# All rights reserved. This configuration file is provided to you under the
+# terms and conditions of the Eclipse Distribution License v1.0 which
+# accompanies this distribution, and is available at
+# http://www.eclipse.org/org/documents/edl-v10.php
+#
+
+echo "Try building vss-testclient docker"
+cd ../
+
+if [ ! -d vss-testclient/tokens ]; then
+    echo "Copying example token"
+    mkdir vss-testclient/tokens
+    cp -r ../certificates/jwt/*token vss-testclient/tokens
+else
+    echo "Using existing token folder"
+fi
+
+sudo docker build -f vss-testclient/Dockerfile .

--- a/clients/vss-testclient/requirements.txt
+++ b/clients/vss-testclient/requirements.txt
@@ -1,0 +1,3 @@
+cmd2~=1.3
+websockets~=8.1
+pygments~=2.7


### PR DESCRIPTION
Dockerfile and helper script to containerize the vss-testclient.

We can later build it in CI (and push to dockerhub), so it is easier to get started playing with kuksa.val