### PR TITLE
remove possible newline from jwt in dbcfeeder.py

### DIFF
--- a/clients/feeder/dbc2val/dbcfeeder.py
+++ b/clients/feeder/dbc2val/dbcfeeder.py
@@ -127,7 +127,7 @@ if cfg['can.port'] == "elmcan":
 
 
 with open(cfg['vss.jwttoken'], 'r') as f:
-    token = f.read()
+    token = f.readline().rstrip('\n')
 
 mapping = dbc2vssmapper.mapper(cfg['vss.mapping'])
 


### PR DESCRIPTION
For some reason the new super admin may be parsed with a new line at the end. In `dbcfeeder.py` this new line `\n` gets included in the authZ request. `jwt-cpp` then fails to decode the jwt.
The same issue does not occur in `vss-testclient/testclient.py`

This PR is a quick fix to strip any new line characters from the token when reading the token from file in `dbcfeeder.py`

Signed-off-by: Woerner Dominic (RBCH/PJ-IOT) <dominic.woerner2@ch.bosch.com>