### PR TITLE
Added the feature to get/set attributes to the go client.

### DIFF
--- a/kuksa_go_client/kuksa_viss/api.go
+++ b/kuksa_go_client/kuksa_viss/api.go
@@ -14,31 +14,47 @@ func (cc *KuksaClientComm) ConnectToKuksaValServerWs() error {
 	return err
 }
 
-// Function to get value from VSS tree
-func (cc *KuksaClientComm) GetValueFromKuksaValServer(path string) (string, error) {
+// Function to get attribute value from VSS tree
+func (cc *KuksaClientComm) GetAttrValueFromKuksaValServer(path string, attr string) (string, error) {
 
 	// Create new KuksaValRequest
 	req := objx.New(make(map[string]interface{}))
 	req.Set("requestId", uuid.New().String())
 	req.Set("action", "get")
 	req.Set("path", path)
+	req.Set("attribute", attr)
 
 	resp, err := cc.communicationHandler(req)
 	var value string
-	if resp.Has("data.dp.value") {
-		value = resp.Get("data.dp.value").String()
+	if resp.Has("data.dp." + attr) {
+		value = resp.Get("data.dp." + attr).String()
 	}
+	return value, err
+}
+
+// Function to get value from VSS tree
+func (cc *KuksaClientComm) GetValueFromKuksaValServer(path string) (string, error) {
+
+	value, err := cc.GetAttrValueFromKuksaValServer(path, "value")
 	return value, err
 }
 
 // Function to subscribe value from VSS tree
 func (cc *KuksaClientComm) SubscribeFromKuksaValServer(path string, subsChannel *chan []byte) (string, error) {
 
+	subscriptionId, err := cc.SubscribeAttrFromKuksaValServer(path, subsChannel, "value")
+	return subscriptionId, err
+}
+
+// Function to subscribe attribute value from VSS tree
+func (cc *KuksaClientComm) SubscribeAttrFromKuksaValServer(path string, subsChannel *chan []byte, attr string) (string, error) {
+
 	// Create new KuksaValRequest
 	req := objx.New(make(map[string]interface{}))
 	req.Set("requestId", uuid.New().String())
 	req.Set("action", "subscribe")
 	req.Set("path", path)
+	req.Set("attribute", attr)
 
 	// Create channel for subscription
 	resp, err := cc.communicationHandler(req)
@@ -73,6 +89,12 @@ func (cc *KuksaClientComm) UnsubscribeFromKuksaValServer(id string) error {
 
 // Function to set value from VSS tree
 func (cc *KuksaClientComm) SetValueFromKuksaValServer(path string, value string) error {
+	err := cc.SetAttrValueFromKuksaValServer(path, value, "value")
+	return err
+}
+
+// Function to set value from VSS tree
+func (cc *KuksaClientComm) SetAttrValueFromKuksaValServer(path string, value string, attr string) error {
 
 	// Create new KuksaValRequest
 	respChannel := make(chan objx.Map)
@@ -82,7 +104,8 @@ func (cc *KuksaClientComm) SetValueFromKuksaValServer(path string, value string)
 	req.Set("requestId", uuid)
 	req.Set("action", "set")
 	req.Set("path", path)
-	req.Set("value", value)
+	req.Set("attribute", attr)
+	req.Set(attr, value)
 
 	_, err := cc.communicationHandler(req)
 	return err

--- a/kuksa_go_client/main.go
+++ b/kuksa_go_client/main.go
@@ -30,9 +30,24 @@ func main() {
 		log.Fatalf("Authorization Error: %v", err)
 	}
 
+	// Set and Get the attribute targetValue
+	err = kuksaClientComm.SetAttrValueFromKuksaValServer("Vehicle.Body.Trunk.IsOpen", "true", "targetValue")
+	if err != nil {
+		log.Printf("Set Attribute Error: %v", err)
+	} else {
+		log.Printf("Vehicle.Body.Trunk.IsOpen Set: True")
+	}
+
+	var value string
+	value, err = kuksaClientComm.GetAttrValueFromKuksaValServer("Vehicle.Body.Trunk.IsOpen", "targetValue")
+	if err != nil {
+		log.Printf("Get Attribute Error: %v", err)
+	} else {
+		log.Printf("Vehicle.Body.Trunk.IsOpen: " + value)
+	}
+
 	// Get Value of Vehicle.Speed1
 	// This datapoint does not exist in the VSS and should result in an error
-	var value string
 	value, err = kuksaClientComm.GetValueFromKuksaValServer("Vehicle.Speed1")
 	if err != nil {
 		log.Printf("Get Error: %v", err)


### PR DESCRIPTION
You can now get, set and subscribe attributes using the go client.
The APIs have been extended in a backwards compatible manner accordingly.
The main.go now calls the new APIs (for get and set attributes) as an example.