### PR TITLE
Remove gps feeder build from jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,14 +28,12 @@ node('docker') {
                 stage('arm64') {
                     sh "docker buildx build --platform=linux/arm64 -f ./kuksa-val-server/docker/Dockerfile -t arm64/kuksa-val:${versiontag} --output type=docker,dest=./artifacts/kuksa-val-${versiontag}-arm64.tar ."
                     sh "docker buildx build --platform=linux/arm64 -f ./kuksa_viss_client/Dockerfile -t arm64/kuksa-client:${versiontag} --output type=docker,dest=./artifacts/kuksa-client-${versiontag}-arm64.tar ."
-                    sh "docker buildx build --platform=linux/arm64 -t arm64/kuksa-gps-feeder:${versiontag} --output type=docker,dest=./artifacts/kuksa-gps-feeder-${versiontag}-arm64.tar kuksa_feeders/gps2val"
                 }
                 }, 
                 amd64: {
                 stage('amd64') {
                     sh "docker buildx build --platform=linux/amd64 -f ./kuksa-val-server/docker/Dockerfile -t amd64/kuksa-val:${versiontag} --output type=docker,dest=./artifacts/kuksa-val-${versiontag}-amd64.tar ."
                     sh "docker buildx build --platform=linux/amd64 -f ./kuksa_viss_client/Dockerfile -t amd64/kuksa-client:${versiontag} --output type=docker,dest=./artifacts/kuksa-client-${versiontag}-amd64.tar ."
-                    sh "docker buildx build --platform=linux/amd64 -t amd64/kuksa-gps-feeder:${versiontag} --output type=docker,dest=./artifacts/kuksa-gps-feeder-${versiontag}-amd64.tar kuksa_feeders/gps2val"
                     
                     sh "docker build -t kuksa-val-dev-ubuntu20.04:${versiontag} -f ./kuksa-val-server/docker/Dockerfile.dev ."
                     sh "docker save kuksa-val-dev-ubuntu20.04:${versiontag}  > artifacts/kuksa-val-dev-ubuntu20.04:${versiontag}.tar"


### PR DESCRIPTION
Because feeders moved over to https://github.com/eclipse/kuksa.val.feeders