### PR TITLE
Better validation and unit tests  for updateVSSTree

### DIFF
--- a/include/VSSRequestJsonSchema.hpp
+++ b/include/VSSRequestJsonSchema.hpp
@@ -70,6 +70,28 @@ static const char* SCHEMA_SET=R"(
 }
 )";
 
+static const char* SCHEMA_UPDATE_VSS_TREE=R"(
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Update tree Request",
+    "description": "Enables the client to update data model",
+    "type": "object",
+    "required": ["action", "metadata", "requestId"],
+    "properties": {
+        "action": {
+            "enum": [ "updateVSSTree"],
+            "description": "The identifier for the set request"
+        },
+        "metadata": {
+            "$ref": "viss#/definitions/metadata"
+        },
+        "requestId": {
+            "$ref": "viss#/definitions/requestId"
+        }
+    }
+}
+)";
+
 
 static const char* SCHEMA_UPDATE_TREE=R"(
 {
@@ -95,6 +117,7 @@ static const char* SCHEMA_UPDATE_TREE=R"(
     }
 }
 )";
+
 
 static const char* SCHEMA = (R"(
 {

--- a/include/VSSRequestJsonSchema.hpp
+++ b/include/VSSRequestJsonSchema.hpp
@@ -93,7 +93,7 @@ static const char* SCHEMA_UPDATE_VSS_TREE=R"(
 )";
 
 
-static const char* SCHEMA_UPDATE_TREE=R"(
+static const char* SCHEMA_UPDATE_METADATA=R"(
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "title": "Update tree Request",

--- a/include/VSSRequestValidator.hpp
+++ b/include/VSSRequestValidator.hpp
@@ -43,10 +43,10 @@ class VSSRequestValidator {
 
     private:
         class MessageValidator;
-        VSSRequestValidator::MessageValidator *getValidator;
-        VSSRequestValidator::MessageValidator *setValidator;
-        VSSRequestValidator::MessageValidator *updateMetadataValidator;
-        VSSRequestValidator::MessageValidator *updateVSSTreeValidator;
+        std::unique_ptr<VSSRequestValidator::MessageValidator> getValidator;
+        std::unique_ptr<VSSRequestValidator::MessageValidator> setValidator;
+        std::unique_ptr<VSSRequestValidator::MessageValidator> updateMetadataValidator;
+        std::unique_ptr<VSSRequestValidator::MessageValidator> updateVSSTreeValidator;
 
         std::shared_ptr<ILogger> logger;
 };

--- a/include/VSSRequestValidator.hpp
+++ b/include/VSSRequestValidator.hpp
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- * Copyright (c) 2020 Robert Bosch GmbH.
+ * Copyright (c) 2020-2021 Robert Bosch GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -29,8 +29,6 @@
 #include "ILogger.hpp"
 
 
-
-
 class VSSRequestValidator {
     public:
         VSSRequestValidator(std::shared_ptr<ILogger> loggerUtil);        
@@ -39,15 +37,17 @@ class VSSRequestValidator {
         void validateGet(jsoncons::json &request);
         void validateSet(jsoncons::json &request);
         void validateUpdateTree(jsoncons::json &request);
+        void validateUpdateVSSTree(jsoncons::json &request);
+
         std::string tryExtractRequestId(jsoncons::json &request);
 
     private:
-        std::shared_ptr<jsoncons::jsonschema::json_schema<jsoncons::json> > getSchema;
-        std::shared_ptr<jsoncons::jsonschema::json_schema<jsoncons::json> > setSchema;
-        std::shared_ptr<jsoncons::jsonschema::json_schema<jsoncons::json> > updateTreeSchema;
-        jsoncons::jsonschema::json_validator<jsoncons::json> *getValidator;
-        jsoncons::jsonschema::json_validator<jsoncons::json> *setValidator;
-        jsoncons::jsonschema::json_validator<jsoncons::json> *updateTreeValidator;
+        class MessageValidator;
+        VSSRequestValidator::MessageValidator *getValidator;
+        VSSRequestValidator::MessageValidator *setValidator;
+        VSSRequestValidator::MessageValidator *updateTreeValidator;
+        VSSRequestValidator::MessageValidator *updateVSSTreeValidator;
+
         std::shared_ptr<ILogger> logger;
 };
 

--- a/include/VSSRequestValidator.hpp
+++ b/include/VSSRequestValidator.hpp
@@ -36,7 +36,7 @@ class VSSRequestValidator {
 
         void validateGet(jsoncons::json &request);
         void validateSet(jsoncons::json &request);
-        void validateUpdateTree(jsoncons::json &request);
+        void validateUpdateMetadata(jsoncons::json &request);
         void validateUpdateVSSTree(jsoncons::json &request);
 
         std::string tryExtractRequestId(jsoncons::json &request);
@@ -45,7 +45,7 @@ class VSSRequestValidator {
         class MessageValidator;
         VSSRequestValidator::MessageValidator *getValidator;
         VSSRequestValidator::MessageValidator *setValidator;
-        VSSRequestValidator::MessageValidator *updateTreeValidator;
+        VSSRequestValidator::MessageValidator *updateMetadataValidator;
         VSSRequestValidator::MessageValidator *updateVSSTreeValidator;
 
         std::shared_ptr<ILogger> logger;

--- a/include/VssCommandProcessor.hpp
+++ b/include/VssCommandProcessor.hpp
@@ -45,7 +45,6 @@ class VssCommandProcessor : public IVssCommandProcessor {
 
   std::string processSubscribe(WsChannel& channel, const std::string& request_id, const std::string& path);
   std::string processUnsubscribe(const std::string & request_id, uint32_t subscribeID);
-  std::string processUpdateVSSTree(WsChannel& channel, const std::string& request_id,  jsoncons::json& metadata);
   std::string processUpdateMetaData(WsChannel& channel, jsoncons::json& request);
   std::string processGetMetaData(jsoncons::json &request);
   std::string processAuthorize(WsChannel& channel, const std::string & request_id,
@@ -56,6 +55,8 @@ class VssCommandProcessor : public IVssCommandProcessor {
   std::string getPathFromRequest(const jsoncons::json &req, bool *gen1_compat);
   std::string processGet2(WsChannel &channel, jsoncons::json &request);
   std::string processSet2(WsChannel &channel, jsoncons::json &request);
+  std::string processUpdateVSSTree(WsChannel& channel, jsoncons::json &request);
+
 
  public:
   VssCommandProcessor(std::shared_ptr<ILogger> loggerUtil,

--- a/src/VSSRequestValidator.cpp
+++ b/src/VSSRequestValidator.cpp
@@ -63,16 +63,16 @@ class VSSRequestValidator::MessageValidator {
 VSSRequestValidator::VSSRequestValidator(std::shared_ptr<ILogger> loggerUtil)  {
   this->logger = loggerUtil;
 
-  this->getValidator           = new MessageValidator(VSS_JSON::SCHEMA_GET);
-  this->setValidator           = new MessageValidator(VSS_JSON::SCHEMA_SET);
-  this->updateTreeValidator    = new MessageValidator(VSS_JSON::SCHEMA_UPDATE_TREE);
-  this->updateVSSTreeValidator = new MessageValidator(VSS_JSON::SCHEMA_UPDATE_VSS_TREE);
+  this->getValidator            = new MessageValidator(VSS_JSON::SCHEMA_GET);
+  this->setValidator            = new MessageValidator(VSS_JSON::SCHEMA_SET);
+  this->updateMetadataValidator = new MessageValidator(VSS_JSON::SCHEMA_UPDATE_METADATA);
+  this->updateVSSTreeValidator  = new MessageValidator(VSS_JSON::SCHEMA_UPDATE_VSS_TREE);
 }
 
 VSSRequestValidator::~VSSRequestValidator() {  
     delete getValidator;
     delete setValidator;
-    delete updateTreeValidator;
+    delete updateMetadataValidator;
     delete updateVSSTreeValidator;
 }
 
@@ -84,8 +84,8 @@ void VSSRequestValidator::validateSet(jsoncons::json& request) {
   setValidator->validate(request);
 }
 
-void VSSRequestValidator::validateUpdateTree(jsoncons::json& request) {
-  updateTreeValidator->validate(request);
+void VSSRequestValidator::validateUpdateMetadata(jsoncons::json& request) {
+  updateMetadataValidator->validate(request);
 }
 
 void VSSRequestValidator::validateUpdateVSSTree(jsoncons::json& request) {

--- a/src/VSSRequestValidator.cpp
+++ b/src/VSSRequestValidator.cpp
@@ -1,6 +1,6 @@
 /*
  * ******************************************************************************
- * Copyright (c) 2020 Robert Bosch GmbH.
+ * Copyright (c) 2020-2021 Robert Bosch GmbH.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -8,104 +8,95 @@
  * https://www.eclipse.org/org/documents/epl-2.0/index.php
  *
  *  Contributors:
- *      Robert Bosch GmbH 
+ *      Robert Bosch GmbH
  * *****************************************************************************
  */
 
-
-/** This will validate VSS requests in one place, giving some basic guarantees 
- *  regarding request validity such as mandatory fields and required datatypes*
+/** This will validate VSS requests in one place, giving some basic guarantees
+ *  regarding request validity such as mandatory fields and required datatypes
  */
 
-#include "VSSRequestJsonSchema.hpp"  
 #include "VSSRequestValidator.hpp"
-
 
 #include <jsoncons_ext/jsonschema/jsonschema.hpp>
 #include <string>
 
+#include "VSSRequestJsonSchema.hpp"
 
-json vss_resolver(const jsoncons::uri& uri) {
-    if ( std::string(uri.path()) == std::string("/viss" )) {
-        return json::parse(VSS_JSON::SCHEMA);
+
+class VSSRequestValidator::MessageValidator {
+  private:
+    std::shared_ptr<jsoncons::jsonschema::json_schema<jsoncons::json> > schema;
+    jsoncons::jsonschema::json_validator<jsoncons::json>* validator;
+
+  public: 
+    MessageValidator(const char* SCHEMA) {
+        this->schema = jsoncons::jsonschema::make_schema(jsoncons::json::parse(SCHEMA), vss_resolver);
+        this->validator = new jsoncons::jsonschema::json_validator<jsoncons::json>(this->schema);
     }
-    else {
-        throw  jsoncons::jsonschema::schema_error("Could not open " + std::string(uri.base()) + " for schema loading\n");
-    }
-}
 
-
-VSSRequestValidator::VSSRequestValidator(std::shared_ptr<ILogger> loggerUtil) {
-    this->logger=loggerUtil;  
-
-    this->getSchema = jsoncons::jsonschema::make_schema(json::parse(VSS_JSON::SCHEMA_GET), vss_resolver);
-    this->getValidator =  new jsoncons::jsonschema::json_validator<json>(this->getSchema);
-
-    this->setSchema = jsoncons::jsonschema::make_schema(json::parse(VSS_JSON::SCHEMA_SET), vss_resolver);
-    this->setValidator =  new jsoncons::jsonschema::json_validator<json>(this->setSchema);
-
-    this->updateTreeSchema = jsoncons::jsonschema::make_schema(json::parse(VSS_JSON::SCHEMA_UPDATE_TREE), vss_resolver);
-    this->updateTreeValidator =  new jsoncons::jsonschema::json_validator<json>(this->updateTreeSchema);
-}
-
-VSSRequestValidator::~VSSRequestValidator() {
-    delete this->getValidator;
-}
-
-
-void VSSRequestValidator::validateGet(jsoncons::json &request) {
+  void validate(jsoncons::json& request) {
     std::stringstream ss;
-    bool valid=true;
-    auto reporter = [&ss,&valid](const jsoncons::jsonschema::validation_output& o)
-        {
-            valid=false;
-            ss << o.instance_location() << ": " << o.message() << "\n";
+    bool valid = true;
+    auto reporter = [&ss, &valid](const jsoncons::jsonschema::validation_output& o) {
+      valid = false;
+      ss << o.instance_location() << ": " << o.message() << "\n";
     };
-
-    this->getValidator->validate(request, reporter);
-
+    this->validator->validate(request, reporter);
     if (!valid) {
-        throw jsoncons::jsonschema::schema_error("VSS get malformed: "+ss.str());
+      throw jsoncons::jsonschema::schema_error(ss.str());
     }
     return;
-}
+  }
 
-void VSSRequestValidator::validateSet(jsoncons::json &request) {
-    std::stringstream ss;
-    bool valid=true;
-    auto reporter = [&ss,&valid](const jsoncons::jsonschema::validation_output& o)
-        {
-            valid=false;
-            ss << o.instance_location() << ": " << o.message() << "\n";
-    };
-
-    this->setValidator->validate(request, reporter);
-
-    if (!valid) {
-        throw jsoncons::jsonschema::schema_error("VSS set malformed: "+ss.str());
+  static jsoncons::json vss_resolver(const jsoncons::uri& uri) {
+    if (std::string(uri.path()) == std::string("/viss")) {
+      return jsoncons::json::parse(VSS_JSON::SCHEMA);
+    } else {
+      throw jsoncons::jsonschema::schema_error("Could not open " + std::string(uri.base()) + " for schema loading\n");
     }
+  }
+  
+};
+
+
+VSSRequestValidator::VSSRequestValidator(std::shared_ptr<ILogger> loggerUtil)  {
+  this->logger = loggerUtil;
+
+  this->getValidator           = new MessageValidator(VSS_JSON::SCHEMA_GET);
+  this->setValidator           = new MessageValidator(VSS_JSON::SCHEMA_SET);
+  this->updateTreeValidator    = new MessageValidator(VSS_JSON::SCHEMA_UPDATE_TREE);
+  this->updateVSSTreeValidator = new MessageValidator(VSS_JSON::SCHEMA_UPDATE_VSS_TREE);
 }
 
-void VSSRequestValidator::validateUpdateTree(jsoncons::json &request) {
-    std::stringstream ss;
-    bool valid=true;
-    auto reporter = [&ss,&valid](const jsoncons::jsonschema::validation_output& o)
-        {
-            valid=false;
-            ss << o.instance_location() << ": " << o.message() << "\n";
-    };
-
-    this->updateTreeValidator->validate(request, reporter);
-
-    if (!valid) {
-        throw jsoncons::jsonschema::schema_error("VSS update tree malformed: "+ss.str());
-    }
+VSSRequestValidator::~VSSRequestValidator() {  
+    delete getValidator;
+    delete setValidator;
+    delete updateTreeValidator;
+    delete updateVSSTreeValidator;
 }
 
-/* When JSON schema validation fails, we can not be sure if the request contains a request_id 
- * This hleper tries to extract one in a save way (Helpful in error response), or 
- * returning "Unknown" if none is present
+void VSSRequestValidator::validateGet(jsoncons::json& request) {
+  getValidator->validate(request);
+}
+
+void VSSRequestValidator::validateSet(jsoncons::json& request) {
+  setValidator->validate(request);
+}
+
+void VSSRequestValidator::validateUpdateTree(jsoncons::json& request) {
+  updateTreeValidator->validate(request);
+}
+
+void VSSRequestValidator::validateUpdateVSSTree(jsoncons::json& request) {
+ updateVSSTreeValidator->validate(request);
+}
+
+/* When JSON schema validation fails, we can not be sure if the request contains
+ * a request_id This hleper tries to extract one in a save way (Helpful in error
+ * response), or returning "Unknown" if none is present
  * */
-std::string VSSRequestValidator::tryExtractRequestId(jsoncons::json &request) {
-    return request.get_value_or<std::string>("requestId", "UNKNOWN");;
+std::string VSSRequestValidator::tryExtractRequestId(jsoncons::json& request) {
+  return request.get_value_or<std::string>("requestId", "UNKNOWN");
+  ;
 }

--- a/src/VSSRequestValidator.cpp
+++ b/src/VSSRequestValidator.cpp
@@ -27,12 +27,12 @@
 class VSSRequestValidator::MessageValidator {
   private:
     std::shared_ptr<jsoncons::jsonschema::json_schema<jsoncons::json> > schema;
-    jsoncons::jsonschema::json_validator<jsoncons::json>* validator;
+    std::unique_ptr<jsoncons::jsonschema::json_validator<jsoncons::json>> validator;
 
   public: 
     MessageValidator(const char* SCHEMA) {
         this->schema = jsoncons::jsonschema::make_schema(jsoncons::json::parse(SCHEMA), vss_resolver);
-        this->validator = new jsoncons::jsonschema::json_validator<jsoncons::json>(this->schema);
+        this->validator = std::make_unique<jsoncons::jsonschema::json_validator<jsoncons::json>>(this->schema);
     }
 
   void validate(jsoncons::json& request) {
@@ -60,20 +60,16 @@ class VSSRequestValidator::MessageValidator {
 };
 
 
-VSSRequestValidator::VSSRequestValidator(std::shared_ptr<ILogger> loggerUtil)  {
-  this->logger = loggerUtil;
-
-  this->getValidator            = new MessageValidator(VSS_JSON::SCHEMA_GET);
-  this->setValidator            = new MessageValidator(VSS_JSON::SCHEMA_SET);
-  this->updateMetadataValidator = new MessageValidator(VSS_JSON::SCHEMA_UPDATE_METADATA);
-  this->updateVSSTreeValidator  = new MessageValidator(VSS_JSON::SCHEMA_UPDATE_VSS_TREE);
+VSSRequestValidator::VSSRequestValidator(std::shared_ptr<ILogger> loggerUtil) : 
+  logger(loggerUtil) {
+  
+  this->getValidator            = std::make_unique<MessageValidator>( VSS_JSON::SCHEMA_GET);
+  this->setValidator            = std::make_unique<MessageValidator>( VSS_JSON::SCHEMA_SET);
+  this->updateMetadataValidator = std::make_unique<MessageValidator>( VSS_JSON::SCHEMA_UPDATE_METADATA);
+  this->updateVSSTreeValidator  = std::make_unique<MessageValidator>( VSS_JSON::SCHEMA_UPDATE_VSS_TREE);
 }
 
 VSSRequestValidator::~VSSRequestValidator() {  
-    delete getValidator;
-    delete setValidator;
-    delete updateMetadataValidator;
-    delete updateVSSTreeValidator;
 }
 
 void VSSRequestValidator::validateGet(jsoncons::json& request) {

--- a/src/VssCommandProcessor.cpp
+++ b/src/VssCommandProcessor.cpp
@@ -173,7 +173,7 @@ string VssCommandProcessor::processUpdateVSSTree(WsChannel& channel, jsoncons::j
 
   jsoncons::json answer;
   answer["action"] = "updateVSSTree";
-  answer["requestId"] = request["requestId"].as<std::string>();
+  answer.insert_or_assign("requestId", request["requestId"]);
   answer["timestamp"] = JsonResponses::getTimeStamp();
 
   std::stringstream ss;
@@ -221,11 +221,9 @@ string VssCommandProcessor::processGetMetaData(jsoncons::json &request) {
         requestValidator->tryExtractRequestId(request), "getMetaData", string("Unhandled error: ") + e.what());
   }
 
-  string requestId = request["requestId"].as_string();
   jsoncons::json result;
   result["action"] = "getMetaData";
-  result["requestId"] = requestId;
-
+  result.insert_or_assign("requestId", request["requestId"]);
   jsoncons::json st = database->getMetaData(path);
   result["timestamp"] = JsonResponses::getTimeStamp();
   if (0 == st.size()){
@@ -266,8 +264,7 @@ string VssCommandProcessor::processUpdateMetaData(WsChannel& channel, jsoncons::
 
   jsoncons::json answer;
   answer["action"] = "updateMetaData";
-  string requestId = request["requestId"].as_string();
-  answer["requestId"] = requestId;
+  answer.insert_or_assign("requestId", request["requestId"]);
   answer["timestamp"] = JsonResponses::getTimeStamp();
 
   std::stringstream ss;
@@ -287,10 +284,10 @@ string VssCommandProcessor::processUpdateMetaData(WsChannel& channel, jsoncons::
     return ss.str();
   } catch (noPermissionException &nopermission) {
     logger->Log(LogLevel::ERROR, string(nopermission.what()));
-    return JsonResponses::noAccess(requestId, "updateMetaData", nopermission.what());
+    return JsonResponses::noAccess(request["requestId"].as<string>(), "updateMetaData", nopermission.what());
   } catch (std::exception &e) {
     logger->Log(LogLevel::ERROR, "Unhandled error: " + string(e.what()));
-    return JsonResponses::malFormedRequest(requestId, "get", string("Unhandled error: ") + e.what());
+    return JsonResponses::malFormedRequest(request["requestId"].as<string>(), "get", string("Unhandled error: ") + e.what());
   } 
 
   ss << pretty_print(answer);

--- a/src/VssCommandProcessor.cpp
+++ b/src/VssCommandProcessor.cpp
@@ -250,7 +250,7 @@ string VssCommandProcessor::processUpdateMetaData(WsChannel& channel, jsoncons::
   VSSPath path=VSSPath::fromVSS(request["path"].as_string());
 
   try {
-    requestValidator->validateUpdateTree(request);
+    requestValidator->validateUpdateMetadata(request);
   } catch (jsoncons::jsonschema::schema_error & e) {
     std::string msg=std::string(e.what());
     boost::algorithm::trim(msg);

--- a/src/VssCommandProcessor.cpp
+++ b/src/VssCommandProcessor.cpp
@@ -155,17 +155,30 @@ string VssCommandProcessor::processUnsubscribe(const string & request_id,
   }
 }
 
-string VssCommandProcessor::processUpdateVSSTree(WsChannel& channel, const string& request_id,  jsoncons::json& metaData){
+string VssCommandProcessor::processUpdateVSSTree(WsChannel& channel, jsoncons::json &request){
   logger->Log(LogLevel::VERBOSE, "VssCommandProcessor::processUpdateVSSTree");
   
+  try {
+    requestValidator->validateUpdateVSSTree(request);
+  } catch (jsoncons::jsonschema::schema_error &e) {
+    std::string msg=std::string(e.what());
+    boost::algorithm::trim(msg);
+    logger->Log(LogLevel::ERROR, msg);
+    return JsonResponses::malFormedRequest( requestValidator->tryExtractRequestId(request), "updateVSSTree", string("Schema error: ") + msg);
+  } catch (std::exception &e) {
+    logger->Log(LogLevel::ERROR, "Unhandled error: " + string(e.what()));
+    return JsonResponses::malFormedRequest(
+        requestValidator->tryExtractRequestId(request) , "updateVSSTree", string("Unhandled error: ") + e.what());
+  }
+
   jsoncons::json answer;
   answer["action"] = "updateVSSTree";
-  answer["requestId"] = request_id;
+  answer["requestId"] = request["requestId"].as<std::string>();
   answer["timestamp"] = JsonResponses::getTimeStamp();
 
   std::stringstream ss;
   try {
-    database->updateJsonTree(channel, metaData);
+    database->updateJsonTree(channel, request["metadata"]);
   } catch (genException &e) {
     logger->Log(LogLevel::ERROR, string(e.what()));
     jsoncons::json error;
@@ -180,16 +193,14 @@ string VssCommandProcessor::processUpdateVSSTree(WsChannel& channel, const strin
     return ss.str();
   } catch (noPermissionException &nopermission) {
     logger->Log(LogLevel::ERROR, string(nopermission.what()));
-    return JsonResponses::noAccess(request_id, "updateVSSTree", nopermission.what());
+    return JsonResponses::noAccess(request["requestId"].as<std::string>(), "updateVSSTree", nopermission.what());
   } catch (std::exception &e) {
     logger->Log(LogLevel::ERROR, "Unhandled error: " + string(e.what()));
-    return JsonResponses::malFormedRequest(request_id, "get", string("Unhandled error: ") + e.what());
+    return JsonResponses::malFormedRequest(request["requestId"].as<std::string>(), "get", string("Unhandled error: ") + e.what());
   }
-
 
   ss << pretty_print(answer);
   return ss.str();
-  
 }
 
 string VssCommandProcessor::processGetMetaData(jsoncons::json &request) {
@@ -446,9 +457,7 @@ string VssCommandProcessor::processQuery(const string &req_json,
            + clientID + " with secret " + clientSecret);
       response = processAuthorizeWithPermManager(channel, request_id, clientID, clientSecret);
     } else if (action == "updateVSSTree") {
-      string request_id = root["requestId"].as<string>();
-      logger->Log(LogLevel::VERBOSE, "VssCommandProcessor::processQuery: update MetaData query  for with request id " + request_id);
-      response = processUpdateVSSTree(channel, request_id, root["metadata"]);
+      response = processUpdateVSSTree(channel,root);
     } else {
       string path = root["path"].as<string>();
       string request_id = root["requestId"].as<string>();

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -40,6 +40,7 @@ if(BUILD_UNIT_TEST)
     VssDatabaseTests.cpp
     VSSPathTests.cpp
     KuksavalUnitTest.cpp
+    UpdateVSSTreeTest.cpp
   )
 
   # declares a test with our executable

--- a/test/unit-test/CMakeLists.txt
+++ b/test/unit-test/CMakeLists.txt
@@ -41,6 +41,7 @@ if(BUILD_UNIT_TEST)
     VSSPathTests.cpp
     KuksavalUnitTest.cpp
     UpdateVSSTreeTest.cpp
+    UpdateMetadataTest.cpp
   )
 
   # declares a test with our executable

--- a/test/unit-test/Gen2GetTests.cpp
+++ b/test/unit-test/Gen2GetTests.cpp
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Get_Invalid_JSON) {
       {
   "action": "get",
   "error": {
-    "message": "Schema error: VSS get malformed: #/requestId: Expected string, found uint64",
+    "message": "Schema error: #/requestId: Expected string, found uint64",
     "number": 400,
     "reason": "Bad Request"
   },
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Get_Invalid_JSON_NoRequestID) {
   {
   "action": "get",
   "error": {
-    "message": "Schema error: VSS get malformed: #: Required property \"requestId\" not found\n#/path: Expected string, found uint64",
+    "message": "Schema error: #: Required property \"requestId\" not found\n#/path: Expected string, found uint64",
     "number": 400,
     "reason": "Bad Request"
   },

--- a/test/unit-test/Gen2SetTests.cpp
+++ b/test/unit-test/Gen2SetTests.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Invalid_JSON) {
       {
   "action": "set",
   "error": {
-    "message": "Schema error: VSS set malformed: #/requestId: Expected string, found uint64",
+    "message": "Schema error: #/requestId: Expected string, found uint64",
     "number": 400,
     "reason": "Bad Request"
   },
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Invalid_JSON_NoRequestID) {
 {
   "action": "set",
   "error": {
-    "message": "Schema error: VSS set malformed: #: Required property \"requestId\" not found\n#/path: Expected string, found uint64",
+    "message": "Schema error: #: Required property \"requestId\" not found\n#/path: Expected string, found uint64",
     "number": 400,
     "reason": "Bad Request"
   },

--- a/test/unit-test/UpdateMetadataTest.cpp
+++ b/test/unit-test/UpdateMetadataTest.cpp
@@ -1,0 +1,220 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2021 Robert Bosch GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ *  Contributors:
+ *      Robert Bosch GmbH - initial API and functionality
+ * *****************************************************************************
+ */
+
+/** This are tests for VSSUpdateMetadata. No access checks */
+
+#include <boost/test/unit_test.hpp>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+#include <turtle/mock.hpp>
+#undef BOOST_BIND_GLOBAL_PLACEHOLDERS
+
+#include "UnitTestHelpers.hpp"
+
+#include <thread>
+
+#include <memory>
+#include <string>
+
+#include "IAccessCheckerMock.hpp"
+#include "IAuthenticatorMock.hpp"
+#include "ILoggerMock.hpp"
+#include "ISubscriptionHandlerMock.hpp"
+#include "WsChannel.hpp"
+
+#include "exception.hpp"
+
+#include "VSSPath.hpp"
+
+#include "JsonResponses.hpp"
+#include "VssCommandProcessor.hpp"
+#include "VssDatabase.hpp"
+
+#include "exception.hpp"
+
+namespace {
+// common resources for tests
+std::string validFilename{"test_vss_rel_2.0.json"};
+
+std::shared_ptr<ILoggerMock> logMock;
+std::shared_ptr<IAuthenticatorMock> authMock;
+std::shared_ptr<IAccessCheckerMock> accCheckMock;
+
+std::shared_ptr<ISubscriptionHandlerMock> subHandlerMock;
+
+std::shared_ptr<VssDatabase> db;
+
+std::unique_ptr<VssCommandProcessor> processor;
+
+// Pre-test initialization and post-test desctruction of common resources
+struct TestSuiteFixture {
+  TestSuiteFixture() {
+    logMock = std::make_shared<ILoggerMock>();
+    authMock = std::make_shared<IAuthenticatorMock>();
+
+    accCheckMock = std::make_shared<IAccessCheckerMock>();
+    subHandlerMock = std::make_shared<ISubscriptionHandlerMock>();
+
+    std::string vss_file{"test_vss_rel_2.0.json"};
+
+    MOCK_EXPECT(logMock->Log).at_least(0);  // ignore log events
+    db = std::make_shared<VssDatabase>(logMock, subHandlerMock);
+    db->initJsonTree(vss_file);
+
+    processor = std::make_unique<VssCommandProcessor>(
+        logMock, db, authMock, accCheckMock, subHandlerMock);
+  }
+  ~TestSuiteFixture() {
+    logMock.reset();
+    accCheckMock.reset();
+    authMock.reset();
+    subHandlerMock.reset();
+    processor.reset();
+  }
+};
+}  // namespace
+
+// Define name of test suite and define test suite fixture for pre and post test
+// handling
+BOOST_FIXTURE_TEST_SUITE(UpdateMetadataTests, TestSuiteFixture);
+
+/* Adding to VSS tree */
+BOOST_AUTO_TEST_CASE(update_metadata_change) {
+  WsChannel channel;
+  channel.setAuthorized(false);
+  channel.enableModifyTree();
+  channel.setConnID(1);
+
+  std::string updateMetadataRequestString = R"(
+    {
+        "action": "updateMetaData",
+        "requestId": "1",
+        "path": "Vehicle/Speed",
+        "metadata": {
+            "max": 9999
+        }
+    }
+  )";
+
+
+  json expectedupdateMetadataResponse = json::parse(R"(
+    {
+    "action": "updateMetaData",  
+    "requestId": "1" 
+    }
+    )");
+ 
+
+  // We need to verify metadata has been added correctly
+  std::string getMetadataRequestString{R"(
+    {
+    "action": "getMetaData",  
+    "path": "Vehicle/Speed",
+    "requestId": "1"
+    }
+    )"};
+
+  json getMetadataResponse = json::parse(R"(
+    {
+    "action": "getMetaData",
+    "metadata": {
+        "Vehicle": {
+        "children": {
+            "Speed": {
+            "datatype": "int32",
+            "description": "Vehicle speed, as sensed by the gearbox.",
+            "max": 9999,
+            "min": -250,
+            "type": "sensor",
+            "unit": "km/h",
+            "uuid": "1efc9a11943b5a15ac159786051c5836"
+            }
+        },
+        "description": "High-level vehicle data.",
+        "type": "branch",
+        "uuid": "1c72453e738511e9b29ad46a6a4b77e9"
+        }
+    },
+    "requestId": "1"
+    }
+    )");
+
+
+  // run updateVSSTree
+  auto resStr = processor->processQuery(updateMetadataRequestString, channel);
+  auto res = json::parse(resStr);
+
+  // Does result have a timestamp?
+  BOOST_TEST(res.contains("timestamp"));
+  // Assign timestamp for comparision purposes
+  expectedupdateMetadataResponse.insert_or_assign("timestamp", res["timestamp"]);
+
+  BOOST_TEST(res == expectedupdateMetadataResponse);
+
+
+  // verify metadata
+  resStr = processor->processQuery(getMetadataRequestString, channel);
+  res = json::parse(resStr);
+
+  // Does result have a timestamp?
+  BOOST_TEST(res.contains("timestamp"));
+  // Assign timestamp for comparision purposes
+  getMetadataResponse.insert_or_assign("timestamp", res["timestamp"]);
+
+  BOOST_TEST(res == getMetadataResponse);
+  
+}
+
+BOOST_AUTO_TEST_CASE(update_metadata_brokenrequest) {
+  WsChannel channel;
+  channel.setAuthorized(false);
+  channel.enableModifyTree();
+  channel.setConnID(1);
+
+  std::string updateMetadataRequestString = R"(
+    {
+        "action": "updateMetaData",
+        "requestId": "1",
+        "path": "Vehicle/Speed",
+        "metadata": 42
+    })";
+
+
+  json expectedupdateMetadataResponse = json::parse(R"(
+  {
+  "action": "updateMetaData",
+  "error": {
+    "message": "Schema error: #/metadata: Expected object, found uint64",
+    "number": 400,
+    "reason": "Bad Request"
+  },
+  "requestId": "1"
+  }
+  )");
+ 
+
+
+  // run updateVSSTree
+  auto resStr = processor->processQuery(updateMetadataRequestString, channel);
+  auto res = json::parse(resStr);
+
+  // Does result have a timestamp?
+  BOOST_TEST(res.contains("timestamp"));
+  // Assign timestamp for comparision purposes
+  expectedupdateMetadataResponse.insert_or_assign("timestamp", res["timestamp"]);
+
+  BOOST_TEST(res == expectedupdateMetadataResponse);  
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit-test/UpdateVSSTreeTest.cpp
+++ b/test/unit-test/UpdateVSSTreeTest.cpp
@@ -1,0 +1,424 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2021 Robert Bosch GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ *  Contributors:
+ *      Robert Bosch GmbH - initial API and functionality
+ * *****************************************************************************
+ */
+
+/** This are tests for VSSUpdateTree. No access checks */
+
+#include <boost/test/unit_test.hpp>
+#define BOOST_BIND_GLOBAL_PLACEHOLDERS
+#include <turtle/mock.hpp>
+#undef BOOST_BIND_GLOBAL_PLACEHOLDERS
+
+#include "UnitTestHelpers.hpp"
+
+#include <thread>
+
+#include <memory>
+#include <string>
+
+#include "IAccessCheckerMock.hpp"
+#include "IAuthenticatorMock.hpp"
+#include "ILoggerMock.hpp"
+#include "ISubscriptionHandlerMock.hpp"
+#include "WsChannel.hpp"
+
+#include "exception.hpp"
+
+#include "VSSPath.hpp"
+
+#include "JsonResponses.hpp"
+#include "VssCommandProcessor.hpp"
+#include "VssDatabase.hpp"
+
+#include "exception.hpp"
+
+namespace {
+// common resources for tests
+std::string validFilename{"test_vss_rel_2.0.json"};
+
+std::shared_ptr<ILoggerMock> logMock;
+std::shared_ptr<IAuthenticatorMock> authMock;
+std::shared_ptr<IAccessCheckerMock> accCheckMock;
+
+std::shared_ptr<ISubscriptionHandlerMock> subHandlerMock;
+
+std::shared_ptr<VssDatabase> db;
+
+std::unique_ptr<VssCommandProcessor> processor;
+
+// Pre-test initialization and post-test desctruction of common resources
+struct TestSuiteFixture {
+  TestSuiteFixture() {
+    logMock = std::make_shared<ILoggerMock>();
+    authMock = std::make_shared<IAuthenticatorMock>();
+
+    accCheckMock = std::make_shared<IAccessCheckerMock>();
+    subHandlerMock = std::make_shared<ISubscriptionHandlerMock>();
+
+    std::string vss_file{"test_vss_rel_2.0.json"};
+
+    MOCK_EXPECT(logMock->Log).at_least(0);  // ignore log events
+    db = std::make_shared<VssDatabase>(logMock, subHandlerMock);
+    db->initJsonTree(vss_file);
+
+    processor = std::make_unique<VssCommandProcessor>(
+        logMock, db, authMock, accCheckMock, subHandlerMock);
+  }
+  ~TestSuiteFixture() {
+    logMock.reset();
+    accCheckMock.reset();
+    authMock.reset();
+    subHandlerMock.reset();
+    processor.reset();
+  }
+};
+}  // namespace
+
+// Define name of test suite and define test suite fixture for pre and post test
+// handling
+BOOST_FIXTURE_TEST_SUITE(UpdateVSSTreeTests, TestSuiteFixture);
+
+/* Adding to VSS tree */
+BOOST_AUTO_TEST_CASE(update_vss_tree_add) {
+  WsChannel channel;
+  channel.setAuthorized(false);
+  channel.enableModifyTree();
+  channel.setConnID(1);
+
+  json metatdata = json::parse(R"(
+    {
+    "Vehicle": {
+        "type": "branch",
+        "uuid": "ccc825f94139544dbb5f4bfd033bece6",
+        "children": {
+        "Private": {
+            "type": "branch",
+            "uuid": "4161866b048a5b76aa3124dec82e0260",
+            "children": {
+            "ThrustersActive": {
+                "datatype": "boolean",
+                "type": "sensor",
+                "uuid": "304b0817a2df524fa442c6a2d2742ed0"
+            }
+            }
+        }
+        }
+    }
+    }
+  )");
+
+  jsoncons::json updateRequest;
+  updateRequest["action"] = "updateVSSTree";
+  updateRequest["metadata"] = metatdata;
+  updateRequest["requestId"] = "1";
+
+  std::string expectedupdateVSSTreeAnswerString{R"(
+    {
+    "action": "updateVSSTree",  
+    "requestId": "1" 
+    }
+    )"};
+  jsoncons::json expectedupdateVSSTreeAnswer =
+      jsoncons::json::parse(expectedupdateVSSTreeAnswerString);
+
+  // We need to verify metadata has been added correctly
+  std::string getMetadataRequestString{R"(
+    {
+    "action": "getMetaData",  
+    "path": "Vehicle.Private",
+    "requestId": "1"
+    }
+    )"};
+
+  std::string getMetadataResponseString{R"(
+    {
+    "action": "getMetaData",
+    "metadata": {
+        "Vehicle": {
+        "children": {
+            "Private": {
+            "children": {
+                "ThrustersActive": {
+                "datatype": "boolean",
+                "type": "sensor",
+                "uuid": "304b0817a2df524fa442c6a2d2742ed0"
+                }
+            },
+            "description": "Uncontrolled branch where non-public signals can be defined.",
+            "type": "branch",
+            "uuid": "4161866b048a5b76aa3124dec82e0260"
+            }
+        },
+        "description": "High-level vehicle data.",
+        "type": "branch",
+        "uuid": "ccc825f94139544dbb5f4bfd033bece6"
+        }
+    },
+    "requestId": "1"
+    }
+    )"};
+  jsoncons::json getMetadataResponse =
+      jsoncons::json::parse(getMetadataResponseString);
+
+  // run updateVSSTree
+  auto resStr = processor->processQuery(updateRequest.as_string(), channel);
+  auto res = json::parse(resStr);
+
+  // Does result have a timestamp?
+  BOOST_TEST(res.contains("timestamp"));
+  // Assign timestamp for comparision purposes
+  expectedupdateVSSTreeAnswer.insert_or_assign("timestamp", res["timestamp"]);
+
+  BOOST_TEST(res == expectedupdateVSSTreeAnswer);
+
+  // verify metadata
+  resStr = processor->processQuery(getMetadataRequestString, channel);
+  res = json::parse(resStr);
+
+  // Does result have a timestamp?
+  BOOST_TEST(res.contains("timestamp"));
+  // Assign timestamp for comparision purposes
+  getMetadataResponse.insert_or_assign("timestamp", res["timestamp"]);
+
+  BOOST_TEST(res == getMetadataResponse);
+}
+
+/* Check whether a default is applied */
+BOOST_AUTO_TEST_CASE(update_vss_tree_apply_default) {
+  WsChannel channel;
+  channel.setAuthorized(false);
+  channel.enableModifyTree();
+  channel.setConnID(1);
+
+  json metatdata = json::parse(R"(
+    {
+    "Vehicle": {
+        "type": "branch",
+        "uuid": "ccc825f94139544dbb5f4bfd033bece6",
+        "children": {
+        "Private": {
+            "type": "branch",
+            "uuid": "4161866b048a5b76aa3124dec82e0260",
+            "children": {
+            "TestAttribute": {
+                "datatype": "uint16",
+                "default": "100",
+                "type": "attribute",
+                "uuid": "0185"
+            }
+            }
+        }
+        }
+    }
+    }
+  )");
+
+  jsoncons::json updateRequest;
+  updateRequest["action"] = "updateVSSTree";
+  updateRequest["metadata"] = metatdata;
+  updateRequest["requestId"] = "1";
+
+  std::string expectedupdateVSSTreeAnswerString{R"(
+    {
+    "action": "updateVSSTree",  
+    "requestId": "1" 
+    }
+    )"};
+  jsoncons::json expectedupdateVSSTreeAnswer =
+      jsoncons::json::parse(expectedupdateVSSTreeAnswerString);
+
+  // Verify default is applied as value
+  std::string getValueString{R"(
+    {
+    "action": "get",  
+    "path": "Vehicle.Private.TestAttribute",
+    "requestId": "1"
+    }
+    )"};
+
+  // Read access has been checked
+  MOCK_EXPECT(accCheckMock->checkReadAccess)
+      .once()
+      .with(mock::any, VSSPath::fromVSS("Vehicle/Private/TestAttribute"))
+      .returns(true);
+
+  std::string getValueResponseString{R"(
+    {
+    "action": "get",
+    "path": "Vehicle.Private.TestAttribute",
+    "requestId": "1",
+    "value": "100"
+    }
+    )"};
+  jsoncons::json getValueResponse =
+      jsoncons::json::parse(getValueResponseString);
+
+  // run updateVSSTree
+  auto resStr = processor->processQuery(updateRequest.as_string(), channel);
+  auto res = json::parse(resStr);
+
+  // Does result have a timestamp?
+  BOOST_TEST(res.contains("timestamp"));
+  // Assign timestamp for comparision purposes
+  expectedupdateVSSTreeAnswer.insert_or_assign("timestamp", res["timestamp"]);
+
+  BOOST_TEST(res == expectedupdateVSSTreeAnswer);
+
+  // verify metadata
+  resStr = processor->processQuery(getValueString, channel);
+  res = json::parse(resStr);
+
+  // Does result have a timestamp?
+  BOOST_TEST(res.contains("timestamp"));
+  // Assign timestamp for comparision purposes
+  getValueResponse.insert_or_assign("timestamp", res["timestamp"]);
+
+  BOOST_TEST(res == getValueResponse);
+}
+
+/* Override existing metadata in tree */
+BOOST_AUTO_TEST_CASE(update_vss_tree_override) {
+  WsChannel channel;
+  channel.setAuthorized(false);
+  channel.enableModifyTree();
+  channel.setConnID(1);
+
+  json metatdata = json::parse(R"(
+    {
+    "Vehicle": {
+        "type": "branch",
+        "uuid": "ccc825f94139544dbb5f4bfd033bece6",
+        "children": {
+        "Speed": {
+            "max": 9100
+        }
+        }
+    }
+    }
+  )");
+
+  jsoncons::json updateRequest;
+  updateRequest["action"] = "updateVSSTree";
+  updateRequest["metadata"] = metatdata;
+  updateRequest["requestId"] = "1";
+
+  std::string expectedupdateVSSTreeAnswerString{R"(
+    {
+    "action": "updateVSSTree",  
+    "requestId": "1" 
+    }
+    )"};
+  jsoncons::json expectedupdateVSSTreeAnswer =
+      jsoncons::json::parse(expectedupdateVSSTreeAnswerString);
+
+  // We need to verify metadata has been added correctly
+  std::string getMetadataRequestString{R"(
+    {
+    "action": "getMetaData",  
+    "path": "Vehicle.Speed",
+    "requestId": "1"
+    }
+    )"};
+
+  std::string getMetadataResponseString{R"(
+    {
+    "action": "getMetaData",
+    "metadata": {
+        "Vehicle": {
+        "children": {
+            "Speed": {
+            "datatype": "int32",
+            "description": "Vehicle speed, as sensed by the gearbox.",
+            "max": 9100,
+            "min": -250,
+            "type": "sensor",
+            "unit": "km/h",
+            "uuid": "1efc9a11943b5a15ac159786051c5836"
+            }
+        },
+        "description": "High-level vehicle data.",
+        "type": "branch",
+        "uuid": "ccc825f94139544dbb5f4bfd033bece6"
+        }
+    },
+    "requestId": "1"
+    }
+    )"};
+  jsoncons::json getMetadataResponse =
+      jsoncons::json::parse(getMetadataResponseString);
+
+  // run updateVSSTree
+  auto resStr = processor->processQuery(updateRequest.as_string(), channel);
+  auto res = json::parse(resStr);
+
+  // Does result have a timestamp?
+  BOOST_TEST(res.contains("timestamp"));
+  // Assign timestamp for comparision purposes
+  expectedupdateVSSTreeAnswer.insert_or_assign("timestamp", res["timestamp"]);
+
+  BOOST_TEST(res == expectedupdateVSSTreeAnswer);
+
+  // verify metadata
+  resStr = processor->processQuery(getMetadataRequestString, channel);
+  res = json::parse(resStr);
+
+  // Does result have a timestamp?
+  BOOST_TEST(res.contains("timestamp"));
+  // Assign timestamp for comparision purposes
+  getMetadataResponse.insert_or_assign("timestamp", res["timestamp"]);
+
+  BOOST_TEST(res == getMetadataResponse);
+}
+
+/* Broken Request */
+BOOST_AUTO_TEST_CASE(update_vss_tree_brokenrequest) {
+  WsChannel channel;
+  channel.setAuthorized(false);
+  channel.enableModifyTree();
+  channel.setConnID(1);
+
+  std::string brokenUpdateVSSTreeRequest{R"(
+    {
+    "action": "updateVSSTree",  
+    "element": "this request has no metadata",
+    "requestId": "1" 
+    }
+    )"};
+
+  std::string expectedupdateVSSTreeAnswerString{R"(
+  {
+  "action": "updateVSSTree",
+  "error": {
+    "message": "Schema error: VSS get malformed: #: Required property \"metadata\" not found\n#/path.",
+    "number": 400,
+    "reason": "Bad Request"
+  },
+  "requestId": "1"
+  }
+    )"};
+  jsoncons::json expectedupdateVSSTreeAnswer =
+      jsoncons::json::parse(expectedupdateVSSTreeAnswerString);
+
+  // run updateVSSTree
+  auto resStr = processor->processQuery(brokenUpdateVSSTreeRequest, channel);
+  auto res = json::parse(resStr);
+
+  // Does result have a timestamp?
+  BOOST_TEST(res.contains("timestamp"));
+  // Assign timestamp for comparision purposes
+  expectedupdateVSSTreeAnswer.insert_or_assign("timestamp", res["timestamp"]);
+
+  BOOST_TEST(res == expectedupdateVSSTreeAnswer);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit-test/UpdateVSSTreeTest.cpp
+++ b/test/unit-test/UpdateVSSTreeTest.cpp
@@ -399,7 +399,7 @@ BOOST_AUTO_TEST_CASE(update_vss_tree_brokenrequest) {
   {
   "action": "updateVSSTree",
   "error": {
-    "message": "Schema error: VSS get malformed: #: Required property \"metadata\" not found\n#/path.",
+    "message": "Schema error: #: Required property \"metadata\" not found",
     "number": 400,
     "reason": "Bad Request"
   },


### PR DESCRIPTION
Will fix #191, adding unit tests, and some cleanup in schema validation code (less duplication)
I also added two simple tests for updateMetadata (had none so far), which slightly increases line coverage in command processor