### PR TITLE
Set default stack size explicitely in build scripts

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,7 +96,11 @@ if(BUILD_UNIT_TEST)
 endif(BUILD_UNIT_TEST)
 
 # link library dependencies
-target_link_libraries(${SERVER_OBJ_LIB_NAME} PUBLIC jwt-cpp jsonpath jsoncons ${CMAKE_THREAD_LIBS_INIT})
+# Setting max stack size explicetely to current default value of glibc on Ubuntu, to force MUSL
+# builds using the same max. Otherwise you might have hard to debug differences between MUSL and
+# builds.
+# See also https://wiki.musl-libc.org/functional-differences-from-glibc.html#Thread-stack-size
+target_link_libraries(${SERVER_OBJ_LIB_NAME}  PUBLIC jwt-cpp jsonpath jsoncons ${CMAKE_THREAD_LIBS_INIT} -Wl,-z,stack-size=8388608)
 
 if ("${ADDRESS_SAN}" STREQUAL "ON" AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   target_compile_options(${SERVER_OBJ_LIB_NAME} PUBLIC -g -fsanitize=address -fno-omit-frame-pointer)


### PR DESCRIPTION
This should fix #101 

This PR makes sure max stack size are similar in glibc (e.g. Ubuntu) and MUSL (Alpine) builds, to get consistent results on both

Wrt the REST implementation: using a regex on non-length checked input is probably a bad idea, and generally you can probably still fuzz the whole thing to kingdome come.
I assume eventuall out experimental (pre-VISS2) REST prototype should be replaced with a better version anyway, so no cleanup for now. Should be good enough for experiments.

Also sidenote: This does _not_ increase memory usage, stack is reserved as virtual memory. The actual memory usage still depends on stack usage.
