### PR TITLE
Remove informational text that might be misinterpreted as legal

### DIFF
--- a/kuksa_databroker/README.md
+++ b/kuksa_databroker/README.md
@@ -15,8 +15,7 @@
     - [Build and run databroker container](#build-and-run-databroker-container)
   - [Limitations](#limitations)
   - [GRPC overview](#grpc-overview)
-  - [Data Privacy Information](#data-privacy-information)
-
+ 
 ## Intro
 
 Kuksa Data Broker is a GRPC service acting as a broker of vehicle data / data points / signals.
@@ -237,29 +236,3 @@ This implementation uses the default GRPC transport HTTP/2 and the default seria
 
 HTTP/2 is a binary replacement for HTTP/1.1 used for handling connections / multiplexing (channels) & and providing a standardized way to add authorization headers for authorization & TLS for encryption / authentication. It support two way streaming between client and server.
 
-## Data Privacy Information
-
-Your privacy is important to us.
-The following Information is to provide you with information relevant to data protection in order to be able to use the software in a data protection compliant manner.
-It is provided as an information source for your solution-specific data protection and data privacy topics.
-This is not intended to provide and should not be relied on for legal advice.
-
-### Your Role
-
-First things first: when you choose and use our software, you are most likely acting in the role of data controller, if personal related data is being processed.
-Therefore, you must ensure that the processing of personal data complies with the respective local legal requirements, e.g. when processing data within the scope of General Data Protection Regulation (GDPR) the legal requirements for a controller from the GDPR.
-
-### Where may the processing of personal related data be relevant?
-
-When using our software in combination with other software components, personal data or data categories may be collected for the purpose of developing, testing and running in-vehicle applications (Vehicle Apps).
-Possible examples are the vehicle identification number (VIN), the number plate, GPS data, video data, audio data, or other measurement data.
-You can determine which data or data categories are collected when configuring the software.
-These data are stored in volatile memory and are deleted by shutting down the system.
-You are responsible for the compliant handling of the data in accordance with the applicable local law.
-
-### What have we done to make the software data protection friendly?
-
-This section describes the measures taken to integrate the requirements of the data protection directly into the software development.
-The technical measures described below follow a "privacy by design" approach.
-
-- Deletion possibility: The software does not save data permanently since it uses only volatile memory. All collected or processed data can be deleted by rebooting the host hardware.


### PR DESCRIPTION
Removing "legal advice"