### PR TITLE
Update Boost download URL to to retirement of bintray download service

### DIFF
--- a/boost.cmake
+++ b/boost.cmake
@@ -31,7 +31,7 @@ findBoost("")
 
 if(NOT Boost_FOUND)
   string(REPLACE "." "_" BOOST_VER_ ${BOOST_VER}) 
-  set(BOOST_URL "https://dl.bintray.com/boostorg/release/${BOOST_VER}/source/boost_${BOOST_VER_}.tar.bz2" CACHE STRING "Boost download URL")
+  set(BOOST_URL "https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VER}/source/boost_${BOOST_VER_}.tar.bz2" CACHE STRING "Boost download URL")
   set(BOOST_URL_SHA256 "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb" CACHE STRING "Boost download URL SHA256 checksum")
   option(BOOST_DISABLE_TESTS "Do not build test targets" OFF)
   include(FetchContent)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,11 +15,13 @@ RUN apk update && apk add cmake wget alpine-sdk glib-dev openssl-dev libstdc++ m
 
 
 #Build Boost 1.75
+ENV BOOST_VER=1.75.0
+ENV BOOST_VER_=1_75_0
 RUN mkdir /buildboost
 WORKDIR /buildboost
-RUN wget https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2
-RUN tar xvjf boost_1_75_0.tar.bz2
-WORKDIR /buildboost/boost_1_75_0
+RUN wget   https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VER}/source/boost_${BOOST_VER_}.tar.bz2
+RUN tar xvjf boost_${BOOST_VER_}.tar.bz2
+WORKDIR /buildboost/boost_${BOOST_VER_}
 RUN ./bootstrap.sh
 RUN ./b2 -j 6 install
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -21,11 +21,13 @@ RUN apt-get  update && DEBIAN_FRONTEND="noninteractive" apt-get -y install libss
                         gcovr
 
 #Build Boost 1.75
+ENV BOOST_VER=1.75.0
+ENV BOOST_VER_=1_75_0
 RUN mkdir /buildboost
 WORKDIR /buildboost
-RUN wget   https://dl.bintray.com/boostorg/release/1.75.0/source/boost_1_75_0.tar.bz2
-RUN tar xvjf boost_1_75_0.tar.bz2
-WORKDIR /buildboost/boost_1_75_0
+RUN wget   https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VER}/source/boost_${BOOST_VER_}.tar.bz2
+RUN tar xvjf boost_${BOOST_VER_}.tar.bz2
+WORKDIR /buildboost/boost_${BOOST_VER_}
 RUN ./bootstrap.sh
 RUN ./b2 -j 6 install
 


### PR DESCRIPTION
Fixes #186 

Approve/merge if builds on Azure CI go through, Eclispe CI still has permissions problems