### PR TITLE
Transfromations and better error logging for DBC feeder

### DIFF
--- a/kuksa_feeders/dbc2val/dbc2vssmapper.py
+++ b/kuksa_feeders/dbc2val/dbc2vssmapper.py
@@ -11,12 +11,23 @@
 ########################################################################
 
 import yaml 
+import transforms.mapping
+import transforms.math
+
 
 class mapper:
 
     def __init__(self,input):
         with open(input,'r') as file:
             self.mapping = yaml.full_load(file)
+
+        self.transforms={}
+        self.transforms['fullmapping']=transforms.mapping.mapping(discard_non_matching_items=True)
+        self.transforms['partialmapping']=transforms.mapping.mapping(discard_non_matching_items=False)
+        self.transforms['math']=transforms.math.math()
+
+
+
         for key in self.mapping.keys():
             self.mapping[key]['lastupdate']=0.0
             if 'minupdatedelay' not in self.mapping[key]:
@@ -33,7 +44,18 @@ class mapper:
             self.mapping[key]['lastupdate']=time
             return True
         return False
-        #
+
+    # Check whether there are transforms defined to map DBC signal "signal" to 
+    # VSS path "target". Returns the (potentially) transformed values
+    def transform(self,signal, target, value):
+        if "transform" not in self.mapping[signal]["targets"][target].keys(): #no transform defined, return as is
+            return value
+        for transform in self.mapping[signal]["targets"][target]["transform"]:
+            if transform in self.transforms.keys():  #found a known transform and apply
+                value=self.transforms[transform].transform(self.mapping[signal]["targets"][target]["transform"][transform],value)
+            else:
+                print(f"Warning: Unknown transform {transform} for {signal}->{target}")
+        return value
 
     def __contains__(self,key):
         return key in self.mapping.keys()

--- a/kuksa_feeders/dbc2val/dbcfeeder.py
+++ b/kuksa_feeders/dbc2val/dbcfeeder.py
@@ -14,6 +14,7 @@
 import os, sys, signal
 import configparser
 import queue
+import json
 
 import dbc2vssmapper
 import dbcreader
@@ -89,7 +90,12 @@ while running:
             tv=mapping.transform(signal,target,value)
             if tv is not None: #none indicates the transform decided to not set the value
                 print("Update VSS path {} to {} based on signal {}".format(target, tv, signal))
-                kuksa.setValue(target, tv)
+                resp=json.loads(kuksa.setValue(target, tv))
+                if "error" in resp:
+                    if "message" in resp["error"]: 
+                        print("Error setting {}: {}".format(target, resp["error"]["message"]))
+                    else:
+                        print("Unknown error setting {}: {}".format(target, resp))
             pass
     except queue.Empty:
         pass

--- a/kuksa_feeders/dbc2val/dbcfeeder.py
+++ b/kuksa_feeders/dbc2val/dbcfeeder.py
@@ -85,9 +85,12 @@ signal.signal(signal.SIGTERM, terminationSignalreceived)
 while running:
     try:
         signal, value=canQueue.get(timeout=1)
-        print("Update signal {} to {}".format(signal, value))
         for target in mapping[signal]['targets']:
-            kuksa.setValue(target, value)
+            tv=mapping.transform(signal,target,value)
+            if tv is not None: #none indicates the transform decided to not set the value
+                print("Update VSS path {} to {} based on signal {}".format(target, tv, signal))
+                kuksa.setValue(target, tv)
+            pass
     except queue.Empty:
         pass
 

--- a/kuksa_feeders/dbc2val/mapping.yml
+++ b/kuksa_feeders/dbc2val/mapping.yml
@@ -1,18 +1,36 @@
-# Map OBD values to tree
-
+# Mapping Speed
 UIspeed_signed257:
   minupdatedelay: 100
   targets: 
-    - Vehicle.OBD.Speed
+    Vehicle.Speed: {}
+    Vehicle.OBD.Speed: {}
 
 
-#RearPower266:
-#  minupdatedelay: 100
-#  targets:
-#    - Vehicle.OBD.EngineLoad
+#this is kW, do some magic to get in 0-100 int range
+RearPower266:
+  minupdatedelay: 100
+  targets:
+    Vehicle.OBD.EngineLoad:
+      transform:
+        math: "floor(abs(x/5))"
 
-#Change this to type string in VSS file to work with M3 DBC
+#Mapping to numeriv VSS gears, and extract parking state
 DIgear118:
   minupdatedelay: 100
   targets:
-    - Vehicle.Drivetrain.Transmission.Gear
+    Vehicle.Powertrain.Transmission.Gear:
+      transform:
+        fullmapping:
+          Neutral: 0
+          Idle: 0
+          Park: 0
+          Reverse: -1
+          Drive: 1
+    Vehicle.Chassis.ParkingBrake.IsEngaged:
+      transform:
+        fullmapping:
+          Neutral: "false"
+          Idle: "false"
+          Park: "true"
+          Reverse: "false"
+          Drive: "false"

--- a/kuksa_feeders/dbc2val/requirements.txt
+++ b/kuksa_feeders/dbc2val/requirements.txt
@@ -3,4 +3,5 @@ cantools
 python-can
 pyyaml
 j1939
+py_expression_eval
 kuksa-viss-client

--- a/kuksa_feeders/dbc2val/transforms/mapping.py
+++ b/kuksa_feeders/dbc2val/transforms/mapping.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+
+########################################################################
+# Copyright (c) 2021 Robert Bosch GmbH
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+
+
+class mapping:
+
+    # setting discard_non_matching_items to true will return "None" if a value
+    # is not found in the mapping table. This can be used to only add
+    # a subset of possible values to VSS
+    # setting discard_non_matching_items to false will return values for
+    # which no match exists unmodified
+    def __init__(self, discard_non_matching_items):
+        self.discard_non_matching_items=discard_non_matching_items
+
+    def transform(self, spec, value):
+        for k,v in spec.items():
+            if value==k:
+                return v
+        #no match
+        if self.discard_non_matching_items:
+            return None
+        else:
+            return value

--- a/kuksa_feeders/dbc2val/transforms/math.py
+++ b/kuksa_feeders/dbc2val/transforms/math.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python3
+
+########################################################################
+# Copyright (c) 2021 Robert Bosch GmbH
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+########################################################################
+
+from py_expression_eval import Parser
+
+class math:
+
+    def __init__(self):
+        self.parser=Parser()
+        
+    def transform(self, spec, value):
+        return self.parser.parse(spec).evaluate({'x': value})
+        


### PR DESCRIPTION
 - Adds the abilty to transform data (mapping or math formula) to dbc feeder, allowing more flexible mapping. See updated `mapping.yml` for examples
 - Will print error messages from kuksa.val server

Should have made detecting #211 much easier @anntexx 

Sidenote: The feeder/kuksa_viss _client is immensely slow for me.  I think some blocking problem, but that is a topic for another ticket :)

Can't add you as a reviewer @anntexx , but if can test whether DBC feeder works at least as good for you as before, would be nice 