### PR TITLE
Publish kuksa.val data via Eclipse Kanto

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "3rd-party-libs/turtle"]
 	path = kuksa-val-server/3rd-party-libs/turtle
 	url = https://github.com/mat007/turtle.git
+[submodule "kuksa_apps/kanto/ditto-clients-python"]
+	path = kuksa_apps/kanto/ditto-clients-python
+	url = https://github.com/eclipse/ditto-clients-python.git

--- a/kuksa_apps/README.md
+++ b/kuksa_apps/README.md
@@ -8,4 +8,5 @@ Name | Description
 [dapr state_store](./dapr/state_store) | Store data to dapr `statestore` component
 [web client](./web-client) | A static webpage, which virsualize `kuksa.val` data
 [node red](./node-red) | Examples of `kuksa.val` clients using node-red flows, either via MQTT or via Websocket
+[kanto](./kanto) | Data bridge between `kuksa.val` and [Eclipse Kanto](https://github.com/eclipse-kanto/kanto)
 

--- a/kuksa_apps/kanto/Dockerfile
+++ b/kuksa_apps/kanto/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.9-slim
+
+COPY ditto-clients-python ./ditto-clients-python
+RUN pip3 install ./ditto-clients-python
+
+
+COPY requirements.txt ./
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+COPY ./*.py ./
+
+CMD [ "python3", "./edge_client.py" ]

--- a/kuksa_apps/kanto/README.md
+++ b/kuksa_apps/kanto/README.md
@@ -1,0 +1,6 @@
+# Publish kuksa.val data via Eclipse Kanto
+// TODO
+# Prerequisites
+// TODO
+# Run the example
+// TODO

--- a/kuksa_apps/kanto/edge_client.py
+++ b/kuksa_apps/kanto/edge_client.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+import signal
+import sys
+
+import paho.mqtt.client as mqtt
+from ditto.client import Client
+from ditto.model.feature import Feature
+from ditto.protocol.things.commands import Command
+from kuksa_viss_client import KuksaClientThread
+
+from edge_device_info import EdgeDeviceInfo
+from utils import process_tree, process_signal
+
+FEATURE_ID_VSS = "VSS"
+
+EDGE_CLOUD_CONNECTOR_TOPIC_DEV_INFO = "edge/thing/response"
+EDGE_CLOUD_CONNECTOR_TOPIC_DEV_INFO_REQUEST = "edge/thing/request"
+
+
+class EdgeClient:
+    def __init__(self):
+        self.mqtt_client = None
+        cfg = {"ip": "127.0.0.1"}
+        self.kuksa_client = KuksaClientThread(cfg)
+        self.device_info = None
+        self.ditto_client = None
+
+    def on_connect(self, client:mqtt.Client, obj, flags, rc):
+        print("Connected with result code " + str(rc))
+        self.mqtt_client = client
+        # init ditto client
+        self.ditto_client = Client(paho_client=self.mqtt_client)
+        self.ditto_client.connect()
+        # init kuksa client
+        self.kuksa_client.start()
+        self.kuksa_client.authorize()
+        # trigger initialization
+        self.mqtt_client.subscribe(EDGE_CLOUD_CONNECTOR_TOPIC_DEV_INFO)
+        self.mqtt_client.publish(EDGE_CLOUD_CONNECTOR_TOPIC_DEV_INFO_REQUEST, None, 1)
+
+    def on_message(self, client, userdata, msg):
+        try:
+            if msg.topic == EDGE_CLOUD_CONNECTOR_TOPIC_DEV_INFO:
+                if self.device_info is None:
+                    self.device_info = EdgeDeviceInfo()
+                    self.device_info.unmarshal_json(msg.payload)
+                    self.add_vss_feature()
+                    self.subscribe()
+                else:
+                    print('device info already available - discarding message')
+                return
+        except Exception as ex:
+            print(ex)
+
+    def subscribe(self):
+        self.kuksa_client.subscribe('Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Altitude', self.on_kuksa_signal)
+        self.kuksa_client.subscribe('Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Latitude', self.on_kuksa_signal)
+        self.kuksa_client.subscribe('Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Longitude', self.on_kuksa_signal)
+        # self.kuksa_client.subscribe('Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Accuracy', self.on_kuksa_signal)
+        self.kuksa_client.subscribe('Vehicle.Cabin.Infotainment.Navigation.CurrentLocation.Speed', self.on_kuksa_signal)
+
+    def add_vss_feature(self):
+        # add the vss feature
+        cmd = Command(self.device_info.deviceId).feature(FEATURE_ID_VSS).modify(Feature().to_ditto_dict())
+        cmd_envelope = cmd.envelope(response_required=False, content_type="application/json")
+        self.ditto_client.send(cmd_envelope)
+
+        # add the vss tree as properties
+        vss_tree = self.kuksa_client.getValue('Vehicle/Cabin/Infotainment/Navigation/CurrentLocation/*')
+        processed = process_tree(vss_tree)
+        for key, val in processed.items():
+            if 'Heading' in key or 'Accuracy' in key:
+                continue
+            cmd = Command(self.device_info.deviceId).feature_property(FEATURE_ID_VSS, key).modify(val)
+            cmd_envelope = cmd.envelope(response_required=False, content_type="application/json")
+            self.ditto_client.send(cmd_envelope)
+
+    def on_kuksa_signal(self, message):
+        if self.device_info is None:
+            print('no device info is initialized to process VSS data for')
+            return
+        path, val = process_signal(message)
+        # update property
+        cmd = Command(self.device_info.deviceId).feature_property(FEATURE_ID_VSS, path.replace('.','/')).modify(val)
+        cmd_envelope = cmd.envelope(response_required=False, content_type="application/json")
+        self.ditto_client.send(cmd_envelope)
+
+    def shutdown(self):
+        self.kuksa_client.stop()
+        self.ditto_client.disconnect()
+
+
+if __name__ == "__main__":
+    paho_client = mqtt.Client()
+    edge_client = EdgeClient()
+
+    paho_client.on_connect = edge_client.on_connect
+    paho_client.on_message = edge_client.on_message
+    paho_client.connect("localhost")
+
+
+    def termination_signal_received(signal_number, frame):
+        print("Received termination signal. Shutting down")
+        edge_client.shutdown()
+        paho_client.disconnect()
+
+
+    signal.signal(signal.SIGINT, termination_signal_received)
+    signal.signal(signal.SIGQUIT, termination_signal_received)
+    signal.signal(signal.SIGTERM, termination_signal_received)
+    print('before loop forever')
+    paho_client.loop_forever()

--- a/kuksa_apps/kanto/edge_device_info.py
+++ b/kuksa_apps/kanto/edge_device_info.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+from ditto.model.namespaced_id import NamespacedID
+import json
+
+DEVICE_ID_KEY = "deviceId"
+TENANT_ID_KEY = "tenantId"
+POLICY_ID_KEY = "policyId"
+
+ALLOWED_KEYS = [DEVICE_ID_KEY, TENANT_ID_KEY, POLICY_ID_KEY]
+
+
+class EdgeDeviceInfo:
+    def __init__(self, **kwargs):
+        self.deviceId = None
+        self.tenantId = None
+        self.policyId = None
+
+        for k, v in kwargs.items():
+            print(k)
+            if k in ALLOWED_KEYS:
+                self.__setattr__(k, v)
+
+    def unmarshal_json(self, data: json):
+        try:
+            envelope_dict = json.loads(data)
+        except json.JSONDecodeError as jex:
+            return jex
+
+        for k, v in envelope_dict.copy().items():
+            if k == DEVICE_ID_KEY:
+                self.deviceId = NamespacedID().from_string(v)
+
+            if k == POLICY_ID_KEY:
+                self.policyId = NamespacedID().from_string(v)
+
+            if k == TENANT_ID_KEY:
+                self.tenantId = v
+
+        print(self)
+        return 0

--- a/kuksa_apps/kanto/requirements.txt
+++ b/kuksa_apps/kanto/requirements.txt
@@ -1,0 +1,3 @@
+paho-mqtt
+kuksa-viss-client
+ditto-client

--- a/kuksa_apps/kanto/utils.py
+++ b/kuksa_apps/kanto/utils.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+
+import json
+
+
+# returns a key-value pairs where the key is the VSS path and the value is the
+# value reported for this path
+def process_tree(vss_tree):
+    res = {}
+    vss_data = json.loads(vss_tree)
+    for item in vss_data['data']:
+        print(item)
+        res[item['path']] = item['dp']['value']
+    print(res)
+    return res
+
+
+# returns a key-value pairs where the key is the VSS path and the value is the
+# value reported for this path
+def process_signal(vss_signal):
+    res = {}
+    vss_signal_json = json.loads(vss_signal)
+    vss_data = vss_signal_json['data']
+    return vss_data['path'], vss_data['dp']['value']


### PR DESCRIPTION
The provided implementation is a bridge between kuksa.val and Eclipse Kanto
that enables VSS data to be handled between these components. It also
utilizes the deployment of kuksa.val and the respective data feeders
via the OTA container management capabilities provided by Eclipse Kanto at the edge.

Signed-off-by: Konstantina Gramatova <konstantina.gramatova@bosch.io>