### PR TITLE
Correctly type check boolean values

### DIFF
--- a/src/VssDatabase.cpp
+++ b/src/VssDatabase.cpp
@@ -65,7 +65,7 @@ jsoncons::json tryParse(jsoncons::json val) {
 }
 
     // Check the value type and if the value is within the range
-  void checkTypeAndBound(std::shared_ptr<ILogger> logger, string value_type, jsoncons::json val) {
+  void checkTypeAndBound(std::shared_ptr<ILogger> logger, string value_type, jsoncons::json &val) {
     bool typeValid = false;
 
     boost::algorithm::to_lower(value_type);
@@ -171,7 +171,6 @@ jsoncons::json tryParse(jsoncons::json val) {
         msg << "The type " << value_type << " with value " << val.as<float>()
             << " is out of bound";
         logger->Log(LogLevel::ERROR, "VssDatabase::setSignal: " + msg.str());
-
         throw outOfBoundException(msg.str());
       }
     }  else if (value_type == "float") {
@@ -203,6 +202,22 @@ jsoncons::json tryParse(jsoncons::json val) {
         throw outOfBoundException(msg.str());
       }
     } else if (value_type == "boolean") {
+      string v=val.as<string>();
+      boost::algorithm::erase_all(v, "\"");
+
+      if ( v == "true") {
+        val=true;
+      }
+      else if ( v == "false" ) {
+        val=false;
+      }
+      else {
+        std::stringstream msg;
+        msg << val.as_string() << " is not a bool. Valid values are true and false ";
+        logger->Log(LogLevel::ERROR, "VssDatabase::setSignal: " + msg.str()); 
+        std::cout << pretty_print(val) << std::endl;
+        throw outOfBoundException(msg.str());
+      }
       typeValid = true;
     } else if (value_type == "string") {
       typeValid = true;


### PR DESCRIPTION
Should fix #133 

```json
Test Client> setValue Vehicle.OBD.DriveCycleStatus.MIL foo
{
    "action": "set", 
    "error": {
        "message": "foo is not a bool. Valid values are true and false ", 
        "number": 400, 
        "reason": "Value passed is out of bounds"
    }, 
    "requestId": "9dfe6e60-3374-493a-aca8-30736a82d6f3", 
    "timestamp": 1616169129422
}

Test Client> setValue Vehicle.OBD.DriveCycleStatus.MIL true
{
    "action": "set", 
    "requestId": "a10e1ee1-9732-4704-ad28-e9c614d00501", 
    "timestamp": 1616169134986
}

Test Client> getValue Vehicle.OBD.DriveCycleStatus.MIL 
{
    "action": "get", 
    "path": "Vehicle.OBD.DriveCycleStatus.MIL", 
    "requestId": "2d6d790f-8c48-40fb-bb30-a22f2da76e01", 
    "timestamp": 1616169138448, 
    "value": true
}

Test Client> 
```

I guess the whole typeCheck code is due for a refactoring when we tacke #46 
