### PR TITLE
Support (u)int64 in set

### DIFF
--- a/src/VssDatabase.cpp
+++ b/src/VssDatabase.cpp
@@ -109,6 +109,19 @@ jsoncons::json tryParse(jsoncons::json val) {
 
         throw outOfBoundException(msg.str());
       }
+    } else if (value_type == "uint64") {
+      typeValid = true;
+      long double longDoubleVal;
+      ValidateValue(logger, val, longDoubleVal);
+      if (!((longDoubleVal <= numeric_limits<uint64_t>::max()) &&
+            (longDoubleVal >= numeric_limits<uint64_t>::min()))) {
+        std::stringstream msg;
+        msg << "The type " << value_type << " with value " << val.as<float>()
+            << " is out of bound";
+        logger->Log(LogLevel::ERROR, "VssDatabase::setSignal: " + msg.str());
+
+        throw outOfBoundException(msg.str());
+      }
     } else if (value_type == "int8") {
       typeValid = true;
       long double longDoubleVal;
@@ -148,7 +161,20 @@ jsoncons::json tryParse(jsoncons::json val) {
 
         throw outOfBoundException(msg.str());
       }
-    } else if (value_type == "float") {
+    } else if (value_type == "int64") {
+      typeValid = true;
+      long double longDoubleVal;
+      ValidateValue(logger, val, longDoubleVal);
+      if (!((longDoubleVal <= numeric_limits<int64_t>::max()) &&
+            (longDoubleVal >= numeric_limits<int64_t>::min()))) {
+        std::stringstream msg;
+        msg << "The type " << value_type << " with value " << val.as<float>()
+            << " is out of bound";
+        logger->Log(LogLevel::ERROR, "VssDatabase::setSignal: " + msg.str());
+
+        throw outOfBoundException(msg.str());
+      }
+    }  else if (value_type == "float") {
       typeValid = true;
       long double longDoubleVal;
       ValidateValue(logger, val, longDoubleVal);


### PR DESCRIPTION
Fixes #109 

I guess the whole type & bounds checking code can be iproved (and incorporate min/max), but for now I kept the coding pattern and just added `int64` und `unit64` to fix the problem that those data types could not be set