### PR TITLE
Fix unittest timestamp races and Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ node('docker') {
                 stage('amd64') {
                     sh "docker buildx build --platform=linux/amd64 -f ./docker/Dockerfile -t amd64/kuksa-val:${versiontag} --output type=docker,dest=./artifacts/kuksa-val-${versiontag}-amd64.tar ."
                     
-                    sh "docker buildx build --platform=linux/arm64 -f ./clients/vss-testclient/Dockerfile -t amd64/kuksa-vssclient:${versiontag} --output type=docker,dest=./artifacts/kuksa-vssclient-${versiontag}-amd64.tar ./clients/"
+                    sh "docker buildx build --platform=linux/amd64 -f ./clients/vss-testclient/Dockerfile -t amd64/kuksa-vssclient:${versiontag} --output type=docker,dest=./artifacts/kuksa-vssclient-${versiontag}-amd64.tar ./clients/"
 
                     sh "docker build -t kuksa-val-dev-ubuntu20.04:${versiontag} -f docker/Dockerfile.dev ."
                     sh "docker save kuksa-val-dev-ubuntu20.04:${versiontag}  > artifacts/kuksa-val-dev-ubuntu20.04:${versiontag}.tar"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,8 @@ node('docker') {
                 tools: [ BoostTest(pattern: 'artifacts/results.xml') ]]
         )
         cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'artifacts/coverage.xml', conditionalCoverageTargets: '70, 0, 0', enableNewApi: true, failUnhealthy: false, failUnstable: false, lineCoverageTargets: '80, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '80, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+        //Cleaning up: After unittest we do not need dev docker in local registry
+        sh "docker rmi kuksa-val-dev-ubuntu20.04:${versiontag}"
     }
     stage('Compress') {
         sh 'ls -al artifacts'

--- a/test/unit-test/VssCommandProcessorTests.cpp
+++ b/test/unit-test/VssCommandProcessorTests.cpp
@@ -389,6 +389,8 @@ BOOST_AUTO_TEST_CASE(Given_ValidSetQuery_When_ValueOutOfBound_Shall_ReturnError)
 
   // timestamp must not be zero
   BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
+  jsonValueOutOfBound["timestamp"] = res["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+
   BOOST_TEST(res == jsonValueOutOfBound);
 }
 
@@ -438,6 +440,7 @@ BOOST_AUTO_TEST_CASE(Given_ValidSetQuery_When_NoPermission_Shall_ReturnError)
 
   // timestamp must not be zero
   BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
+  jsonNoAccess["timestamp"] = res["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
   BOOST_TEST(res == jsonNoAccess);
 }
 
@@ -487,6 +490,9 @@ BOOST_AUTO_TEST_CASE(Given_ValidSetQuery_When_DBThrowsNotExpectedException_Shall
 
   // timestamp must not be zero
   BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
+  // Set timestamp for comparision purposes
+  jsonMalformedReq["timestamp"] = res["timestamp"].as<int64_t>();
+
   BOOST_TEST(res == jsonMalformedReq);
 }
 


### PR DESCRIPTION
This fixes two timestamp races in unittests (triggered more  easily due to the change to ms in #90 )

Also this fixes #96 and #93 