### PR TITLE
Apply default values upon initial loading of VSS tree

### DIFF
--- a/include/VssCommandProcessor.hpp
+++ b/include/VssCommandProcessor.hpp
@@ -45,7 +45,7 @@ class VssCommandProcessor : public IVssCommandProcessor {
 
   std::string processSubscribe(WsChannel& channel, const std::string& request_id, const std::string& path);
   std::string processUnsubscribe(const std::string & request_id, uint32_t subscribeID);
-  std::string processUpdateVSSTree(WsChannel& channel, const std::string& request_id, const jsoncons::json& metadata);
+  std::string processUpdateVSSTree(WsChannel& channel, const std::string& request_id,  jsoncons::json& metadata);
   std::string processUpdateMetaData(WsChannel& channel, jsoncons::json& request);
   std::string processGetMetaData(jsoncons::json &request);
   std::string processAuthorize(WsChannel& channel, const std::string & request_id,

--- a/include/VssDatabase.hpp
+++ b/include/VssDatabase.hpp
@@ -53,7 +53,12 @@ class VssDatabase : public IVssDatabase {
 
 
   void initJsonTree(const boost::filesystem::path &fileName) override;
+  
   bool checkPathValid(const VSSPath& path);
+  static bool isActor(const jsoncons::json &element);
+  static bool isSensor(const jsoncons::json &element);
+
+
   void updateJsonTree(jsoncons::json& sourceTree, const jsoncons::json& jsonTree);
   void updateJsonTree(WsChannel& channel, const jsoncons::json& value) override;
   void updateMetaData(WsChannel& channel, const VSSPath& path, const jsoncons::json& newTree) override;
@@ -62,6 +67,7 @@ class VssDatabase : public IVssDatabase {
   jsoncons::json setSignal(const VSSPath &path, jsoncons::json &value) override; //gen2 version
   jsoncons::json getSignal(const VSSPath &path) override; //Gen2 version
 
+  void applyDefaultValues(jsoncons::json &tree, VSSPath currentPath);
 
 };
 #endif

--- a/include/VssDatabase.hpp
+++ b/include/VssDatabase.hpp
@@ -61,7 +61,7 @@ class VssDatabase : public IVssDatabase {
 
 
   void updateJsonTree(jsoncons::json& sourceTree, const jsoncons::json& jsonTree);
-  void updateJsonTree(WsChannel& channel, const jsoncons::json& value) override;
+  void updateJsonTree(WsChannel& channel, jsoncons::json& value) override;
   void updateMetaData(WsChannel& channel, const VSSPath& path, const jsoncons::json& newTree) override;
   jsoncons::json getMetaData(const VSSPath& path) override;
   

--- a/include/VssDatabase.hpp
+++ b/include/VssDatabase.hpp
@@ -57,6 +57,7 @@ class VssDatabase : public IVssDatabase {
   bool checkPathValid(const VSSPath& path);
   static bool isActor(const jsoncons::json &element);
   static bool isSensor(const jsoncons::json &element);
+  static bool isAttribute(const jsoncons::json &element);
 
 
   void updateJsonTree(jsoncons::json& sourceTree, const jsoncons::json& jsonTree);

--- a/include/interface/IVssDatabase.hpp
+++ b/include/interface/IVssDatabase.hpp
@@ -28,7 +28,7 @@ class IVssDatabase {
     virtual ~IVssDatabase() {}
 
     virtual void initJsonTree(const boost::filesystem::path &fileName) = 0;
-    virtual void updateJsonTree(WsChannel& channel, const jsoncons::json& value) = 0;
+    virtual void updateJsonTree(WsChannel& channel, jsoncons::json& value) = 0;
     virtual void updateMetaData(WsChannel& channel, const VSSPath& path, const jsoncons::json& value) = 0;
     virtual jsoncons::json getMetaData(const VSSPath &path) = 0;
   

--- a/src/VssCommandProcessor.cpp
+++ b/src/VssCommandProcessor.cpp
@@ -448,7 +448,7 @@ string VssCommandProcessor::processQuery(const string &req_json,
     } else if (action == "updateVSSTree") {
       string request_id = root["requestId"].as<string>();
       logger->Log(LogLevel::VERBOSE, "VssCommandProcessor::processQuery: update MetaData query  for with request id " + request_id);
-      response = processUpdateVSSTree(channel, request_id, root["updateadata"]);
+      response = processUpdateVSSTree(channel, request_id, root["metadata"]);
     } else {
       string path = root["path"].as<string>();
       string request_id = root["requestId"].as<string>();

--- a/src/VssCommandProcessor.cpp
+++ b/src/VssCommandProcessor.cpp
@@ -155,7 +155,7 @@ string VssCommandProcessor::processUnsubscribe(const string & request_id,
   }
 }
 
-string VssCommandProcessor::processUpdateVSSTree(WsChannel& channel, const string& request_id, const jsoncons::json& metaData){
+string VssCommandProcessor::processUpdateVSSTree(WsChannel& channel, const string& request_id,  jsoncons::json& metaData){
   logger->Log(LogLevel::VERBOSE, "VssCommandProcessor::processUpdateVSSTree");
   
   jsoncons::json answer;

--- a/src/VssDatabase.cpp
+++ b/src/VssDatabase.cpp
@@ -248,16 +248,17 @@ void VssDatabase::updateJsonTree(jsoncons::json& sourceTree, const jsoncons::jso
 
 }
 
-void VssDatabase::updateJsonTree(WsChannel& channel, const jsoncons::json& jsonTree){
+void VssDatabase::updateJsonTree(WsChannel& channel,  jsoncons::json& jsonTree){
   if (! channel.authorizedToModifyTree()) {
      stringstream msg;
      msg << "do not have write access for updating json tree or is invalid";
      throw noPermissionException(msg.str());
   }
-
+  if (jsonTree.contains("Vehicle")) {
+    applyDefaultValues(jsonTree["Vehicle"], VSSPath::fromVSS(""));
+  }
   updateJsonTree(meta_tree__, jsonTree);
   updateJsonTree(data_tree__, jsonTree);
-
 }
 
 // update a metadata in tree, which will only do one-level-deep shallow merge/update.

--- a/src/VssDatabase.cpp
+++ b/src/VssDatabase.cpp
@@ -52,6 +52,11 @@ bool VssDatabase::isSensor(const json &element) {
   return element.contains("type") && element["type"]=="sensor";
 }
 
+/** Returns true if the json structure is of VSS type attribute */
+bool VssDatabase::isAttribute(const json &element) {
+  return element.contains("type") && element["type"]=="attribute";
+}
+
 
 /** Iterates over a given VSS tree and checks for sensors and actuators specifying the "default"
  *  metadata. If a default is present, it will be used as "value" (and thus returned upon get
@@ -60,7 +65,7 @@ bool VssDatabase::isSensor(const json &element) {
 void VssDatabase::applyDefaultValues(json &tree, VSSPath path) {
   //logger_->Log(LogLevel::VERBOSE, "Applying default values in "+path.to_string());
 
-  if ( isSensor(tree) || isActor(tree) ) {
+  if ( isSensor(tree) || isActor(tree) || isAttribute(tree)) {
     if (tree.contains("default")) {
       logger_->Log(LogLevel::INFO, "Setting default for "+path.to_string()+" to "+tree["default"].as<string>());
       /** Not using setSignal, as that always operates on the complete tree. However applyDefaultValues shall also

--- a/test/unit-test/VssDatabaseTests.cpp
+++ b/test/unit-test/VssDatabaseTests.cpp
@@ -267,4 +267,248 @@ BOOST_AUTO_TEST_CASE(Given_ValidVssFilenameAndChannelAuthorized_When_SetSingleSi
 }
 
 
+/*********************** isActor() tests ************************/
+BOOST_AUTO_TEST_CASE(Check_IsActor_ForActor) {
+    std::string inputJsonString{R"({
+  "datatype": "boolean",
+  "description": "Is brake light on",
+  "type": "actuator",
+  "uuid": "7b8b136ec8aa59cb8773aa3c455611a4"
+})"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isActor(inputJson) == true);
+}
+
+BOOST_AUTO_TEST_CASE(Check_IsActor_ForSensor) {
+    std::string inputJsonString{R"({
+  "datatype": "uint8",
+  "description": "Rain intensity. 0 = Dry, No Rain. 100 = Covered.",
+  "type": "sensor",
+  "unit": "percent",
+  "uuid": "02828e9e5f7b593fa2160e7b6dbad157"
+})"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isActor(inputJson) == false);
+}
+
+BOOST_AUTO_TEST_CASE(Check_IsActor_ForAttribute) {
+    std::string inputJsonString{R"(
+    {
+      "datatype": "uint16",
+      "description": "Gross capacity of the battery",
+      "type": "attribute",
+      "unit": "kWh",
+      "uuid": "7b5402cc647454b49ee019e8689d3737"
+    }
+    )"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isActor(inputJson) == false);
+}
+
+BOOST_AUTO_TEST_CASE(Check_IsActor_ForInvalid) {
+    std::string inputJsonString{R"({
+  "element": "invalidVSSJSon"
+})"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isActor(inputJson) == false);
+}
+
+/*********************** isSensor() tests ************************/
+BOOST_AUTO_TEST_CASE(Check_IsSensor_ForSensor) {
+    std::string inputJsonString{R"({
+  "datatype": "uint8",
+  "description": "Rain intensity. 0 = Dry, No Rain. 100 = Covered.",
+  "type": "sensor",
+  "unit": "percent",
+  "uuid": "02828e9e5f7b593fa2160e7b6dbad157"
+})"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isSensor(inputJson) == true);
+}
+
+BOOST_AUTO_TEST_CASE(Check_IsSensor_ForActor) {
+    std::string inputJsonString{R"({
+  "datatype": "boolean",
+  "description": "Is brake light on",
+  "type": "actuator",
+  "uuid": "7b8b136ec8aa59cb8773aa3c455611a4"
+})"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isSensor(inputJson) == false);
+}
+
+BOOST_AUTO_TEST_CASE(Check_IsSensor_ForAttribute) {
+  std::string inputJsonString{R"(
+  {
+    "datatype": "uint16",
+    "description": "Gross capacity of the battery",
+    "type": "attribute",
+    "unit": "kWh",
+    "uuid": "7b5402cc647454b49ee019e8689d3737"
+  }    
+  )"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isSensor(inputJson) == false);
+}
+
+
+BOOST_AUTO_TEST_CASE(Check_IsSensor_ForInvalid) {
+    std::string inputJsonString{R"({
+  "element": "invalidVSSJSon"
+})"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isSensor(inputJson) == false);
+}
+
+/*********************** isAttribute() tests ************************/
+BOOST_AUTO_TEST_CASE(Check_IsAttribute_ForSensor) {
+    std::string inputJsonString{R"({
+  "datatype": "uint8",
+  "description": "Rain intensity. 0 = Dry, No Rain. 100 = Covered.",
+  "type": "sensor",
+  "unit": "percent",
+  "uuid": "02828e9e5f7b593fa2160e7b6dbad157"
+})"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isAttribute(inputJson) == false);
+}
+
+BOOST_AUTO_TEST_CASE(Check_IsAttribute_ForActor) {
+    std::string inputJsonString{R"({
+  "datatype": "boolean",
+  "description": "Is brake light on",
+  "type": "actuator",
+  "uuid": "7b8b136ec8aa59cb8773aa3c455611a4"
+})"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isAttribute(inputJson) == false);
+}
+
+BOOST_AUTO_TEST_CASE(Check_IsAttribute_ForAttribute) {
+  std::string inputJsonString{R"(
+  {
+    "datatype": "uint16",
+    "description": "Gross capacity of the battery",
+    "type": "attribute",
+    "unit": "kWh",
+    "uuid": "7b5402cc647454b49ee019e8689d3737"
+  }    
+  )"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isAttribute(inputJson) == true);
+}
+
+
+BOOST_AUTO_TEST_CASE(Check_IsAttribute_ForInvalid) {
+  std::string inputJsonString{R"({
+  "element": "invalidVSSJSon"
+  })"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+  BOOST_TEST(VssDatabase::isAttribute(inputJson) == false);
+}
+
+
+/*** applyDefaultValue Checks **/
+BOOST_AUTO_TEST_CASE(applyDefaultValues_withDefault) {
+  std::string inputJsonString{R"(
+    {
+      "datatype": "uint8",
+      "default": 0,
+      "description": "Number of doors in vehicle",
+      "type": "attribute",
+      "uuid": "49a445e112f35283b4be6ec82812b29b"
+    }
+  )"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+
+  std::string expectedJsonString{R"(
+  {
+    "datatype": "uint8",
+    "default": 0,
+    "value": "0",
+    "description": "Number of doors in vehicle",
+    "type": "attribute",
+    "uuid": "49a445e112f35283b4be6ec82812b29b"
+  }
+  )"};
+  jsoncons::json expectedJson = jsoncons::json::parse(expectedJsonString);
+
+  db->applyDefaultValues(inputJson,VSSPath::fromVSS(""));
+  BOOST_TEST(inputJson == expectedJson);
+}
+
+
+BOOST_AUTO_TEST_CASE(applyDefaultValues_Recurse) {
+  std::string inputJsonString{R"(
+  {
+    "children": {
+      "ChargePlugType": {
+        "datatype": "string",
+        "default": "ccs",
+        "description": "Type of charge plug available on the vehicle (CSS includes Type2).",
+        "enum": [
+          "type 1",
+          "type 2",
+          "ccs",
+          "chademo"
+        ],
+        "type": "attribute",
+        "uuid": "0c4cf2b3979456928967e73b646bda05"
+      },
+      "ChargePortFlap": {
+        "datatype": "string",
+        "default": "closed",
+        "description": "Signal indicating if charge port cover is open or closed, can potentially be controlled manually.",
+        "enum": [
+          "open",
+          "closed"
+        ],
+        "type": "actuator",
+        "uuid": "528e53ad98c1546b90bb48f24f04815a"
+      }
+    }
+  }
+  )"};
+  jsoncons::json inputJson = jsoncons::json::parse(inputJsonString);
+
+  std::string expectedJsonString{R"(
+   {
+    "children": {
+      "ChargePlugType": {
+        "datatype": "string",
+        "default": "ccs",
+        "value": "ccs",
+        "description": "Type of charge plug available on the vehicle (CSS includes Type2).",
+        "enum": [
+          "type 1",
+          "type 2",
+          "ccs",
+          "chademo"
+        ],
+        "type": "attribute",
+        "uuid": "0c4cf2b3979456928967e73b646bda05"
+      },
+      "ChargePortFlap": {
+        "datatype": "string",
+        "default": "closed",
+        "value": "closed",
+        "description": "Signal indicating if charge port cover is open or closed, can potentially be controlled manually.",
+        "enum": [
+          "open",
+          "closed"
+        ],
+        "type": "actuator",
+        "uuid": "528e53ad98c1546b90bb48f24f04815a"
+      }
+    }
+  }
+  )"};
+  jsoncons::json expectedJson = jsoncons::json::parse(expectedJsonString);
+
+  db->applyDefaultValues(inputJson,VSSPath::fromVSS(""));
+  BOOST_TEST(inputJson == expectedJson);
+}
+
+
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Will fix #166 

Upon loading of a VSS file `default` entries will be copied to values.
```
~/kuksa.val/build/src$ ./kuksa-val-server --vss vss_release_2.1.json kuksa.val server
Commit 2f3afd9-dirty from 2021-05-06T11:43:05+02:00
Read configs from config.ini
Update vss path to /home/sebastian/kuksa.val/build/src/vss_release_2.1.json
Update cert-path to /home/sebastian/kuksa.val/build/src/.
Log START
VERBOSE: Try reading JWT pub key from /home/sebastian/kuksa.val/build/src/./jwt.key.pub
VERBOSE: SubscribeThread: Started Subscription Thread!
VERBOSE: VssDatabase::VssDatabase : VSS tree initialized using JSON file = /home/sebastian/kuksa.val/build/src/vss_release_2.1.json
INFO: Setting default for Vehicle/Body/ChargingPort/Type to unknown
INFO: Setting default for Vehicle/Cabin/Door/Row1/LeftCount to 0
INFO: Setting default for Vehicle/Cabin/Door/Row1/RightCount to 0
INFO: Setting default for Vehicle/Cabin/Door/Row2/LeftCount to 0
INFO: Setting default for Vehicle/Cabin/Door/Row2/RightCount to 0
INFO: Setting default for Vehicle/Cabin/Door/Row3/LeftCount to 0
INFO: Setting default for Vehicle/Cabin/Door/Row3/RightCount to 0
INFO: Setting default for Vehicle/Cabin/Door/Row4/LeftCount to 0
INFO: Setting default for Vehicle/Cabin/Door/Row4/RightCount to 0
INFO: Setting default for Vehicle/Cabin/DriverPosition to 0
INFO: Setting default for Vehicle/Cabin/SeatPosCount to 0
INFO: Setting default for Vehicle/Cabin/SeatRowCount to 0
INFO: Setting default for Vehicle/Chassis/Axle/Row1Count to 2
INFO: Setting default for Vehicle/Chassis/Axle/Row2Count to 2
INFO: Setting default for Vehicle/Chassis/CurbWeight to 0
INFO: Setting default for Vehicle/Chassis/GrossWeight to 0
INFO: Setting default for Vehicle/Chassis/Height to 0
INFO: Setting default for Vehicle/Chassis/Length to 0
INFO: Setting default for Vehicle/Chassis/SteeringWheel/Position to front_left
INFO: Setting default for Vehicle/Chassis/TowWeight to 0
INFO: Setting default for Vehicle/Chassis/Track to 0
INFO: Setting default for Vehicle/Chassis/Wheelbase to 0
INFO: Setting default for Vehicle/Chassis/Width to 0
INFO: Setting default for Vehicle/CurbWeight to 0
INFO: Setting default for Vehicle/CurrentOverallWeight to 0
INFO: Setting default for Vehicle/GrossWeight to 0
INFO: Setting default for Vehicle/Height to 0
INFO: Setting default for Vehicle/Length to 0
INFO: Setting default for Vehicle/MaxTowBallWeight to 0
INFO: Setting default for Vehicle/MaxTowWeight to 0
INFO: Setting default for Vehicle/Powertrain/Battery/Charging/ChargePlugType to ccs
INFO: Setting default for Vehicle/Powertrain/Battery/Charging/ChargePortFlap to closed
INFO: Setting default for Vehicle/Powertrain/Battery/Charging/Mode to manual
INFO: Setting default for Vehicle/Powertrain/Battery/Charging/StartStopCharging to stop
INFO: Setting default for Vehicle/Powertrain/Battery/Charging/Timer/Mode to starttime
INFO: Setting default for Vehicle/Powertrain/CombustionEngine/AspirationType to unknown
INFO: Setting default for Vehicle/Powertrain/CombustionEngine/Configuration to unknown
INFO: Setting default for Vehicle/Powertrain/CombustionEngine/FuelType to unknown
INFO: Setting default for Vehicle/Powertrain/CombustionEngine/MaxPower to 0
INFO: Setting default for Vehicle/Powertrain/CombustionEngine/MaxTorque to 0
INFO: Setting default for Vehicle/Powertrain/ElectricMotor/MaxPower to 0
INFO: Setting default for Vehicle/Powertrain/ElectricMotor/MaxRegenPower to 0
INFO: Setting default for Vehicle/Powertrain/ElectricMotor/MaxRegenTorque to 0
INFO: Setting default for Vehicle/Powertrain/ElectricMotor/MaxTorque to 0
INFO: Setting default for Vehicle/Powertrain/FuelSystem/FuelType to unknown
INFO: Setting default for Vehicle/Powertrain/FuelSystem/HybridType to unknown
INFO: Setting default for Vehicle/Powertrain/Transmission/DriveType to unknown
INFO: Setting default for Vehicle/Powertrain/Transmission/GearCount to 0
INFO: Setting default for Vehicle/Powertrain/Transmission/Type to unknown
INFO: Setting default for Vehicle/Width to 0
INFO: Initializing Boost.Beast web-socket and http server on 127.0.0.1:8090
INFO: Starting Boost.Beast web-socket and http server
```

```
Test Client> authorize ../../kuksa_certificates/jwt/super-admin.json.token 
{
    "TTL": 1767225599, 
    "action": "authorize", 
    "requestId": "213416e7-1093-47fd-866c-b2ec0a02e353", 
    "timestamp": "2021-05-18T18:42:47.1621359767Z"
}

Test Client> getValue Vehicle/Powertrain/Battery/Charging/ChargePortFlap
{
    "action": "get", 
    "path": "Vehicle/Powertrain/Battery/Charging/ChargePortFlap", 
    "requestId": "c64487c9-116b-425b-9dee-9634cb53acf7", 
    "timestamp": "1981-01-01T00:00:00.0000000000Z", 
    "value": "closed"
}
```


also supports applying defaults when applying a file during runtime as in

```
updateVSSTree ../../kuksa_viss_client/test2.json 
```

The code for updateVSSTree was broken, and is not very robust, I suggest repairing it in a separate PR (see #191 ).  In this PR I just repaired it enough to make the feature work.


This PR also includes unittests for all newly introduced functions