### PR TITLE
Feature/iso timestamps

### DIFF
--- a/include/JsonResponses.hpp
+++ b/include/JsonResponses.hpp
@@ -62,6 +62,8 @@ namespace JsonResponses {
                         jsoncons::json& jsonResponse);
 
   std::string getTimeStamp();
+
+  std::string getTimeStampZero();
 }
 
 #endif

--- a/include/JsonResponses.hpp
+++ b/include/JsonResponses.hpp
@@ -61,7 +61,7 @@ namespace JsonResponses {
                         const std::string message,
                         jsoncons::json& jsonResponse);
 
-  int64_t getTimeStamp();
+  std::string getTimeStamp();
 }
 
 #endif

--- a/src/JsonResponses.cpp
+++ b/src/JsonResponses.cpp
@@ -12,8 +12,9 @@
  * *****************************************************************************
  */
 #include "JsonResponses.hpp"
-#include <chrono>
-#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include <time.h>
+
 
 namespace JsonResponses {
   void malFormedRequest(std::string request_id,
@@ -147,8 +148,9 @@ namespace JsonResponses {
      TZD  = time zone designator (Z or +hh:mm or -hh:mm)
 */
   std::string getTimeStamp(){
-    using namespace boost::posix_time;
-    ptime t = microsec_clock::universal_time();
-    return to_iso_extended_string(t)+"Z";
+    auto itt=std::time(nullptr);
+    std::ostringstream ss;
+    ss << std::put_time(gmtime(&itt), "%FT%T.%sZ");
+    return ss.str();
   }
 }

--- a/src/JsonResponses.cpp
+++ b/src/JsonResponses.cpp
@@ -13,6 +13,7 @@
  */
 #include "JsonResponses.hpp"
 #include <chrono>
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 namespace JsonResponses {
   void malFormedRequest(std::string request_id,
@@ -130,9 +131,24 @@ namespace JsonResponses {
     return ss.str();
   }
 
-  int64_t getTimeStamp(){
-    return std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::system_clock::now().time_since_epoch()
-          ).count();
+/** Return an extended ISO8601 UTC timestamp according to W3C guidelines https://www.w3.org/TR/NOTE-datetime
+ * Complete date plus hours, minutes, seconds and a decimal fraction of a second
+      YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
+    
+    where:
+
+     YYYY = four-digit year
+     MM   = two-digit month (01=January, etc.)
+     DD   = two-digit day of month (01 through 31)
+     hh   = two digits of hour (00 through 23) (am/pm NOT allowed)
+     mm   = two digits of minute (00 through 59)
+     ss   = two digits of second (00 through 59)
+     s    = one or more digits representing a decimal fraction of a second
+     TZD  = time zone designator (Z or +hh:mm or -hh:mm)
+*/
+  std::string getTimeStamp(){
+    using namespace boost::posix_time;
+    ptime t = microsec_clock::universal_time();
+    return to_iso_extended_string(t)+"Z";
   }
 }

--- a/src/JsonResponses.cpp
+++ b/src/JsonResponses.cpp
@@ -132,8 +132,8 @@ namespace JsonResponses {
     return ss.str();
   }
 
-/** Return an extended ISO8601 UTC timestamp according to W3C guidelines https://www.w3.org/TR/NOTE-datetime
- * Complete date plus hours, minutes, seconds and a decimal fraction of a second
+  /** Return an extended ISO8601 UTC timestamp according to W3C guidelines https://www.w3.org/TR/NOTE-datetime
+   * Complete date plus hours, minutes, seconds and a decimal fraction of a second
       YYYY-MM-DDThh:mm:ss.sTZD (eg 1997-07-16T19:20:30.45+01:00)
     
     where:
@@ -146,11 +146,20 @@ namespace JsonResponses {
      ss   = two digits of second (00 through 59)
      s    = one or more digits representing a decimal fraction of a second
      TZD  = time zone designator (Z or +hh:mm or -hh:mm)
-*/
+  */
   std::string getTimeStamp(){
     auto itt=std::time(nullptr);
     std::ostringstream ss;
     ss << std::put_time(gmtime(&itt), "%FT%T.%sZ");
     return ss.str();
   }
+
+  /** This extended ISO8601 UTC timestamp according to W3C guidelines https://www.w3.org/TR/NOTE-datetime
+  *  for unix timestamp zero. This will be used  when values that have never been set are queried
+  *  This makes sure to habe a syntactically compliant timestamp
+  */
+  std::string getTimeStampZero() {
+    return "1981-01-01T00:00:00.0000000000Z";
+  }
 }
+

--- a/src/VssDatabase.cpp
+++ b/src/VssDatabase.cpp
@@ -388,7 +388,7 @@ jsoncons::json VssDatabase::getSignal(const VSSPath& path) {
     if (result.contains("timestamp")) {
       answer["timestamp"] = result["timestamp"].as<string>();
     } else {
-      answer["timestamp"] = "0";
+      answer["timestamp"] = JsonResponses::getTimeStampZero();
     }
     return answer;
 

--- a/test/unit-test/Gen2GetTests.cpp
+++ b/test/unit-test/Gen2GetTests.cpp
@@ -19,7 +19,7 @@
 #include <turtle/mock.hpp>
 #undef BOOST_BIND_GLOBAL_PLACEHOLDERS
 
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include "UnitTestHelpers.hpp"
 
 #include <thread>
 
@@ -85,14 +85,6 @@ struct TestSuiteFixture {
 }  // namespace
 
 
-//Verifies a timestamp exists and is of type string. Copies it to the
-//expected answers
-static inline void verify_timestamp(json &expected, const json &result) {
-  BOOST_TEST(result.contains("timestamp"));
-  BOOST_TEST(result["timestamp"].is_string());
-  BOOST_CHECK_NO_THROW(boost::posix_time::from_iso_extended_string(result["timestamp"].as_string()));
-  expected["timestamp"]=result["timestamp"].as_string(); 
-}
 
 // Define name of test suite and define test suite fixture for pre and post test
 // handling

--- a/test/unit-test/Gen2GetTests.cpp
+++ b/test/unit-test/Gen2GetTests.cpp
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- * Copyright (c) 2020 Robert Bosch GmbH.
+ * Copyright (c) 2020-2021 Robert Bosch GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -19,7 +19,8 @@
 #include <turtle/mock.hpp>
 #undef BOOST_BIND_GLOBAL_PLACEHOLDERS
 
-#include <chrono>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
 #include <thread>
 
 #include <memory>
@@ -82,6 +83,16 @@ struct TestSuiteFixture {
   }
 };
 }  // namespace
+
+
+//Verifies a timestamp exists and is of type string. Copies it to the
+//expected answers
+static inline void verify_timestamp(json &expected, const json &result) {
+  BOOST_TEST(result.contains("timestamp"));
+  BOOST_TEST(result["timestamp"].is_string());
+  BOOST_CHECK_NO_THROW(boost::posix_time::from_iso_extended_string(result["timestamp"].as_string()));
+  expected["timestamp"]=result["timestamp"].as_string(); 
+}
 
 // Define name of test suite and define test suite fixture for pre and post test
 // handling
@@ -168,12 +179,8 @@ BOOST_AUTO_TEST_CASE(Gen2_Get_Invalid_JSON) {
       processor->processQuery(jsonSetRequestForSignal.as_string(), channel);
   auto res = json::parse(resStr);
 
-  // Does result have a timestamp?
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-
-  // Remove timestamp for comparision purposes
-  expectedJson["timestamp"] = res["timestamp"].as<int64_t>();
-
+  verify_timestamp(expectedJson,res);
+  
   BOOST_TEST(res == expectedJson);
 }
 
@@ -208,11 +215,8 @@ BOOST_AUTO_TEST_CASE(Gen2_Get_Invalid_JSON_NoRequestID) {
   auto res = json::parse(resStr);
 
   // Does result have a timestamp?
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-
-  // Remove timestamp for comparision purposes
-  expectedJson["timestamp"] = res["timestamp"].as<int64_t>();
-
+  verify_timestamp(expectedJson,res);
+  
   BOOST_TEST(res == expectedJson);
 }
 
@@ -242,10 +246,8 @@ BOOST_AUTO_TEST_CASE(Gen2_Get_NonExistingPath) {
   auto res = json::parse(resStr);
 
   // verify
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] =
-      jsonPathNotFound["timestamp"]
-          .as<int64_t>();  // ignoring timestamp difference for response
+  verify_timestamp(jsonPathNotFound,res);
+
   BOOST_TEST(res == jsonPathNotFound);
 }
 
@@ -371,10 +373,8 @@ BOOST_AUTO_TEST_CASE(Gen2_Get_Wildcard_NonExisting) {
   auto res = json::parse(resStr);
 
   // verify
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] =
-      jsonPathNotFound["timestamp"]
-          .as<int64_t>();  // ignoring timestamp difference for response
+  verify_timestamp(jsonPathNotFound,res);
+
   BOOST_TEST(res == jsonPathNotFound);
 }
 
@@ -409,8 +409,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Get_noPermissionException) {
   // verify
 
   // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  jsonNoAccess["timestamp"] = res["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  verify_timestamp(jsonNoAccess,res);
   BOOST_TEST(res == jsonNoAccess);
 
 }
@@ -471,11 +470,8 @@ BOOST_AUTO_TEST_CASE(Gen2_Get_StableTimestamp) {
       processor->processQuery(jsonGetRequestForSignal.as_string(), channel);
   auto res = json::parse(resStr);
 
-  // Does result have a timestamp?
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
+  verify_timestamp(expectedJson,res);
 
-  // Remove timestamp for comparision purposes
-  expectedJson.insert_or_assign("timestamp",res["timestamp"]);
   BOOST_TEST(res == expectedJson);
 
   //wait 20ms (timestamps should be 1 ms resolution, but 20 ms should

--- a/test/unit-test/Gen2SetTests.cpp
+++ b/test/unit-test/Gen2SetTests.cpp
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- * Copyright (c) 2020 Robert Bosch GmbH.
+ * Copyright (c) 2020-2021 Robert Bosch GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -18,6 +18,8 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <turtle/mock.hpp>
 #undef BOOST_BIND_GLOBAL_PLACEHOLDERS
+
+#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <memory>
 #include <string>
@@ -80,6 +82,15 @@ struct TestSuiteFixture {
 };
 }  // namespace
 
+//Verifies a timestamp exists and is of type string. Copies it to the
+//expected answers
+static inline void verify_timestamp(json &expected, const json &result) {
+  BOOST_TEST(result.contains("timestamp"));
+  BOOST_TEST(result["timestamp"].is_string());
+  BOOST_CHECK_NO_THROW(boost::posix_time::from_iso_extended_string(result["timestamp"].as_string()));
+  expected["timestamp"]=result["timestamp"].as_string(); 
+}
+
 // Define name of test suite and define test suite fixture for pre and post test
 // handling
 BOOST_FIXTURE_TEST_SUITE(Gen2SetTests, TestSuiteFixture);
@@ -130,11 +141,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Sensor_Simple) {
       processor->processQuery(jsonSetRequestForSignal.as_string(), channel);
   auto res = json::parse(resStr);
 
-  // Does result have a timestamp?
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-
-  // Remove timestamp for comparision purposes
-  expectedJson["timestamp"] = res["timestamp"].as<int64_t>();
+  verify_timestamp(expectedJson,res);
 
   BOOST_TEST(res == expectedJson);
 }
@@ -174,11 +181,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Invalid_JSON) {
       processor->processQuery(jsonSetRequestForSignal.as_string(), channel);
   auto res = json::parse(resStr);
 
-  // Does result have a timestamp?
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-
-  // Remove timestamp for comparision purposes
-  expectedJson["timestamp"] = res["timestamp"].as<int64_t>();
+  verify_timestamp(expectedJson,res);
 
   BOOST_TEST(res == expectedJson);
 }
@@ -214,11 +217,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Invalid_JSON_NoRequestID) {
       processor->processQuery(jsonSetRequestForSignal.as_string(), channel);
   auto res = json::parse(resStr);
 
-  // Does result have a timestamp?
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-
-  // Remove timestamp for comparision purposes
-  expectedJson["timestamp"] = res["timestamp"].as<int64_t>();
+  verify_timestamp(expectedJson,res);
 
   BOOST_TEST(res == expectedJson);
 }
@@ -267,11 +266,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Non_Existing_Path) {
 
   auto res = json::parse(resStr);
 
-  // Does result have a timestamp?
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-
-  // Remove timestamp for comparision purposes
-  expectedJson["timestamp"] = res["timestamp"].as<int64_t>();
+  verify_timestamp(expectedJson,res);
 
   BOOST_TEST(res == expectedJson);
 }
@@ -321,11 +316,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Branch) {
 
   auto res = json::parse(resStr);
 
-  // Does result have a timestamp?
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-
-  // Remove timestamp for comparision purposes
-  expectedJson["timestamp"] = res["timestamp"].as<int64_t>();
+  verify_timestamp(expectedJson,res);
 
   BOOST_TEST(res == expectedJson);
 }
@@ -375,11 +366,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Attribute) {
 
   auto res = json::parse(resStr);
 
-  // Does result have a timestamp?
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-
-  // Remove timestamp for comparision purposes
-  expectedJson["timestamp"] = res["timestamp"].as<int64_t>();
+  verify_timestamp(expectedJson,res);
 
   BOOST_TEST(res == expectedJson);
 }
@@ -414,10 +401,8 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_noPermissionException) {
   auto res = json::parse(resStr);
 
   // verify
+  verify_timestamp(jsonNoAccess,res);
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  jsonNoAccess["timestamp"] = res["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
   BOOST_TEST(res == jsonNoAccess);
 }
 

--- a/test/unit-test/Gen2SetTests.cpp
+++ b/test/unit-test/Gen2SetTests.cpp
@@ -19,7 +19,7 @@
 #include <turtle/mock.hpp>
 #undef BOOST_BIND_GLOBAL_PLACEHOLDERS
 
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include "UnitTestHelpers.hpp"
 
 #include <memory>
 #include <string>
@@ -81,15 +81,6 @@ struct TestSuiteFixture {
   }
 };
 }  // namespace
-
-//Verifies a timestamp exists and is of type string. Copies it to the
-//expected answers
-static inline void verify_timestamp(json &expected, const json &result) {
-  BOOST_TEST(result.contains("timestamp"));
-  BOOST_TEST(result["timestamp"].is_string());
-  BOOST_CHECK_NO_THROW(boost::posix_time::from_iso_extended_string(result["timestamp"].as_string()));
-  expected["timestamp"]=result["timestamp"].as_string(); 
-}
 
 // Define name of test suite and define test suite fixture for pre and post test
 // handling

--- a/test/unit-test/KuksavalUnitTest.cpp
+++ b/test/unit-test/KuksavalUnitTest.cpp
@@ -17,7 +17,8 @@
 #define BOOST_BIND_GLOBAL_PLACEHOLDERS
 #include <boost/test/included/unit_test.hpp>
 //can not undefine here, needs to be on for whole compilation unit to prevent warning
- 
+
+#include "UnitTestHelpers.hpp" 
 
 #include <string>
 #include <memory>
@@ -826,9 +827,8 @@ BOOST_AUTO_TEST_CASE(process_query_set_get_simple)
      )");
 
 
-   BOOST_TEST(set_response_json.contains("timestamp") == true);
-   // remove timestamp to match
-   set_response_json.erase("timestamp");
+   verify_timestamp(set_response_expected, set_response_json);
+
 
    BOOST_TEST(set_response_json == set_response_expected);
 
@@ -853,11 +853,8 @@ BOOST_AUTO_TEST_CASE(process_query_set_get_simple)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected,response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -894,13 +891,8 @@ BOOST_AUTO_TEST_CASE(process_query_get_withwildcard)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected,response_json);
 
-
-
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1018,11 +1010,8 @@ BOOST_AUTO_TEST_CASE(process_query_get_withwildcard_invalid)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1202,10 +1191,6 @@ BOOST_AUTO_TEST_CASE(json_SigningHandler)
 #endif
    json response_json = json::parse(response);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-   // remove timestamp to match
-   response_json.erase("timestamp");
-
    json expected = json::parse(R"({
     "action": "get",
     "path": "Vehicle.OBD.EngineSpeed",
@@ -1213,6 +1198,7 @@ BOOST_AUTO_TEST_CASE(json_SigningHandler)
     "value": 2345
     })");
 
+   verify_timestamp(expected, response_json);
    // Pre-check
    BOOST_TEST(response_json == expected);
 
@@ -1278,11 +1264,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1331,11 +1314,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_path)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1383,11 +1363,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_branch_path)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1436,11 +1413,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_non_permitted_path)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   //BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1486,10 +1460,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_invalid_permission_valid_path)
         })");
 
    json response_json = json::parse(response);
-   BOOST_TEST(response_json.contains("timestamp") == true);
 
-   // remove timestamp to match
-   response_json.erase("timestamp");
+   verify_timestamp(expected, response_json);
 
    BOOST_TEST(response_json == expected);
 }
@@ -1539,11 +1511,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_branch_permission_valid_path)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1592,11 +1561,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_branch_permission_valid_path_2)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1645,11 +1611,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_permission)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1696,10 +1659,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_write_permission)
         })");
 
    json response_json = json::parse(response);
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
+   
+   verify_timestamp(expected, response_json);
 
    BOOST_TEST(response_json == expected);
 }
@@ -1748,12 +1709,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_permission_wildcard_req
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
-   response_json.erase("warning");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1801,12 +1758,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_permission_branch_path_
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
-   response_json.erase("warning");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1855,11 +1808,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_full_read_permission)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1909,11 +1859,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_write)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -1962,11 +1909,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_not_permitted)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected,response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -2014,11 +1958,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_wildcard_permission)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 
    // verify with a get request
@@ -2040,11 +1981,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_wildcard_permission)
 
    json get_response_json = json::parse(get_response);
 
+   verify_timestamp(get_expected, get_response_json);
 
-   BOOST_TEST(get_response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   get_response_json.erase("timestamp");
    BOOST_TEST(get_response_json == get_expected);
 }
 
@@ -2103,11 +2041,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_branch_permission)
 
    json response_json = json::parse(response);
 
+   verify_timestamp(expected, response_json);
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 
    // verify with a get request
@@ -2131,11 +2066,8 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_branch_permission)
 
    json get_response_json = json::parse(get_response);
 
+   verify_timestamp(get_expected, get_response_json);
 
-   BOOST_TEST(get_response_json.contains("timestamp") == true);
-
-   // remove timestamp to match
-   get_response_json.erase("timestamp");
    BOOST_TEST(get_response_json == get_expected);
 
 }
@@ -2352,7 +2284,6 @@ BOOST_AUTO_TEST_CASE(subscription_test)
      "requestId":"8778"
     })");
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
    BOOST_TEST(response_json.contains("subscriptionId") == true);
 
    int subID = response_json["subscriptionId"].as<int>();
@@ -2360,9 +2291,8 @@ BOOST_AUTO_TEST_CASE(subscription_test)
    // checked if subid is available. now remove to assert.
    response_json.erase("subscriptionId");
 
+   verify_timestamp(expected, response_json);
 
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 
 
@@ -2378,21 +2308,20 @@ BOOST_AUTO_TEST_CASE(subscription_test)
    string unsub_response = commandProc->processQuery(temp_unsubreq.as_string(),channel);
    json unsub_response_json = json::parse(unsub_response);
 
-   // assert timestamp and subid.
-   BOOST_TEST(unsub_response_json.contains("timestamp") == true);
    BOOST_TEST(unsub_response_json.contains("subscriptionId") == true);
 
    // compare the subit passed and returned.
    BOOST_TEST(unsub_response_json["subscriptionId"].as<int>() == subID);
 
-   // remove timestamp and subid to assert other part of the response.because these are variables.
+   // remove subid to assert other part of the response.because these are variables.
    unsub_response_json.erase("subscriptionId");
-   unsub_response_json.erase("timestamp");
 
    json expected_unsub = json::parse(R"({
      "action":"unsubscribe",
      "requestId":"8779"
     })");
+
+   verify_timestamp(expected_unsub, unsub_response_json);
 
    BOOST_TEST(unsub_response_json == expected_unsub);
 }
@@ -2443,7 +2372,6 @@ BOOST_AUTO_TEST_CASE(subscription_test_wildcard_permission)
      "requestId":"8778"
     })");
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
    BOOST_TEST(response_json.contains("subscriptionId") == true);
 
    int subID = response_json["subscriptionId"].as<int>();
@@ -2451,9 +2379,8 @@ BOOST_AUTO_TEST_CASE(subscription_test_wildcard_permission)
    // checked if subid is available. now remove to assert.
    response_json.erase("subscriptionId");
 
+   verify_timestamp(expected, response_json);
 
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 
 
@@ -2469,21 +2396,21 @@ BOOST_AUTO_TEST_CASE(subscription_test_wildcard_permission)
    string unsub_response = commandProc->processQuery(temp_unsubreq.as_string(),channel);
    json unsub_response_json = json::parse(unsub_response);
 
-   // assert timestamp and subid.
-   BOOST_TEST(unsub_response_json.contains("timestamp") == true);
+   // assert subid.
    BOOST_TEST(unsub_response_json.contains("subscriptionId") == true);
 
    // compare the subit passed and returned.
    BOOST_TEST(unsub_response_json["subscriptionId"].as<int>() == subID);
 
-   // remove timestamp and subid to assert other part of the response.because these are variables.
+   // remove subid to assert other part of the response.because these are variables.
    unsub_response_json.erase("subscriptionId");
-   unsub_response_json.erase("timestamp");
 
    json expected_unsub = json::parse(R"({
      "action":"unsubscribe",
      "requestId":"8779"
     })");
+
+   verify_timestamp(expected_unsub, unsub_response_json);
 
    BOOST_TEST(unsub_response_json == expected_unsub);
 }
@@ -2533,10 +2460,8 @@ BOOST_AUTO_TEST_CASE(subscription_test_no_permission)
                    "requestId":"8778"
                    })");
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
+   verify_timestamp(expected, response_json);
 
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -2586,10 +2511,8 @@ BOOST_AUTO_TEST_CASE(subscription_test_invalidpath)
                    "requestId":"8778"
                    })");
 
-   BOOST_TEST(response_json.contains("timestamp") == true);
+   verify_timestamp(expected, response_json);
 
-   // remove timestamp to match
-   response_json.erase("timestamp");
    BOOST_TEST(response_json == expected);
 }
 
@@ -2637,12 +2560,12 @@ BOOST_AUTO_TEST_CASE(process_sub_with_wildcard)
 
     json response_json = json::parse(response);
     json request_json = json::parse(request);
-    BOOST_TEST(response_json.contains("timestamp") == true);
     BOOST_TEST(response_json.contains("subscriptionId") == true);
-    // remove timestamp to match
-    response_json.erase("timestamp");
     response_json.erase("subscriptionId");
     request_json.erase("path");
+
+    verify_timestamp(expected, response_json);
+
     BOOST_TEST(response_json == expected);
 }
 
@@ -2693,14 +2616,14 @@ BOOST_AUTO_TEST_CASE(process_sub_without_wildcard)
     json response_json = json::parse(response);
     json request_json = json::parse(request);
     // TEST response for parameters
-    BOOST_TEST(response_json.contains("timestamp") == true);
     BOOST_TEST(response_json.contains("subscriptionId") == true);
     // TEST request for parameters
     BOOST_TEST(request_json.contains("path") == true);
-    // remove timestamp to match
-    response_json.erase("timestamp");
     response_json.erase("subscriptionId");
     request_json.erase("path");
+
+    verify_timestamp(expected, response_json);
+
     BOOST_TEST(response_json == expected);
 }
 
@@ -2750,8 +2673,7 @@ BOOST_AUTO_TEST_CASE(subscription_test_invalid_wildcard)
                                 "requestId":"878787"
                                 })");
 
-    BOOST_TEST(response_json.contains("timestamp") == true);
-    // remove timestamp to match
-    response_json.erase("timestamp");
+   verify_timestamp(expected, response_json);
+
     BOOST_TEST(response_json == expected);
 }

--- a/test/unit-test/UnitTestHelpers.hpp
+++ b/test/unit-test/UnitTestHelpers.hpp
@@ -1,0 +1,29 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2021 Robert Bosch GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ *  Contributors:
+ *      Robert Bosch GmbH 
+ * *****************************************************************************
+ */
+
+
+/** Includes helper functions that can be used by different test modules */
+
+#include <boost/test/unit_test.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <jsoncons/json.hpp>
+
+//Verifies a timestamp exists and is of type string. Copies it to the
+//expected answer
+static inline void verify_timestamp(jsoncons::json &expected, const jsoncons::json &result)  {
+  BOOST_TEST(result.contains("timestamp"));
+  BOOST_TEST(result["timestamp"].is_string());
+  BOOST_CHECK_NO_THROW(boost::posix_time::from_iso_extended_string(result["timestamp"].as_string()));
+  expected["timestamp"]=result["timestamp"].as_string(); 
+}

--- a/test/unit-test/VssCommandProcessorTests.cpp
+++ b/test/unit-test/VssCommandProcessorTests.cpp
@@ -110,9 +110,9 @@ BOOST_AUTO_TEST_CASE(Given_ValidGetQuery_When_PathNotValid_Shall_ReturnError)
   auto res = json::parse(resStr);
 
   // verify
-
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonPathNotFound["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  res["timestamp"]=jsonPathNotFound["timestamp"].as_string(); // ignoring timestamp difference for response
   BOOST_TEST(res == jsonPathNotFound);
 }
 
@@ -163,9 +163,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidGetQuery_When_DBThrowsNotExpectedException_Shall
   auto res = json::parse(resStr);
 
   // verify
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonMalformedReq["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonMalformedReq["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response
+
 
   BOOST_TEST(res == jsonMalformedReq);
 }
@@ -214,9 +215,9 @@ BOOST_AUTO_TEST_CASE(Given_ValidGetQuery_When_UserNotAuthorized_Shall_ReturnErro
   auto res = json::parse(resStr);
 
   // verify
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonNoAccess["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonNoAccess["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response
 
 
   BOOST_TEST(res == jsonNoAccess);
@@ -322,9 +323,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidGetQuery_When_NoValueFromDB_Shall_ReturnError)
 
   // verify
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonPathNotFound["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonPathNotFound["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response
+
   BOOST_TEST(res == jsonPathNotFound);
 }
 
@@ -373,9 +375,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidSetQuery_When_InvalidPath_Shall_ReturnError)
 
   // verify
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonPathNotFound["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonPathNotFound["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response
+
   BOOST_TEST(res == jsonPathNotFound);
 }
 
@@ -435,9 +438,9 @@ BOOST_AUTO_TEST_CASE(Given_ValidSetQuery_When_ValueOutOfBound_Shall_ReturnError)
 
   // verify
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  jsonValueOutOfBound["timestamp"] = res["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonValueOutOfBound["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response
 
   BOOST_TEST(res == jsonValueOutOfBound);
 }
@@ -492,9 +495,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidSetQuery_When_NoPermission_Shall_ReturnError)
 
   // verify
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  jsonNoAccess["timestamp"] = res["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonNoAccess["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response
+
   BOOST_TEST(res == jsonNoAccess);
 }
 
@@ -551,10 +555,9 @@ BOOST_AUTO_TEST_CASE(Given_ValidSetQuery_When_DBThrowsNotExpectedException_Shall
 
   // verify
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  // Set timestamp for comparision purposes
-  jsonMalformedReq["timestamp"] = res["timestamp"].as<int64_t>();
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonMalformedReq["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response
 
   BOOST_TEST(res == jsonMalformedReq);
 }
@@ -610,9 +613,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidSetQuery_When_UserAuthorized_Shall_UpdateValue)
 
   // verify
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonSignalValue["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonSignalValue["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response
+
   BOOST_TEST(res == jsonSignalValue);
 }
 
@@ -659,9 +663,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidSubscribeQuery_When_UserAuthorized_Shall_ReturnS
 
   // verify
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonSignalValue["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonSignalValue["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response
+
   BOOST_TEST(res == jsonSignalValue);
 }
 
@@ -708,9 +713,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidSubscribeQuery_When_UserAuthorizedButSubIdZero_S
 
   // verify
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonSignalValue["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonSignalValue["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response
+
   BOOST_TEST(res == jsonSignalValue);
 }
 
@@ -750,9 +756,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidSubscribeQuery_When_UserNotAuthorized_Shall_Retu
 
   // verify
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonNoAccess["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonNoAccess["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
+
   BOOST_TEST(res == jsonNoAccess);
 }
 
@@ -791,10 +798,12 @@ BOOST_AUTO_TEST_CASE(Given_ValidSubscribeQuery_When_PathNotValid_Shall_ReturnErr
   auto res = json::parse(resStr);
 
   // verify
-
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonPathNotFound["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonPathNotFound["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
+  
+  BOOST_TEST(res == jsonPathNotFound);
+  
   BOOST_TEST(res == jsonPathNotFound);
 }
 
@@ -834,9 +843,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidSubscribeQuery_When_OutOfBounds_Shall_ReturnErro
 
   // verify
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonOutOfBound["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonOutOfBound["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
+  
   BOOST_TEST(res == jsonOutOfBound);
 }
 
@@ -876,9 +886,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidSubscribeQuery_When_SubHandlerThrowsNotExpectedE
 
   // verify
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonMalformedReq["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonMalformedReq["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
+
   BOOST_TEST(res == jsonMalformedReq);
 }
 
@@ -923,10 +934,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidUnsubscribeQuery_When_UserAuthorized_Shall_Unsub
   auto res = json::parse(resStr);
 
   // verify
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonSignalValue["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonSignalValue["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
   BOOST_TEST(res == jsonSignalValue);
 }
 
@@ -971,10 +982,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidUnsubscribeQuery_When_Error_Shall_ReturnError)
   auto res = json::parse(resStr);
 
   // verify
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonSignalValue["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonSignalValue["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
   BOOST_TEST(res == jsonSignalValue);
 }
 
@@ -1022,10 +1033,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidGetMetadataQuery_When_UserAuthorized_Shall_GetMe
   auto res = json::parse(resStr);
 
   // verify
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonValue["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonValue["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
   BOOST_TEST(res == jsonValue);
 }
 
@@ -1073,10 +1084,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidAuthJson_When_TokenValid_Shall_Authorize)
   auto res = json::parse(resStr);
 
   // verify
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonValue["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonValue["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
   BOOST_TEST(res == jsonValue);
 }
 
@@ -1124,10 +1135,10 @@ BOOST_AUTO_TEST_CASE(Given_ValidAuthJson_When_TokenInvalid_Shall_ReturnError)
   auto res = json::parse(resStr);
 
   // verify
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonValue["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
 
-  // // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonValue["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
   BOOST_TEST(res == jsonValue);
 }
 
@@ -1157,9 +1168,10 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   auto resStr = processor->processQuery(jsonRequest.as_string(), channel);
   auto res = json::parse(resStr);
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonExpected["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonExpected["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
+
   BOOST_TEST(res == jsonExpected);
 
   //////////////////////
@@ -1171,9 +1183,10 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   jsonValueErr["message"] = "Key not found: 'path'";
   jsonExpected["error"] = jsonValueErr;
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonExpected["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonExpected["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
+
   BOOST_TEST(res == jsonExpected);
 
   //////////////////////
@@ -1185,9 +1198,9 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   jsonValueErr["message"] = "Key not found: 'requestId'";
   jsonExpected["error"] = jsonValueErr;
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonExpected["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonExpected["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
   BOOST_TEST(res == jsonExpected);
 
   //////////////////////
@@ -1199,9 +1212,10 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   jsonValueErr["message"] = "Unknown action requested";
   jsonExpected["error"] = jsonValueErr;
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonExpected["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonExpected["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
+
   BOOST_TEST(res == jsonExpected);
 
   //////////////////////
@@ -1212,9 +1226,10 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   jsonValueErr["message"] = "";
   jsonExpected["error"] = jsonValueErr;
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonExpected["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+  BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonExpected["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
+  
   res["error"] = jsonExpected["error"].as<json>();     // ignoring error content
   BOOST_TEST(res == jsonExpected);
 
@@ -1226,9 +1241,10 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   jsonValueErr["message"] = "";
   jsonExpected["error"] = jsonValueErr;
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonExpected["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+    BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonExpected["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
+  
   res["error"] = jsonExpected["error"].as<json>();     // ignoring error content
   BOOST_TEST(res == jsonExpected);
 
@@ -1240,9 +1256,10 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   jsonValueErr["message"] = "";
   jsonExpected["error"] = jsonValueErr;
 
-  // timestamp must not be zero
-  BOOST_TEST(res["timestamp"].as<int64_t>() > 0);
-  res["timestamp"] = jsonExpected["timestamp"].as<int64_t>(); // ignoring timestamp difference for response
+   BOOST_TEST(res.contains("timestamp"));
+  BOOST_TEST(res["timestamp"].is_string());
+  jsonExpected["timestamp"]=res["timestamp"].as_string(); // ignoring timestamp difference for response 
+
   res["error"] = jsonExpected["error"].as<json>();     // ignoring error content
   BOOST_TEST(res == jsonExpected);
 }

--- a/test/unit-test/VssDatabaseTests.cpp
+++ b/test/unit-test/VssDatabaseTests.cpp
@@ -16,6 +16,8 @@
 #include <turtle/mock.hpp>
 #undef BOOST_BIND_GLOBAL_PLACEHOLDERS
 
+#include "UnitTestHelpers.hpp"
+
 #include <memory>
 #include <string>
 
@@ -190,6 +192,9 @@ BOOST_AUTO_TEST_CASE(Given_ValidVssFilenameAndChannelAuthorized_When_GetSingleSi
   // verify
 
   BOOST_CHECK_NO_THROW(returnJson = db->getSignal(signalPath));
+
+  verify_timestamp(expectedJson, returnJson);
+
   BOOST_TEST(returnJson == expectedJson);
 }
 
@@ -208,6 +213,9 @@ BOOST_AUTO_TEST_CASE(Given_ValidVssFilenameAndChannelAuthorized_When_GetBranch_S
   // verify
 
   BOOST_CHECK_NO_THROW(returnJson = db->getSignal(signalPath));
+
+  verify_timestamp(expectedJson, returnJson);
+
   BOOST_TEST(returnJson == expectedJson);
 }
 


### PR DESCRIPTION
This changes timestamps to ISO8601 format as mandated by VISS V2. Fixes #160 

It should have no effect on our existing tools. but please verify Node RED examples not influenced by this

Not to code: Attaching the mandated UTC timezone "Z" is a bit ugly,  but the to_iso_extended_string method doesn't provide any options, and using the "offical" boost way of using "dateFaces" and "TimeFaces" would be many times the amount of code (and involving stringstream), so I assumed this is cleaner. I considered doing it in C, that is also more code and maybe not "nice" in a C++ Coebase


Get&Set testcase suites have a know a timestamp validation helper.
The older VssCommandProcessorTests.cpp does not include this and has been "manually fixed. Opinions? If there is a preference to also use the helper, I can change it
