### PR TITLE
improve cmake ctest

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -33,7 +33,7 @@ fi
 echo "Go to build directory ${builddir}"
 cd ${builddir}
 
-cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_UNIT_TEST=ON ..
+cmake -DCMAKE_BUILD_TYPE=Coverage -DBUILD_UNIT_TEST=ON -DCTEST_RESULT_CODE=no ..
 
 rm -rf test/unit-test/results.xml
 rm -rf coverage.xml

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -41,8 +41,9 @@ if(BUILD_UNIT_TEST)
   )
 
   # declares a test with our executable
+  set(CTEST_RESULT_CODE yes CACHE BOOL "Build unit tests")
   add_test(NAME ${UNITTEST_EXE_NAME}
-    COMMAND $<TARGET_FILE:${UNITTEST_EXE_NAME}> --log_format=XML --log_sink=results.xml --log_level=all --report_level=no --result_code=no
+    COMMAND $<TARGET_FILE:${UNITTEST_EXE_NAME}> --log_format=XML --log_sink=results.xml --log_level=all --report_level=short --result_code=${CTEST_RESULT_CODE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   target_compile_features(${UNITTEST_EXE_NAME} PRIVATE cxx_std_14)


### PR DESCRIPTION
default `ctest` should show real results and result code. Only for jenkins, it is better to not return errer when some testcases failed, sothat jenkins can continue with generating test reports. Therefore add `TEST_RESULT_CODE` option for cmake