### PR TITLE
Change devcontainer to bullseye to also support ARM64 development  machines

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
                             cmake \
                             libmosquitto-dev \
                             gcovr \
-                            python3-pip
+                            python3-pip \
+                            gdb
 
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,8 @@
 	"name": "KUKSA.val",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Ubuntu version: focal, bionic
-		"args": { "VARIANT": "focal" }
+		// Update 'VARIANT' to pick an Ubuntu/Debian version: focal, bionic
+		"args": { "VARIANT": "bullseye" }
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 


### PR DESCRIPTION
Support for poor Mac OS users.

The previous  devcontainer variant "focal" (or buster) , will never be supported as ARM64 container, thus forcing emulation on current Macs, while bullseye works on AMR64 as well as AMD64.

(see also https://github.com/microsoft/vscode-dev-containers/issues/558 )

Does not affect builds.

Can you confirm it works on amd64 @nayakned ?


