### PR TITLE
[databroker] Add release workflow

### DIFF
--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -201,9 +201,9 @@ jobs:
           labels: |
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
-      - name: Temporarily save container image
+      - name: Save container image (multiarch)
         uses: actions/upload-artifact@v3
         with:
-          name: Container image (multiarch)
+          name: databroker-oci-multiarch.tar
           path: ${{github.workspace}}/databroker-oci-multiarch.tar
           retention-days: 1

--- a/.github/workflows/kuksa_databroker_release.yml
+++ b/.github/workflows/kuksa_databroker_release.yml
@@ -1,0 +1,88 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+name: kuksa_databroker_release
+
+on:
+  # workflow_dispatch:   #TODO: input versions manually
+  push:
+    tags:
+      - "databroker-v*.*.*"
+
+jobs:
+  build_databroker:
+    uses: ./.github/workflows/kuksa_databroker_build.yml
+  create_release:
+    runs-on: ubuntu-latest
+    needs: [build_databroker]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/databroker-/}
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: bin/
+      - name: Create release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          fail_on_unmatched_files: true
+          files: |
+            bin/**
+            LICENSE
+            NOTICE.md
+
+  release-databroker-image:
+    name: "Download and push to ghcr (databroker)"
+    runs-on: ubuntu-latest
+
+    needs: [build_databroker]
+    steps:
+      - id: repository-name-adjusted
+        name: Prepare repository name in lower case for docker upload. This supports repository names in mixed case
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ github.repository }}
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/databroker-/}
+
+      - name: Retrieve saved Docker image
+        uses: actions/download-artifact@v3
+        with:
+          name: databroker-oci-multiarch.tar
+          path: ${{github.workspace}}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Push image to ghcr"
+        env:
+          VAL_NAME: databroker
+          VAL_VERSION: ${{ steps.get_version.outputs.version }}
+          GIT_HUB_REPOSITORY_NAME_LOWER_CASE: ${{ steps.repository-name-adjusted.outputs.lowercase }}
+        shell: bash
+        run: |
+          skopeo copy --all oci-archive:databroker-oci-multiarch.tar "docker://ghcr.io/$GIT_HUB_REPOSITORY_NAME_LOWER_CASE/$VAL_NAME:$VAL_VERSION"
+          skopeo inspect --raw "docker://ghcr.io/$GIT_HUB_REPOSITORY_NAME_LOWER_CASE/$VAL_NAME:$VAL_VERSION" | jq
+          skopeo inspect "docker://ghcr.io/$GIT_HUB_REPOSITORY_NAME_LOWER_CASE/$VAL_NAME:$VAL_VERSION"


### PR DESCRIPTION
When a tag with the form `databroker-vXX.XX.XX` is pushed, this workflow will run and:
* Push a multiarch container of databroker to ghcr.
* Create a draft release with databroker binaries.