### PR TITLE
Subscriptions Fixes 1

### DIFF
--- a/include/JsonResponses.hpp
+++ b/include/JsonResponses.hpp
@@ -28,10 +28,10 @@ namespace JsonResponses {
                         std::string message,
                         jsoncons::json& jsonResponse);
 
-  std::string malFormedRequest(std::string message);
+  std::string malFormedRequest(std::string message, std::string requestId="UNKNOWN");
   
   void malFormedRequest(std::string message,
-                        jsoncons::json& jsonResponse);
+                        jsoncons::json& jsonResponse, std::string requesId="UNKNOWN");
 
   /** A API call requested a non-existant path */
   std::string pathNotFound(std::string request_id,

--- a/include/VSSRequestJsonSchema.hpp
+++ b/include/VSSRequestJsonSchema.hpp
@@ -70,6 +70,54 @@ static const char* SCHEMA_SET=R"(
 }
 )";
 
+
+static const char* SCHEMA_SUBSCRIBE=R"(
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Subscribe Request",
+    "description": "Allows the client to subscribe to time-varying signal notifications on the server.",
+    "type": "object",
+    "required": ["action", "path", "requestId"],
+    "properties": {
+        "action": {
+            "enum": [ "subscribe" ],
+            "description": "The identifier for the subscription request"
+        },
+        "path": {
+            "$ref": "viss#/definitions/path"
+        },
+        "filters": {
+            "$ref": "viss#/definitions/filters"
+        },
+        "requestId": {
+            "$ref": "viss#/definitions/requestId"
+        }
+    }
+}
+)";
+
+static const char* SCHEMA_UNSUBSCRIBE=R"(
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Unsubscribe Request",
+    "description": "Allows the client to unsubscribe to time-varying signal notifications on the server.",
+    "type": "object",
+    "required": ["action", "subscriptionId", "requestId"],
+    "properties": {
+        "action": {
+            "enum": [ "unsubscribe" ],
+            "description": "The identifier for the unsubscribe request"
+        },
+        "subscriptionId": {
+            "$ref": "viss#/definitions/subscriptionId"
+        }, 
+        "requestId": {
+            "$ref": "viss#/definitions/requestId"
+        }
+    }
+}
+)";
+
 static const char* SCHEMA_UPDATE_VSS_TREE=R"(
 {
     "$schema": "http://json-schema.org/draft-04/schema#",

--- a/include/VSSRequestValidator.hpp
+++ b/include/VSSRequestValidator.hpp
@@ -36,6 +36,9 @@ class VSSRequestValidator {
 
         void validateGet(jsoncons::json &request);
         void validateSet(jsoncons::json &request);
+        void validateSubscribe(jsoncons::json &request);
+        void validateUnsubscribe(jsoncons::json &request);
+
         void validateUpdateMetadata(jsoncons::json &request);
         void validateUpdateVSSTree(jsoncons::json &request);
 
@@ -45,6 +48,8 @@ class VSSRequestValidator {
         class MessageValidator;
         std::unique_ptr<VSSRequestValidator::MessageValidator> getValidator;
         std::unique_ptr<VSSRequestValidator::MessageValidator> setValidator;
+        std::unique_ptr<VSSRequestValidator::MessageValidator> subscribeValidator;
+        std::unique_ptr<VSSRequestValidator::MessageValidator> unsubscribeValidator;
         std::unique_ptr<VSSRequestValidator::MessageValidator> updateMetadataValidator;
         std::unique_ptr<VSSRequestValidator::MessageValidator> updateVSSTreeValidator;
 

--- a/include/VssCommandProcessor.hpp
+++ b/include/VssCommandProcessor.hpp
@@ -47,13 +47,14 @@ class VssCommandProcessor : public IVssCommandProcessor {
   std::string processUpdateVSSTree(kuksa::kuksaChannel& channel, jsoncons::json &request);
 
  public:
-  std::string processSubscribe(kuksa::kuksaChannel& channel, const std::string& request_id, const std::string& path);
-  std::string processUnsubscribe(const std::string & request_id, uint32_t subscribeID);
   std::string processGetMetaData(jsoncons::json &request);
   std::string processAuthorize(kuksa::kuksaChannel& channel, const std::string & request_id,
                           const std::string & token);
   std::string processGet2(kuksa::kuksaChannel &channel, jsoncons::json &request);
   std::string processSet2(kuksa::kuksaChannel &channel, jsoncons::json &request);
+  std::string processSubscribe(kuksa::kuksaChannel& channel, jsoncons::json &request);
+  std::string processUnsubscribe(kuksa::kuksaChannel &channel, jsoncons::json &request);
+  
   VssCommandProcessor(std::shared_ptr<ILogger> loggerUtil,
                       std::shared_ptr<IVssDatabase> database,
                       std::shared_ptr<IAuthenticator> vdator,

--- a/src/JsonResponses.cpp
+++ b/src/JsonResponses.cpp
@@ -24,7 +24,7 @@ namespace JsonResponses {
     jsonResponse["action"] = action;
     jsonResponse["requestId"] = request_id;
     jsoncons::json error;
-    error["number"] = 400;
+    error["number"] = "400";
     error["reason"] = "Bad Request";
     error["message"] = message;
     jsonResponse["error"] = error;
@@ -44,7 +44,7 @@ namespace JsonResponses {
   void malFormedRequest(std::string message, jsoncons::json& jsonResponse, std::string requestId) {
     jsoncons::json error;
 
-    error["number"] = 400;
+    error["number"] = "400";
     error["reason"] = "Bad Request";
     error["message"] = message;
     jsonResponse["error"] = error;
@@ -68,7 +68,7 @@ namespace JsonResponses {
     jsonResponse["action"] = action;
     jsonResponse["requestId"] = request_id;
     jsoncons::json error;
-    error["number"] = 404;
+    error["number"] = "404";
     error["reason"] = "Path not found";
     error["message"] = "I can not find " + path + " in my db";
     jsonResponse["error"] = error;
@@ -92,7 +92,7 @@ namespace JsonResponses {
     jsoncons::json error;
     jsonResponse["action"] = action;
     jsonResponse["requestId"] = request_id;
-    error["number"] = 403;
+    error["number"] = "403";
     error["reason"] = "Forbidden";
     error["message"] = message;
     jsonResponse["error"] = error;
@@ -116,7 +116,7 @@ namespace JsonResponses {
     jsonResponse["action"] = action;
     jsonResponse["requestId"] = request_id;
     jsoncons::json error;
-    error["number"] = 400;
+    error["number"] = "400";
     error["reason"] = "Value passed is out of bounds";
     error["message"] = message;
     jsonResponse["error"] = error;

--- a/src/JsonResponses.cpp
+++ b/src/JsonResponses.cpp
@@ -41,18 +41,19 @@ namespace JsonResponses {
     return ss.str();
   }
 
-  void malFormedRequest(std::string message, jsoncons::json& jsonResponse) {
+  void malFormedRequest(std::string message, jsoncons::json& jsonResponse, std::string requestId) {
     jsoncons::json error;
 
     error["number"] = 400;
     error["reason"] = "Bad Request";
     error["message"] = message;
     jsonResponse["error"] = error;
+    jsonResponse["requestId"] = requestId;
     jsonResponse["ts"] = getTimeStamp();
   }
-  std::string malFormedRequest(std::string message) {
+  std::string malFormedRequest(std::string message, std::string requestId) {
     jsoncons::json answer;
-    malFormedRequest(message, answer);
+    malFormedRequest(message, answer, requestId);
 
     std::stringstream ss;
     ss << pretty_print(answer);

--- a/src/SubscriptionHandler.cpp
+++ b/src/SubscriptionHandler.cpp
@@ -155,7 +155,7 @@ int SubscriptionHandler::updateByUUID(const string &signalUUID, const json &data
   for (auto subID : handle->second) {
     std::lock_guard<std::mutex> lock(subMutex);
     tuple<SubscriptionId, ConnectionId, json> newSub;
-    logger->Log(LogLevel::VERBOSE, "SubscriptionHandler::updateByUUID: new value set at path " + std::to_string(subID.first) + ss.str());
+    logger->Log(LogLevel::VERBOSE, "SubscriptionHandler::updateByUUID: new value set at path " + std::to_string(subID.first) + ": " + ss.str());
     newSub = std::make_tuple(subID.first, subID.second, data);
     buffer.push(newSub);
     c.notify_one();

--- a/src/VSSRequestValidator.cpp
+++ b/src/VSSRequestValidator.cpp
@@ -65,6 +65,9 @@ VSSRequestValidator::VSSRequestValidator(std::shared_ptr<ILogger> loggerUtil) :
   
   this->getValidator            = std::make_unique<MessageValidator>( VSS_JSON::SCHEMA_GET);
   this->setValidator            = std::make_unique<MessageValidator>( VSS_JSON::SCHEMA_SET);
+  this->subscribeValidator      = std::make_unique<MessageValidator>( VSS_JSON::SCHEMA_SUBSCRIBE);
+  this->unsubscribeValidator    = std::make_unique<MessageValidator>( VSS_JSON::SCHEMA_UNSUBSCRIBE);
+
   this->updateMetadataValidator = std::make_unique<MessageValidator>( VSS_JSON::SCHEMA_UPDATE_METADATA);
   this->updateVSSTreeValidator  = std::make_unique<MessageValidator>( VSS_JSON::SCHEMA_UPDATE_VSS_TREE);
 }
@@ -78,6 +81,14 @@ void VSSRequestValidator::validateGet(jsoncons::json& request) {
 
 void VSSRequestValidator::validateSet(jsoncons::json& request) {
   setValidator->validate(request);
+}
+
+void VSSRequestValidator::validateSubscribe(jsoncons::json& request) {
+  subscribeValidator->validate(request);
+}
+
+void VSSRequestValidator::validateUnsubscribe(jsoncons::json& request) {
+  unsubscribeValidator->validate(request);
 }
 
 void VSSRequestValidator::validateUpdateMetadata(jsoncons::json& request) {

--- a/src/VssCommandProcessor.cpp
+++ b/src/VssCommandProcessor.cpp
@@ -56,94 +56,6 @@ VssCommandProcessor::~VssCommandProcessor() {
 }
 
 
-
-string VssCommandProcessor::processSubscribe(kuksa::kuksaChannel &channel,
-                                             const string & request_id, 
-                                             const string & path) {
-  logger->Log(LogLevel::VERBOSE, string("VssCommandProcessor::processSubscribe: Client wants to subscribe ")+path);
-
-  uint32_t subId = -1;
-  try {
-    subId = subHandler->subscribe(channel, database, path);
-  } catch (noPathFoundonTree &noPathFound) {
-    logger->Log(LogLevel::ERROR, string(noPathFound.what()));
-    return JsonResponses::pathNotFound(request_id, "subscribe", path);
-  } catch (noPermissionException &nopermission) {
-    logger->Log(LogLevel::ERROR, string(nopermission.what()));
-    return JsonResponses::noAccess(request_id, "subscribe", nopermission.what());
-  } catch (genException &outofboundExp) {
-    logger->Log(LogLevel::ERROR, string(outofboundExp.what()));
-    return JsonResponses::valueOutOfBounds(request_id, "subscribe",
-                                    outofboundExp.what());
-  } catch (std::exception &e) {
-    logger->Log(LogLevel::ERROR, "Unhandled error: " + string(e.what()));
-    return JsonResponses::malFormedRequest(request_id, "get", string("Unhandled error: ") + e.what());
-  }
-
-  if (subId > 0) {
-    jsoncons::json answer;
-    answer["action"] = "subscribe";
-    answer["requestId"] = request_id;
-    answer["subscriptionId"] = subId;
-    answer["ts"] = JsonResponses::getTimeStamp();
-
-    std::stringstream ss;
-    ss << pretty_print(answer);
-    return ss.str();
-
-  } else {
-    jsoncons::json root;
-    jsoncons::json error;
-
-    root["action"] = "subscribe";
-    root["requestId"] = request_id;
-    error["number"] = 400;
-    error["reason"] = "Bad Request";
-    error["message"] = "Unknown";
-
-    root["error"] = error;
-    root["ts"] = JsonResponses::getTimeStamp();
-
-    std::stringstream ss;
-
-    ss << pretty_print(root);
-    return ss.str();
-  }
-}
-
-string VssCommandProcessor::processUnsubscribe(const string & request_id,
-                                               uint32_t subscribeID) {
-  int res = subHandler->unsubscribe(subscribeID);
-  if (res == 0) {
-    jsoncons::json answer;
-    answer["action"] = "unsubscribe";
-    answer["requestId"] = request_id;
-    answer["subscriptionId"] = subscribeID;
-    answer["ts"] = JsonResponses::getTimeStamp();
-
-    std::stringstream ss;
-    ss << pretty_print(answer);
-    return ss.str();
-
-  } else {
-    jsoncons::json root;
-    jsoncons::json error;
-
-    root["action"] = "unsubscribe";
-    root["requestId"] = request_id;
-    error["number"] = 400;
-    error["reason"] = "Unknown error";
-    error["message"] = "Error while unsubscribing";
-
-    root["error"] = error;
-    root["ts"] = JsonResponses::getTimeStamp();
-
-    std::stringstream ss;
-    ss << pretty_print(root);
-    return ss.str();
-  }
-}
-
 string VssCommandProcessor::processUpdateVSSTree(kuksa::kuksaChannel& channel, jsoncons::json &request){
   logger->Log(LogLevel::VERBOSE, "VssCommandProcessor::processUpdateVSSTree");
   
@@ -347,28 +259,17 @@ string VssCommandProcessor::processQuery(const string &req_json,
            + token + " with request id " + request_id);
 
       response = processAuthorize(channel, request_id, token);
-    } else if (action == "unsubscribe") {
-      //string request_id = root["requestId"].as<int>();
-      string request_id = root["requestId"].as<string>();
-      uint32_t subscribeID = root["subscriptionId"].as<int>();
-      logger->Log(LogLevel::VERBOSE, "VssCommandProcessor::processQuery: unsubscribe query  for sub ID = "
-              + to_string(subscribeID) + " with request id " + request_id);
-
-      response = processUnsubscribe(request_id, subscribeID);
+    } 
+    else if (action == "unsubscribe") {
+      response = processUnsubscribe(channel, root);
+    } 
+    else if (action == "subscribe") {
+      response = processSubscribe(channel, root);
     } else if (action == "updateVSSTree") {
       response = processUpdateVSSTree(channel,root);
     } else {
-      string path = root["path"].as<string>();
-      string request_id = root["requestId"].as<string>();
-     if (action == "subscribe") {
-        logger->Log(LogLevel::VERBOSE, "VssCommandProcessor::processQuery: subscribe query  for "
-             + path + " with request id " + request_id);
-        response =
-            processSubscribe(channel, request_id, path);
-      } else {
-        logger->Log(LogLevel::WARNING, "VssCommandProcessor::processQuery: Unknown action " + action);
-        return JsonResponses::malFormedRequest("Unknown action requested");
-      }
+      logger->Log(LogLevel::WARNING, "VssCommandProcessor::processQuery: Unknown action " + action);
+      return JsonResponses::malFormedRequest("Unknown action requested", root.get_value_or<std::string>("requestId", "UNKNOWN"));
     }
   } catch (jsoncons::ser_error &e) {
     logger->Log(LogLevel::WARNING, "JSON parse error");
@@ -380,8 +281,6 @@ string VssCommandProcessor::processQuery(const string &req_json,
     logger->Log(LogLevel::WARNING, "JSON not an object error");
     return JsonResponses::malFormedRequest(e.what());
   }
-
-
   return response;
 }
 

--- a/src/VssCommandProcessor.cpp
+++ b/src/VssCommandProcessor.cpp
@@ -84,7 +84,7 @@ string VssCommandProcessor::processUpdateVSSTree(kuksa::kuksaChannel& channel, j
     logger->Log(LogLevel::ERROR, string(e.what()));
     jsoncons::json error;
 
-    error["number"] = 401;
+    error["number"] = "401";
     error["reason"] = "Unknown error";
     error["message"] = e.what();
 
@@ -129,7 +129,7 @@ string VssCommandProcessor::processGetMetaData(jsoncons::json &request) {
   result["ts"] = JsonResponses::getTimeStamp();
   if (0 == st.size()){
     jsoncons::json error;
-    error["number"] = 404;
+    error["number"] = "404";
     error["reason"] = "Path not found";
     error["message"] = "In database no metadata found for path " + path.getVSSPath();
     result["error"] = error;
@@ -175,7 +175,7 @@ string VssCommandProcessor::processUpdateMetaData(kuksa::kuksaChannel& channel, 
     logger->Log(LogLevel::ERROR, string(e.what()));
     jsoncons::json error;
 
-    error["number"] = 401;
+    error["number"] = "401";
     error["reason"] = "Unknown error";
     error["message"] = e.what();
 
@@ -206,7 +206,7 @@ string VssCommandProcessor::processAuthorize(kuksa::kuksaChannel &channel,
     jsoncons::json error;
     result["action"] = "authorize";
     result["requestId"] = request_id;
-    error["number"] = 401;
+    error["number"] = "401";
     error["reason"] = "Invalid Token";
     error["message"] = "Check the JWT token passed";
 

--- a/src/VssCommandSet.cpp
+++ b/src/VssCommandSet.cpp
@@ -94,7 +94,7 @@ std::string VssCommandProcessor::processSet2(kuksa::kuksaChannel &channel,
     root["action"] = "set";
     root.insert_or_assign("requestId", request["requestId"]);
 
-    error["number"] = 401;
+    error["number"] = "401";
     error["reason"] = "Unknown error";
     error["message"] = e.what();
 

--- a/src/VssCommandUnsubscribe.cpp
+++ b/src/VssCommandUnsubscribe.cpp
@@ -1,0 +1,76 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2022 Robert Bosch GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ *  Contributors:
+ *      Robert Bosch GmbH
+ * *****************************************************************************
+ */
+
+#include <boost/algorithm/string.hpp>
+#include "ISubscriptionHandler.hpp"
+#include "JsonResponses.hpp"
+#include "VSSRequestValidator.hpp"
+#include "VssCommandProcessor.hpp"
+#include "exception.hpp"
+
+string VssCommandProcessor::processUnsubscribe(kuksa::kuksaChannel &channel,
+                                               jsoncons::json &request) {
+  try {
+    requestValidator->validateUnsubscribe(request);
+  } catch (jsoncons::jsonschema::schema_error &e) {
+    std::string msg = std::string(e.what());
+    boost::algorithm::trim(msg);
+    logger->Log(LogLevel::ERROR, msg);
+    return JsonResponses::malFormedRequest(
+        requestValidator->tryExtractRequestId(request), "unsubscribe",
+        string("Schema error: ") + msg);
+  } catch (std::exception &e) {
+    logger->Log(LogLevel::ERROR, "Unhandled error: " + string(e.what()));
+    return JsonResponses::malFormedRequest(
+        requestValidator->tryExtractRequestId(request), "get",
+        string("Unhandled error: ") + e.what());
+  }
+
+  string request_id = request["requestId"].as<string>();
+  uint32_t subscribeID = request["subscriptionId"].as<uint32_t>();
+  logger->Log(
+      LogLevel::VERBOSE,
+      "VssCommandProcessor::processQuery: unsubscribe query  for sub ID = " +
+          to_string(subscribeID) + " with request id " + request_id);
+
+  int res = subHandler->unsubscribe(subscribeID);
+  if (res == 0) {
+    jsoncons::json answer;
+    answer["action"] = "unsubscribe";
+    answer["requestId"] = request_id;
+    answer["subscriptionId"] = std::to_string(subscribeID);
+    answer["ts"] = JsonResponses::getTimeStamp();
+
+    std::stringstream ss;
+    ss << pretty_print(answer);
+    return ss.str();
+
+  } else {
+    jsoncons::json root;
+    jsoncons::json error;
+
+    root["action"] = "unsubscribe";
+    root["requestId"] = request_id;
+    error["number"] = 400;
+    error["reason"] = "Unknown error";
+    error["message"] = "Error while unsubscribing";
+
+    root["error"] = error;
+    root["ts"] = JsonResponses::getTimeStamp();
+
+    std::stringstream ss;
+    ss << pretty_print(root);
+    return ss.str();
+  }
+}

--- a/src/VssCommandUnsubscribe.cpp
+++ b/src/VssCommandUnsubscribe.cpp
@@ -62,7 +62,7 @@ string VssCommandProcessor::processUnsubscribe(kuksa::kuksaChannel &channel,
 
     root["action"] = "unsubscribe";
     root["requestId"] = request_id;
-    error["number"] = 400;
+    error["number"] = "400";
     error["reason"] = "Unknown error";
     error["message"] = "Error while unsubscribing";
 

--- a/src/VssProcessSubscribe.cpp
+++ b/src/VssProcessSubscribe.cpp
@@ -83,7 +83,7 @@ string VssCommandProcessor::processSubscribe(kuksa::kuksaChannel &channel,
 
     root["action"] = "subscribe";
     root["requestId"] = request_id;
-    error["number"] = 400;
+    error["number"] = "400";
     error["reason"] = "Bad Request";
     error["message"] = "Unknown";
 

--- a/src/VssProcessSubscribe.cpp
+++ b/src/VssProcessSubscribe.cpp
@@ -1,0 +1,98 @@
+/*
+ * ******************************************************************************
+ * Copyright (c) 2022 Robert Bosch GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ *  Contributors:
+ *      Robert Bosch GmbH
+ * *****************************************************************************
+ */
+
+#include <boost/algorithm/string.hpp>
+#include "ISubscriptionHandler.hpp"
+#include "JsonResponses.hpp"
+#include "VSSRequestValidator.hpp"
+#include "VssCommandProcessor.hpp"
+#include "exception.hpp"
+
+string VssCommandProcessor::processSubscribe(kuksa::kuksaChannel &channel,
+                                             jsoncons::json &request) {
+  try {
+    requestValidator->validateSubscribe(request);
+  } catch (jsoncons::jsonschema::schema_error &e) {
+    std::string msg = std::string(e.what());
+    boost::algorithm::trim(msg);
+    logger->Log(LogLevel::ERROR, msg);
+    return JsonResponses::malFormedRequest(
+        requestValidator->tryExtractRequestId(request), "subscribe",
+        string("Schema error: ") + msg);
+  } catch (std::exception &e) {
+    logger->Log(LogLevel::ERROR, "Unhandled error: " + string(e.what()));
+    return JsonResponses::malFormedRequest(
+        requestValidator->tryExtractRequestId(request), "get",
+        string("Unhandled error: ") + e.what());
+  }
+
+  string path = request["path"].as<string>();
+  string request_id = request["requestId"].as<string>();
+
+  logger->Log(
+      LogLevel::VERBOSE,
+      string(
+          "VssCommandProcessor::processSubscribe: Client wants to subscribe ") +
+          path);
+
+  uint32_t subId = -1;
+  try {
+    subId = subHandler->subscribe(channel, database, path);
+  } catch (noPathFoundonTree &noPathFound) {
+    logger->Log(LogLevel::ERROR, string(noPathFound.what()));
+    return JsonResponses::pathNotFound(request_id, "subscribe", path);
+  } catch (noPermissionException &nopermission) {
+    logger->Log(LogLevel::ERROR, string(nopermission.what()));
+    return JsonResponses::noAccess(request_id, "subscribe",
+                                   nopermission.what());
+  } catch (genException &outofboundExp) {
+    logger->Log(LogLevel::ERROR, string(outofboundExp.what()));
+    return JsonResponses::valueOutOfBounds(request_id, "subscribe",
+                                           outofboundExp.what());
+  } catch (std::exception &e) {
+    logger->Log(LogLevel::ERROR, "Unhandled error: " + string(e.what()));
+    return JsonResponses::malFormedRequest(
+        request_id, "get", string("Unhandled error: ") + e.what());
+  }
+
+  if (subId > 0) {
+    jsoncons::json answer;
+    answer["action"] = "subscribe";
+    answer["requestId"] = request_id;
+    answer["subscriptionId"] = std::to_string(subId);
+    answer["ts"] = JsonResponses::getTimeStamp();
+
+    std::stringstream ss;
+    ss << pretty_print(answer);
+    return ss.str();
+
+  } else {
+    jsoncons::json root;
+    jsoncons::json error;
+
+    root["action"] = "subscribe";
+    root["requestId"] = request_id;
+    error["number"] = 400;
+    error["reason"] = "Bad Request";
+    error["message"] = "Unknown";
+
+    root["error"] = error;
+    root["ts"] = JsonResponses::getTimeStamp();
+
+    std::stringstream ss;
+
+    ss << pretty_print(root);
+    return ss.str();
+  }
+}

--- a/test/unit-test/Gen2GetTests.cpp
+++ b/test/unit-test/Gen2GetTests.cpp
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Get_Invalid_JSON) {
       "action": "get",
       "error": {
         "message": "Schema error: #/requestId: Expected string, found uint64",
-        "number": 400,
+        "number": "400",
         "reason": "Bad Request"
       },
       "requestId": "100"
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Get_Invalid_JSON_NoRequestID) {
       "action": "get",
       "error": {
         "message": "Schema error: #: Required property \"requestId\" not found\n#/path: Expected string, found uint64",
-        "number": 400,
+        "number": "400",
         "reason": "Bad Request"
       },
       "requestId": "UNKNOWN"

--- a/test/unit-test/Gen2SetTests.cpp
+++ b/test/unit-test/Gen2SetTests.cpp
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Invalid_JSON) {
     "action": "set",
     "error": {
       "message": "Schema error: #/requestId: Expected string, found uint64",
-      "number": 400,
+      "number": "400",
       "reason": "Bad Request"
     },
     "requestId": "100"
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Invalid_JSON_NoRequestID) {
   "action": "set",
   "error": {
     "message": "Schema error: #: Required property \"requestId\" not found\n#/path: Expected string, found uint64",
-    "number": 400,
+    "number": "400",
     "reason": "Bad Request"
   },
   "requestId": "UNKNOWN"
@@ -278,7 +278,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Non_Existing_Path) {
   "action": "set",
   "error": {
     "message": "I can not find Vehicle/Fluxcapacitor/Charge in my db",
-    "number": 404,
+    "number": "404",
     "reason": "Path not found"
   },
   "requestId": "1"
@@ -327,7 +327,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Branch) {
   "action": "set",
   "error": {
     "message": "Can not set Vehicle/VehicleIdentification. Only sensor or actor leaves can be set.",
-    "number": 403,
+    "number": "403",
     "reason": "Forbidden"
   },
   "requestId": "1"
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(Gen2_Set_Attribute) {
   "action": "set",
   "error": {
     "message": "Can not set Vehicle/VehicleIdentification/Brand. Only sensor or actor leaves can be set.",
-    "number": 403,
+    "number": "403",
     "reason": "Forbidden"
   },
   "requestId": "1"

--- a/test/unit-test/KuksavalUnitTest.cpp
+++ b/test/unit-test/KuksavalUnitTest.cpp
@@ -1187,7 +1187,7 @@ BOOST_AUTO_TEST_CASE(process_query_get_withwildcard_invalid)
 
    json expected = json::parse(R"({
                          "action":"get",
-                         "error":{"message":"I can not find Signal.*.RPM1 in my db","number":404,"reason":"Path not found"},
+                         "error":{"message":"I can not find Signal.*.RPM1 in my db","number":"404","reason":"Path not found"},
                          "requestId":"8756"
                          })");
 
@@ -1197,152 +1197,6 @@ BOOST_AUTO_TEST_CASE(process_query_get_withwildcard_invalid)
 
    BOOST_TEST(response_json == expected);
 }
-
-/* Multiset not supported, will reappear with Gen2  support */
-/*
-BOOST_AUTO_TEST_CASE(process_query_set_withwildcard_invalid)
-{
-   WsChannel channel;
-   channel.setConnID(1234);
-   string authReq(R"({
-		"action": "authorize",
-		"requestId": "87568"
-	})");
-   json authReqJson = json::parse(authReq);
-   authReqJson["tokens"] = AUTH_JWT;
-   commandProc->processQuery(authReqJson.as_string(),channel);
-   string request(R"({
-		"action": "set",
-		"path": "Signal.OBD.*",
-                "value" : [{"RPM1" : 345} , {"Speed1" : 546}],
-		"requestId": "8756"
-	})");
-
-   string response = commandProc->processQuery(request,channel);
-
-   json expected = json::parse(R"({
-                              "action":"set",
-                              "error":{"message":"I can not find Signal.OBD.* in my db","number":404,"reason":"Path not found"},
-                              "requestId":"8756"
-                              })");
-
-   json response_json = json::parse(response);
-
-
-   BOOST_TEST(response_json.contains("ts") == true);
-
-   // remove timestamp to match
-   response_json.erase("ts");
-   BOOST_TEST(response_json == expected);
-}
-*/
-
-///HERE
-/* Multiset not supported, will reappear with Gen2  support */
-/*
-BOOST_AUTO_TEST_CASE(process_query_set_invalid_value)
-{
-   WsChannel channel;
-   channel.setConnID(1234);
-   string authReq(R"({
-		"action": "authorize",
-		"requestId": "87568"
-	})");
-   json authReqJson = json::parse(authReq);
-   authReqJson["tokens"] = AUTH_JWT;
-   commandProc->processQuery(authReqJson.as_string(),channel);
-   string request(R"({
-		"action": "set",
-		"path": "Vehicle.OBD.*",
-                "value" : [{"ThrottlePosition" : 34563843034034845945054}],
-		"requestId": "8756"
-	})");
-
-   string response = commandProc->processQuery(request,channel);
-
-   json expected = json::parse(R"({
-                               "action":"set",
-                               "error":{"message":"The type uint8 with value 3.45638e+22 is out of bound","number":400,"reason":"Value passed is out of bounds"},
-                               "requestId":"8756"
-                               })");
-
-   json response_json = json::parse(response);
-
-
-   BOOST_TEST(response_json.contains("ts") == true);
-
-   // remove timestamp to match
-   response_json.erase("ts");
-   BOOST_TEST(response_json == expected);
-}
-*/
-
-/* Multiset currently not supported, will come in Gen2 compliant way in the future */
-/*
-BOOST_AUTO_TEST_CASE(process_query_set_one_valid_one_invalid_value)
-{
-   WsChannel channel;
-   channel.setConnID(1234);
-   string authReq(R"({
-		"action": "authorize",
-		"requestId": "87568"
-	})");
-   json authReqJson = json::parse(authReq);
-   authReqJson["tokens"] = AUTH_JWT;
-   commandProc->processQuery(authReqJson.as_string(),channel);
-
-   string request(R"({
-		"action": "set",
-		"path": "Vehicle.OBD.*",
-                "value" : [{"ThrottlePosition" : 34563843034034845945054},{"EngineSpeed" : 1000}],
-		"requestId": "8756"
-	})");
-
-   string response = commandProc->processQuery(request,channel);
-
-   json expected = json::parse(R"({
-                               "action":"set",
-                               "error":{"message":"The type uint8 with value 3.45638e+22 is out of bound","number":400,"reason":"Value passed is out of bounds"},
-                               "requestId":"8756"
-                               })");
-
-   json response_json = json::parse(response);
-
-
-   BOOST_TEST(response_json.contains("ts") == true);
-
-   // remove timestamp to match
-   response_json.erase("ts");
-   BOOST_TEST(response_json == expected);
-
-
-   string request_getvalid(R"({
-		"action": "get",
-		"path": "Vehicle.*.EngineSpeed",
-		"requestId": "8756"
-	})");
-
-   string response_getvalid = commandProc->processQuery(request_getvalid,channel);
-
-   // This shows that the value from the previous test is not set because of out of bound exception for the ThrottlePosition value, Therefore the RPM was not set despite being   valid. if you swap the order in which the signals are set in above test case then the value here would be 1000.
-   json expected_getvalid = json::parse(R"({
-    "action": "get",
-    "path": "Vehicle.OBD.EngineSpeed",
-    "requestId": "8756",
-    "value": 2345
-    })");
-
-
-   json response_response_getvalid_json = json::parse(response_getvalid);
-
-
-   BOOST_TEST(response_response_getvalid_json.contains("ts") == true);
-
-   // remove timestamp to match
-   response_response_getvalid_json.erase("ts");
-   BOOST_TEST(response_response_getvalid_json == expected_getvalid);
-}
-*/
 
 //----------------------------------------------------Token permissions Tests ------------------------------------------------------------------------
 
@@ -1581,7 +1435,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_non_permitted_path)
 
    json expected = json::parse(R"({
                    "action":"get",
-                   "error":{"message":"Insufficient read access to Vehicle.OBD.Speed","number":403,"reason":"Forbidden"},
+                   "error":{"message":"Insufficient read access to Vehicle.OBD.Speed","number":"403","reason":"Forbidden"},
                    "requestId":"8756"
         })");
 
@@ -1629,7 +1483,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_invalid_permission_valid_path)
 
    json expected = json::parse(R"({
                    "action":"get",
-                   "error":{"message":"Insufficient read access to Vehicle/OBD/EngineSpeed","number":403,"reason":"Forbidden"},
+                   "error":{"message":"Insufficient read access to Vehicle/OBD/EngineSpeed","number":"403","reason":"Forbidden"},
                    "requestId":"8756"
         })");
 
@@ -1838,7 +1692,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_write_permission)
 
    json expected = json::parse(R"({
                    "action":"get",
-                   "error":{"message":"Insufficient read access to Vehicle.OBD.EngineSpeed","number":403,"reason":"Forbidden"},
+                   "error":{"message":"Insufficient read access to Vehicle.OBD.EngineSpeed","number":"403","reason":"Forbidden"},
                    "requestId":"8756"
         })");
 
@@ -1887,7 +1741,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_permission_wildcard_req
 
   json expected = json::parse(R"({
     "action":"get",
-    "error":{"message":"Insufficient read access to Vehicle.OBD.*","number":403,"reason":"Forbidden"},
+    "error":{"message":"Insufficient read access to Vehicle.OBD.*","number":"403","reason":"Forbidden"},
     "requestId":"8756"
     })");
 
@@ -1936,7 +1790,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_read_with_wildcard_permission_branch_path_
 
   json expected = json::parse(R"({
     "action":"get",
-    "error":{"message":"Insufficient read access to Vehicle.OBD","number":403,"reason":"Forbidden"},
+    "error":{"message":"Insufficient read access to Vehicle.OBD","number":"403","reason":"Forbidden"},
     "requestId":"8756"
     })");
 
@@ -2090,7 +1944,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_not_permitted)
 
   json expected = json::parse(R"({
     "action":"set",
-    "error":{"message":"No write access to Vehicle.OBD.EngineSpeed","number":403,"reason":"Forbidden"},
+    "error":{"message":"No write access to Vehicle.OBD.EngineSpeed","number":"403","reason":"Forbidden"},
     "requestId":"8756"
     })");
 
@@ -2224,7 +2078,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_branch_permission)
    //childs. So we test accordingly 
    json expected = json::parse(R"({
     "action":"set",
-    "error":{"message":"No write access to Vehicle/OBD/Speed","number":403,"reason":"Forbidden"},
+    "error":{"message":"No write access to Vehicle/OBD/Speed","number":"403","reason":"Forbidden"},
     "requestId":"8756"
     })");
     
@@ -2250,7 +2104,7 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_branch_permission)
 
   json get_expected = json::parse(R"({
     "action": "get",
-    "error":{"message":"Insufficient read access to Vehicle.OBD.Speed","number":403,"reason":"Forbidden"},
+    "error":{"message":"Insufficient read access to Vehicle.OBD.Speed","number":"403","reason":"Forbidden"},
     "requestId": "8757"
     })");
 
@@ -2262,171 +2116,6 @@ BOOST_AUTO_TEST_CASE(permission_basic_write_with_branch_permission)
 
 }
 
-
-/* No wildcard writes supported until implemented in Gen2 compliant way */
-/*
-BOOST_AUTO_TEST_CASE(permission_basic_write_with_wildcard_in_permitted_path)
-{
-/*
-    Token looks like this.
-
- {
-  "sub": "Example JWT",
-  "iss": "Eclipse kuksa",
-  "admin": true,
-  "iat": 1516239022,
-  "exp": 1609372800,
-  "kuksa-vss": {
-    "Vehicle.OBD.EngineSpeed": "wr",                     ("wr" or "rw" both work!)
-    "Vehicle.OBD.Speed": "w"
-  }
-}
-*/
-/*
-   string AUTH_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJFeGFtcGxlIEpXVCIsImlzcyI6IkVjbGlwc2Uga3Vrc2EiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE2MDkzNzI4MDAsInczYy12c3MiOnsiVmVoaWNsZS5PQkQuRW5naW5lU3BlZWQiOiJ3ciIsIlZlaGljbGUuT0JELlNwZWVkIjoidyJ9fQ.R4Ulq0T84oiTJFb8scj-t4C-GnFQ0QvYVCd4glsXxiOlaNUIovZUehQwJAO5WK3b3Phz86yILuFCxNO7fsdHMmyUzNLhjiXMrL7Y2PU3gvr20EIoWYKyh52BFTH_YT6sB1EWfyhPb63_tWP0P2aa1JcXhBjAlXtmnIghjcj7KloH8MQGzKArjXa4R2NaKLH0FrO5aK8hBH3tevWp38Wae-fIypr4MgG-tXoKMt8juaE7RVDVTRiYyHJkCHjbZ0EZB9gAmy-_FyMiPxHNo8f49UtCGdBq82ZlQ_SKF6cMfH3iPw19BYG9ayIgzfEIm3HFhW8RdnxuxHzHYRtqaQKFYr37qNNk3lg4NRS3g9Mn4XA3ubi07JxBUcFl8_2ReJkcVqhua3ZiTcISkBmje6CUg1DmbH8-7SMaZhC-LJsZc8K9DBZN1cYCId7smhln5LcfjkZRh8N3d-hamrVRvfbdbee7_Ua-2SiJpWlPiIEgx65uYTV7flMgdnng0KVxv5-t_8QjySfKFruXE-HkYKN7TH8EqQA1RXuiDhj8bdFGtrB36HAlVah-cHnCCgL-p-29GceNIEoWJQT9hKWk8kQieXfJfiFUZPOxInDxHyUQEjblY049qMbU2kVSNvQ7nrmwP9OTjcXfnp7bndbstTHCGsVj1ixq8QF3tOdEGlC3Brg";
-
-   WsChannel channel;
-   channel.setConnID(1234);
-   string authReq(R"({
-		"action": "authorize",
-		"requestId": "87568"
-	})");
-   json authReqJson = json::parse(authReq);
-   authReqJson["tokens"] = AUTH_TOKEN;
-   commandProc->processQuery(authReqJson.as_string(),channel);
-   string request(R"({
-		"action": "set",
-		"path": "Vehicle.*",
-                "value" : [{"OBD.Speed":35}, {"OBD.EngineSpeed":50}],
-		"requestId": "8756"
-	})");
-
-   string response = commandProc->processQuery(request,channel);
-
-  json expected = json::parse(R"({
-    "action":"set",
-    "requestId":"8756"
-    })");
-
-   json response_json = json::parse(response);
-
-
-   BOOST_TEST(response_json.contains("ts") == true);
-
-   // remove timestamp to match
-   response_json.erase("ts");
-   BOOST_TEST(response_json == expected);
-
-   // verify with a get request the the previous set has not worked.
-
-    string get_request(R"({
-		"action": "get",
-		"path": "Vehicle.OBD.EngineSpeed",
-		"requestId": "8756"
-	})");
-
-   string get_response = commandProc->processQuery(get_request,channel);
-
-  json get_expected = json::parse(R"({
-    "action": "get",
-    "path": "Vehicle.OBD.EngineSpeed",
-    "requestId": "8756",
-    "value": 50
-    })");
-
-   json get_response_json = json::parse(get_response);
-
-
-   BOOST_TEST(get_response_json.contains("ts") == true);
-
-   // remove timestamp to match
-   get_response_json.erase("ts");
-   BOOST_TEST(get_response_json == get_expected);
-}
-*/
-
-/* Wildcard writes not supported, until implemented Gen2 compliant */
-/*
-BOOST_AUTO_TEST_CASE(permission_basic_write_with_wildcard_in_unpermitted_path)
-{
-/*
-    Token looks like this.
-
- {
-  "sub": "Example JWT",
-  "iss": "Eclipse kuksa",
-  "admin": true,
-  "iat": 1516239022,
-  "exp": 1924948800,
-  "kuksa-vss": {
-    "Vehicle.OBD.EngineSpeed": "wr"    ("wr" or "rw" both work!)
-  }
-}
-*/
-
-/*
-   string AUTH_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJFeGFtcGxlIEpXVCIsImlzcyI6IkVjbGlwc2Uga3Vrc2EiLCJhZG1pbiI6dHJ1ZSwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE5MjQ5NDg4MDAsImt1a3NhLXZzcyI6eyJWZWhpY2xlLk9CRC5FbmdpbmVTcGVlZCI6IndyIn19.O43MpewKMaYLyR0v_1c8STIiGt8fZMfkELda57RmVQxurdtOugT4iObXYF4xIDe68OOJPTk5KY4bYfCjHpYHuh9Cx1AeBAEya3x99KqIJsUhvzLuzvFO2iKbqgZOBt9miVPUC33tYuITNy3avUfzd12uC7a3fSGMlSoidtOfyBaUaxZJav-kGimgvhCUZvb4uHrjQW8ixDlXHgVtKddSmFj3F4fViJ2C0yFx_38c5F_sne5z55Y5zkDaXHVPRmskRZ5YyGpO4IF5KP5LgKR45iFU4_Pm3SmKfI3gpeF4AifyVT5zoE96Woj3KIvfnHG9Jog3ip-Kl4ikVkx_hyuSsvANGWaKx2xfmtrJ0GYQZqitMGBdW_VsCShInDJAkadSHzft6Efi8p0ysvKr5KvLUDb5vu28jSoAbMQs9ufOgUPNZvnTsYdVqaof-7Z7VEo_hJV3nQH5tFlvoMGrqQH2mGQTjDhHpNTWPotq3rMzDl8WbUjrJbDkFikKMByU-xv9pUWSWZ-ndxk45yLbpWUShZVsueoTDRO65kJvxuXPgmt68fiDSNJp4ZnmjeuC3TApv7UrqqPYKGUwpkz9gQF3_MLg2glEJUry5w9P-gEBObQ0mY5nM4W_5fMY_nDy1j1qUY4SsKi-0Xu45Dej3k-cqWoqWVwFEh3CiI4v7wQR_hY";
-
-   WsChannel channel;
-   channel.setConnID(1234);
-   string authReq(R"({
-		"action": "authorize",
-		"requestId": "87568"
-	})");
-   json authReqJson = json::parse(authReq);
-   authReqJson["tokens"] = AUTH_TOKEN;
-   commandProc_auth->processQuery(authReqJson.as_string(),channel);
-   string request(R"({
-		"action": "set",
-		"path": "Vehicle.OBD.*",
-                "value" : [{"Speed":35}, {"EngineSpeed":444}],
-		"requestId": "8756"
-	})");
-
-   string response = commandProc_auth->processQuery(request,channel);
-
-  json expected = json::parse(R"({
-    "action":"set",
-    "error":{"message":"Path(s) in set request do not have write access or is invalid","number":403,"reason":"Forbidden"},
-    "requestId":"8756"
-    })");
-
-   json response_json = json::parse(response);
-
-
-   BOOST_TEST(response_json.contains("ts") == true);
-
-   // remove timestamp to match
-   response_json.erase("ts");
-   BOOST_TEST(response_json == expected);
-
-   // verify with a get request the the previous set has not worked.
-
-    string get_request(R"({
-		"action": "get",
-		"path": "Vehicle.OBD.EngineSpeed",
-		"requestId": "8756"
-	})");
-
-   string get_response = commandProc_auth->processQuery(get_request,channel);
-
-  json get_expected = json::parse(R"({
-    "action": "get",
-    "path": "Vehicle.OBD.EngineSpeed",
-    "requestId": "8756",
-    "value": "---"
-    })");
-
-   json get_response_json = json::parse(get_response);
-
-
-   BOOST_TEST(get_response_json.contains("ts") == true);
-
-   // remove timestamp to match
-   get_response_json.erase("ts");
-   BOOST_TEST(get_response_json == get_expected);
-}
-*/
 
 
 //----------------------------------------------------subscription permission Tests ------------------------------------------------------------------------
@@ -2646,7 +2335,7 @@ BOOST_AUTO_TEST_CASE(subscription_test_no_permission)
 
    json expected = json::parse(R"({
                    "action":"subscribe",
-                   "error":{"message":"no permission to subscribe to path Vehicle.OBD.Speed","number":403,"reason":"Forbidden"},
+                   "error":{"message":"no permission to subscribe to path Vehicle.OBD.Speed","number":"403","reason":"Forbidden"},
                    "requestId":"8778"
                    })");
 
@@ -2697,7 +2386,7 @@ BOOST_AUTO_TEST_CASE(subscription_test_invalidpath)
 
    json expected = json::parse(R"({
                    "action":"subscribe",
-                   "error":{"message":"I can not find Vehicle.OBD.EngineSpeed1 in my db","number":404,"reason":"Path not found"},
+                   "error":{"message":"I can not find Vehicle.OBD.EngineSpeed1 in my db","number":"404","reason":"Path not found"},
                    "requestId":"8778"
                    })");
 
@@ -2856,7 +2545,7 @@ BOOST_AUTO_TEST_CASE(subscription_test_invalid_wildcard)
 
     json expected = json::parse(R"({
                                 "action":"subscribe",
-                                "error":{"message":"I can not find Signal.*.CatCamera in my db","number":404,"reason":"Path not found"},
+                                "error":{"message":"I can not find Signal.*.CatCamera in my db","number":"404","reason":"Path not found"},
                                 "requestId":"878787"
                                 })");
 

--- a/test/unit-test/KuksavalUnitTest.cpp
+++ b/test/unit-test/KuksavalUnitTest.cpp
@@ -2476,7 +2476,7 @@ BOOST_AUTO_TEST_CASE(subscription_test)
 
    BOOST_TEST(response_json.contains("subscriptionId") == true);
 
-   int subID = response_json["subscriptionId"].as<int>();
+   std::string subID = response_json["subscriptionId"].as<std::string>();
 
    // checked if subid is available. now remove to assert.
    response_json.erase("subscriptionId");
@@ -2501,7 +2501,7 @@ BOOST_AUTO_TEST_CASE(subscription_test)
    BOOST_TEST(unsub_response_json.contains("subscriptionId") == true);
 
    // compare the subit passed and returned.
-   BOOST_TEST(unsub_response_json["subscriptionId"].as<int>() == subID);
+   BOOST_TEST(unsub_response_json["subscriptionId"].as<std::string>() == subID);
 
    // remove subid to assert other part of the response.because these are variables.
    unsub_response_json.erase("subscriptionId");
@@ -2564,7 +2564,7 @@ BOOST_AUTO_TEST_CASE(subscription_test_wildcard_permission)
 
    BOOST_TEST(response_json.contains("subscriptionId") == true);
 
-   int subID = response_json["subscriptionId"].as<int>();
+   std::string subID = response_json["subscriptionId"].as<std::string>();
 
    // checked if subid is available. now remove to assert.
    response_json.erase("subscriptionId");
@@ -2590,7 +2590,7 @@ BOOST_AUTO_TEST_CASE(subscription_test_wildcard_permission)
    BOOST_TEST(unsub_response_json.contains("subscriptionId") == true);
 
    // compare the subit passed and returned.
-   BOOST_TEST(unsub_response_json["subscriptionId"].as<int>() == subID);
+   BOOST_TEST(unsub_response_json["subscriptionId"].as<std::string>() == subID);
 
    // remove subid to assert other part of the response.because these are variables.
    unsub_response_json.erase("subscriptionId");

--- a/test/unit-test/RestV1ApiHandlerTests.cpp
+++ b/test/unit-test/RestV1ApiHandlerTests.cpp
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_InvalidRootResourceTarget_Shall_Return
   BOOST_TEST(resultJson["action"].as<std::string>() == "get");
   BOOST_TEST(resultJson.contains("error"));
   auto errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 400);
+  BOOST_TEST(errJson["number"].as<std::string>() == "400");
 }
 
 BOOST_AUTO_TEST_CASE(Given_GetMethod_When_InvalidTargetFormats_Shall_ReturnValidErrorJson)
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_InvalidTargetFormats_Shall_ReturnValid
   BOOST_TEST(resultJson["action"].as<std::string>() == "get");
   BOOST_TEST(resultJson.contains("error"));
   auto errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 404);
+  BOOST_TEST(errJson["number"].as<std::string>() == "404");
 
   // verify
 
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_InvalidTargetFormats_Shall_ReturnValid
   BOOST_TEST(resultJson["action"].as<std::string>() == "get");
   BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 400);
+  BOOST_TEST(errJson["number"].as<std::string>() == "400");
 
   // verify
 
@@ -248,7 +248,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_InvalidTargetFormats_Shall_ReturnValid
   BOOST_TEST(resultJson["action"].as<std::string>() == "get");
   BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 400);
+  BOOST_TEST(errJson["number"].as<std::string>() == "400");
 
   // verify
 
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(Given_GetMethod_When_InvalidTargetFormats_Shall_ReturnValid
   BOOST_TEST(resultJson["action"].as<std::string>() == "get");
   BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 400);
+  BOOST_TEST(errJson["number"].as<std::string>() == "400");
 }
 
 BOOST_AUTO_TEST_CASE(Given_PutMethod_When_InvalidTargetString_Shall_ReturnValidErrorJson)
@@ -280,7 +280,7 @@ BOOST_AUTO_TEST_CASE(Given_PutMethod_When_InvalidTargetString_Shall_ReturnValidE
   BOOST_TEST(resultJson["action"].as<std::string>() == "set");
   BOOST_TEST(resultJson.contains("error"));
   auto errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 400);
+  BOOST_TEST(errJson["number"].as<std::string>() == "400");
 
   // verify
 
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(Given_PutMethod_When_InvalidTargetString_Shall_ReturnValidE
   BOOST_TEST(resultJson["action"].as<std::string>() == "set");
   BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 400);
+  BOOST_TEST(errJson["number"].as<std::string>() == "400");
 
   // verify
 
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE(Given_PutMethod_When_InvalidTargetString_Shall_ReturnValidE
   BOOST_TEST(resultJson["action"].as<std::string>() == "set");
   BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 400);
+  BOOST_TEST(errJson["number"].as<std::string>() == "400");
 }
 
 
@@ -326,7 +326,7 @@ BOOST_AUTO_TEST_CASE(Given_PostMethod_When_InvalidAuthorizeTargetString_Shall_Re
   BOOST_TEST(resultJson["action"].as<std::string>() == "authorize");
   BOOST_TEST(resultJson.contains("error"));
   auto errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 400);
+  BOOST_TEST(errJson["number"].as<std::string>() == "400");
 
   // verify
 
@@ -339,7 +339,7 @@ BOOST_AUTO_TEST_CASE(Given_PostMethod_When_InvalidAuthorizeTargetString_Shall_Re
   BOOST_TEST(resultJson["action"].as<std::string>() == "authorize");
   BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 400);
+  BOOST_TEST(errJson["number"].as<std::string>() == "400");
 
   // verify
 
@@ -352,7 +352,7 @@ BOOST_AUTO_TEST_CASE(Given_PostMethod_When_InvalidAuthorizeTargetString_Shall_Re
   BOOST_TEST(resultJson["action"].as<std::string>() == "authorize");
   BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 400);
+  BOOST_TEST(errJson["number"].as<std::string>() == "400");
 
   // verify
 
@@ -365,7 +365,7 @@ BOOST_AUTO_TEST_CASE(Given_PostMethod_When_InvalidAuthorizeTargetString_Shall_Re
   BOOST_TEST(resultJson["action"].as<std::string>() == "authorize");
   BOOST_TEST(resultJson.contains("error"));
   errJson = resultJson["error"].as<jsoncons::json>();
-  BOOST_TEST(errJson["number"].as<int>() == 400);
+  BOOST_TEST(errJson["number"].as<std::string>() == "400");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/unit-test/UpdateMetadataTest.cpp
+++ b/test/unit-test/UpdateMetadataTest.cpp
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE(update_metadata_brokenrequest) {
   "action": "updateMetaData",
   "error": {
     "message": "Schema error: #/metadata: Expected object, found uint64",
-    "number": 400,
+    "number": "400",
     "reason": "Bad Request"
   },
   "requestId": "1"

--- a/test/unit-test/UpdateVSSTreeTest.cpp
+++ b/test/unit-test/UpdateVSSTreeTest.cpp
@@ -400,7 +400,7 @@ BOOST_AUTO_TEST_CASE(update_vss_tree_brokenrequest) {
   "action": "updateVSSTree",
   "error": {
     "message": "Schema error: #: Required property \"metadata\" not found",
-    "number": 400,
+    "number": "400",
     "reason": "Bad Request"
   },
   "requestId": "1"

--- a/test/unit-test/VssCommandProcessorTests.cpp
+++ b/test/unit-test/VssCommandProcessorTests.cpp
@@ -652,7 +652,7 @@ BOOST_AUTO_TEST_CASE(Given_ValidSubscribeQuery_When_UserAuthorized_Shall_ReturnS
   jsonSignalValue["action"] = "subscribe";
   jsonSignalValue["requestId"] = requestId;
   jsonSignalValue["ts"] = 11111111;
-  jsonSignalValue["subscriptionId"] = subscriptionId;
+  jsonSignalValue["subscriptionId"] = std::to_string(subscriptionId);
 
   // expectations
 
@@ -918,13 +918,13 @@ BOOST_AUTO_TEST_CASE(Given_ValidUnsubscribeQuery_When_UserAuthorized_Shall_Unsub
   channel.set_connectionid(1);
 
   jsonUnsubscribeRequestForSignal["action"] = "unsubscribe";
-  jsonUnsubscribeRequestForSignal["subscriptionId"] = subscriptionId;
+  jsonUnsubscribeRequestForSignal["subscriptionId"] = std::to_string(subscriptionId);
   jsonUnsubscribeRequestForSignal["requestId"] = requestId;
 
   jsonSignalValue["action"] = "unsubscribe";
   jsonSignalValue["requestId"] = requestId;
   jsonSignalValue["ts"] = 11111111;
-  jsonSignalValue["subscriptionId"] = subscriptionId;
+  jsonSignalValue["subscriptionId"] = std::to_string(subscriptionId);
 
   // expectations
 
@@ -963,7 +963,7 @@ BOOST_AUTO_TEST_CASE(Given_ValidUnsubscribeQuery_When_Error_Shall_ReturnError)
   channel.set_connectionid(1);
 
   jsonUnsubscribeRequestForSignal["action"] = "unsubscribe";
-  jsonUnsubscribeRequestForSignal["subscriptionId"] = subscriptionId;
+  jsonUnsubscribeRequestForSignal["subscriptionId"] = std::to_string(subscriptionId);
   jsonUnsubscribeRequestForSignal["requestId"] = requestId;
 
   jsonSignalValueErr["number"] = 400;
@@ -1166,8 +1166,11 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   jsonValueErr["number"] = 400;
   jsonValueErr["reason"] = "Bad Request";
   jsonValueErr["message"] = "Key not found: 'action'";
+
   jsonExpected["error"] = jsonValueErr;
   jsonExpected["ts"] = 123;
+  jsonExpected["requestId"] = "UNKNOWN";
+
 
   //////////////////////
   // check empty request
@@ -1181,8 +1184,8 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   BOOST_TEST(res == jsonExpected);
 
   //////////////////////
-  /// check request with only action
-  jsonRequest["action"] = "notSupportedAction";
+  /// check request with only get action
+  jsonRequest["action"] = "get";
   resStr = processor->processQuery(jsonRequest.as_string(), channel);
   res = json::parse(resStr);
 
@@ -1201,8 +1204,12 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   resStr = processor->processQuery(jsonRequest.as_string(), channel);
   res = json::parse(resStr);
 
-  jsonValueErr["message"] = "Key not found: 'requestId'";
+  jsonValueErr["message"] = "Schema error: #: Required property \"requestId\" not found";
+
+  jsonExpected["requestId"] = "UNKNOWN";
   jsonExpected["error"] = jsonValueErr;
+  jsonExpected["action"] = "get";
+
 
   BOOST_TEST(res.contains("ts"));
   BOOST_TEST(res["ts"].is_string());
@@ -1210,19 +1217,25 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   BOOST_TEST(res == jsonExpected);
 
   //////////////////////
-  /// check request with added requestId
+  /// check request with added requestId, but illegal action
   jsonRequest["requestId"] = 1;
+  jsonRequest["action"] = "nothing";
+
   resStr = processor->processQuery(jsonRequest.as_string(), channel);
   res = json::parse(resStr);
 
   jsonValueErr["message"] = "Unknown action requested";
   jsonExpected["error"] = jsonValueErr;
+  jsonExpected.erase("action");
+  jsonExpected["requestId"] = "1";
+
 
   BOOST_TEST(res.contains("ts"));
   BOOST_TEST(res["ts"].is_string());
   jsonExpected["ts"]=res["ts"].as_string(); // ignoring timestamp difference for response 
 
   BOOST_TEST(res == jsonExpected);
+
 
   //////////////////////
   /// check random string as request
@@ -1231,6 +1244,8 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
 
   jsonValueErr["message"] = "";
   jsonExpected["error"] = jsonValueErr;
+  jsonExpected["requestId"] = "UNKNOWN";
+
 
   BOOST_TEST(res.contains("ts"));
   BOOST_TEST(res["ts"].is_string());

--- a/test/unit-test/VssCommandProcessorTests.cpp
+++ b/test/unit-test/VssCommandProcessorTests.cpp
@@ -696,7 +696,7 @@ BOOST_AUTO_TEST_CASE(Given_ValidSubscribeQuery_When_UserAuthorizedButSubIdZero_S
   jsonSubscribeRequestForSignal["path"] = path;
   jsonSubscribeRequestForSignal["requestId"] = requestId;
 
-  jsonSignalValueErr["number"] = 400;
+  jsonSignalValueErr["number"] = "400";
   jsonSignalValueErr["reason"] = "Bad Request";
   jsonSignalValueErr["message"] = "Unknown";
   jsonSignalValue["action"] = "subscribe";
@@ -966,7 +966,7 @@ BOOST_AUTO_TEST_CASE(Given_ValidUnsubscribeQuery_When_Error_Shall_ReturnError)
   jsonUnsubscribeRequestForSignal["subscriptionId"] = std::to_string(subscriptionId);
   jsonUnsubscribeRequestForSignal["requestId"] = requestId;
 
-  jsonSignalValueErr["number"] = 400;
+  jsonSignalValueErr["number"] = "400";
   jsonSignalValueErr["reason"] = "Unknown error";
   jsonSignalValueErr["message"] = "Error while unsubscribing";
   jsonSignalValue["action"] = "unsubscribe";
@@ -1117,7 +1117,7 @@ BOOST_AUTO_TEST_CASE(Given_ValidAuthJson_When_TokenInvalid_Shall_ReturnError)
   jsonAuthRequest["requestId"] = requestId;
   jsonAuthRequest["tokens"] = dummyToken;
 
-  jsonValueErr["number"] = 401;
+  jsonValueErr["number"] = "401";
   jsonValueErr["reason"] = "Invalid Token";
   jsonValueErr["message"] = "Check the JWT token passed";
   jsonValue["action"] = "authorize";
@@ -1163,7 +1163,7 @@ BOOST_AUTO_TEST_CASE(Given_JsonStrings_When_processQuery_Shall_HandleCorrectlyEr
   // validate that at least one log event was processed
   MOCK_EXPECT(logMock->Log).at_least( 1 );
 
-  jsonValueErr["number"] = 400;
+  jsonValueErr["number"] = "400";
   jsonValueErr["reason"] = "Bad Request";
   jsonValueErr["message"] = "Key not found: 'action'";
 


### PR DESCRIPTION
Fixes nothing in #263 , but makes subscriptions a little more robust

 - enforcing string type subscriptionIDs both directions
   - fixes the occasional "Integer Overflow" on unsubscribe
 - JSON schema checking for subscribe and unsubscribe requests
 - as a result, overall more helpful error messages


@nayakned  please check if it, at the very least, does not make things worse :)