### PR TITLE
Feature/improve error messages

### DIFF
--- a/src/SubscriptionHandler.cpp
+++ b/src/SubscriptionHandler.cpp
@@ -132,8 +132,11 @@ int SubscriptionHandler::unsubscribeAll(ConnectionId connectionID) {
 int SubscriptionHandler::updateByUUID(const string &signalUUID,
                                       const jsoncons::json &value) {
   std::stringstream ss;
+  ss << "SubscriptionHandler::updateByUUID: set value "
+     << pretty_print(value)
+     << " for UUID " << signalUUID;
   ss << pretty_print(value);
-  logger->Log(LogLevel::VERBOSE, "SubscriptionHandler::updateByUUID: new value set at path " + signalUUID + ss.str());
+  logger->Log(LogLevel::VERBOSE, ss.str());
   std::unique_lock<std::mutex> lock(accessMutex);
   auto handle = subscribeHandle.find(signalUUID);
   if (handle == subscribeHandle.end()) {
@@ -163,8 +166,10 @@ int SubscriptionHandler::updateByPath(const string &path, const json &value) {
   (void) value;
   
   std::stringstream ss;
-  ss << pretty_print(value);
-  logger->Log(LogLevel::VERBOSE, "SubscriptionHandler::updateByPath: new value set at path " + path + ss.str());
+  ss << "SubscriptionHandler::updateByPath: set value "
+     << pretty_print(value)
+     << " in path " << path;
+  logger->Log(LogLevel::VERBOSE, ss.str());
   for(auto & publisher: publishers_){
     publisher->sendPathValue(path, value);
   }

--- a/src/VssCommandGet.cpp
+++ b/src/VssCommandGet.cpp
@@ -64,7 +64,7 @@ std::string VssCommandProcessor::processGet2(WsChannel &channel,
       if (!accessValidator_->checkReadAccess(channel, vssPath)) {
         stringstream msg;
         msg << "Insufficient read access to " << pathStr;
-        logger->Log(LogLevel::ERROR, msg.str());
+        logger->Log(LogLevel::WARNING, msg.str());
         return JsonResponses::noAccess(requestId, "get", msg.str());
       } else {
         // TODO: This will add the "last"  timestamp, changing behavior from previous

--- a/src/VssCommandProcessor.cpp
+++ b/src/VssCommandProcessor.cpp
@@ -282,7 +282,7 @@ string VssCommandProcessor::processUpdateMetaData(WsChannel& channel, jsoncons::
     ss << pretty_print(answer);
     return ss.str();
   } catch (noPermissionException &nopermission) {
-    logger->Log(LogLevel::ERROR, string(nopermission.what()));
+    logger->Log(LogLevel::WARNING, string(nopermission.what()));
     return JsonResponses::noAccess(request["requestId"].as<string>(), "updateMetaData", nopermission.what());
   } catch (std::exception &e) {
     logger->Log(LogLevel::ERROR, "Unhandled error: " + string(e.what()));
@@ -388,18 +388,18 @@ string VssCommandProcessor::processQuery(const string &req_json,
         response =
             processSubscribe(channel, request_id, path);
       } else {
-        logger->Log(LogLevel::INFO, "VssCommandProcessor::processQuery: Unknown action " + action);
+        logger->Log(LogLevel::WARNING, "VssCommandProcessor::processQuery: Unknown action " + action);
         return JsonResponses::malFormedRequest("Unknown action requested");
       }
     }
   } catch (jsoncons::ser_error &e) {
-    logger->Log(LogLevel::ERROR, "JSON parse error");
+    logger->Log(LogLevel::WARNING, "JSON parse error");
     return JsonResponses::malFormedRequest(e.what());
   } catch (jsoncons::key_not_found &e) {
-    logger->Log(LogLevel::ERROR, "JSON key not found error");
+    logger->Log(LogLevel::WARNING, "JSON key not found error");
     return JsonResponses::malFormedRequest(e.what());
   } catch (jsoncons::not_an_object &e) {
-    logger->Log(LogLevel::ERROR, "JSON not an object error");
+    logger->Log(LogLevel::WARNING, "JSON not an object error");
     return JsonResponses::malFormedRequest(e.what());
   }
 

--- a/src/VssCommandSet.cpp
+++ b/src/VssCommandSet.cpp
@@ -62,11 +62,15 @@ std::string VssCommandProcessor::processSet2(WsChannel &channel,
   //(set all or none)
   for ( std::tuple<VSSPath,jsoncons::json> setTuple : setPairs) {
     if (! database->pathExists(std::get<0>(setTuple) )) {
+      stringstream msg;
+      msg << "Path " << std::get<0>(setTuple).to_string() << " does not exist";
+      logger->Log(LogLevel::VERBOSE,msg.str());
       return JsonResponses::pathNotFound(request["requestId"].as<string>(), "set", std::get<0>(setTuple).to_string());
     }
     if (! accessValidator_->checkWriteAccess(channel, std::get<0>(setTuple) )) {
       stringstream msg;
       msg << "No write access to " << std::get<0>(setTuple).to_string();
+      logger->Log(LogLevel::VERBOSE,msg.str());
       return JsonResponses::noAccess(request["requestId"].as<string>(), "set", msg.str());
     }
     if (! database->pathIsWritable(std::get<0>(setTuple))) {

--- a/src/VssCommandSet.cpp
+++ b/src/VssCommandSet.cpp
@@ -64,19 +64,19 @@ std::string VssCommandProcessor::processSet2(WsChannel &channel,
     if (! database->pathExists(std::get<0>(setTuple) )) {
       stringstream msg;
       msg << "Path " << std::get<0>(setTuple).to_string() << " does not exist";
-      logger->Log(LogLevel::VERBOSE,msg.str());
+      logger->Log(LogLevel::WARNING,msg.str());
       return JsonResponses::pathNotFound(request["requestId"].as<string>(), "set", std::get<0>(setTuple).to_string());
     }
     if (! accessValidator_->checkWriteAccess(channel, std::get<0>(setTuple) )) {
       stringstream msg;
       msg << "No write access to " << std::get<0>(setTuple).to_string();
-      logger->Log(LogLevel::VERBOSE,msg.str());
+      logger->Log(LogLevel::WARNING,msg.str());
       return JsonResponses::noAccess(request["requestId"].as<string>(), "set", msg.str());
     }
     if (! database->pathIsWritable(std::get<0>(setTuple))) {
       stringstream msg;
       msg << "Can not set " << std::get<0>(setTuple).to_string() << ". Only sensor or actor leaves can be set.";
-      logger->Log(LogLevel::VERBOSE,msg.str());
+      logger->Log(LogLevel::WARNING,msg.str());
       return JsonResponses::noAccess(request["requestId"].as<string>(), "set", msg.str());
     }
   }


### PR DESCRIPTION
This gives better (error) messages in the server log

 - fixed wording in SubscriptionHandler messages
 - emit a log when a write fails due to missing permissions or non-existant path

That should have made the failure in #211 more obvious