### PR TITLE
Do not archive test dev container image used for unit tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /**  
-* Copyright Robert Bosch GmbH, 2020. Part of the Eclipse Kuksa Project.
+* Copyright Robert Bosch GmbH, 2020-2022. Part of the Eclipse Kuksa Project.
 *
 * All rights reserved. This configuration file is provided to you under the
 * terms and conditions of the Eclipse Distribution License v1.0 which
@@ -34,9 +34,8 @@ node('docker') {
                 stage('amd64') {
                     sh "docker buildx build --platform=linux/amd64 -f ./kuksa-val-server/docker/Dockerfile -t amd64/kuksa-val:${versiontag} --output type=docker,dest=./artifacts/kuksa-val-${versiontag}-amd64.tar ."
                     sh "docker buildx build --platform=linux/amd64 -f ./kuksa_viss_client/Dockerfile -t amd64/kuksa-client:${versiontag} --output type=docker,dest=./artifacts/kuksa-client-${versiontag}-amd64.tar ."
-                    
+                    //Build to check it is working and for unit tests, but no need to archive                   
                     sh "docker build -t kuksa-val-dev-ubuntu20.04:${versiontag} -f ./kuksa-val-server/docker/Dockerfile.dev ."
-                    sh "docker save kuksa-val-dev-ubuntu20.04:${versiontag}  > artifacts/kuksa-val-dev-ubuntu20.04:${versiontag}.tar"
             }
         }
     }


### PR DESCRIPTION
Jenkins builds often fail due to limited diskspace.

The largest artifact (>>1GiB) is the Ubuntu-based dev image. We will not archive it anymore (it is used for unittests, but normally not needed after, as development is done via VSCode .devcontainer anyway