### PR TITLE
First scratch of unified base proto

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -92,7 +92,7 @@ UseTab:          Never
 Language: Proto
 BasedOnStyle:  Google
 ColumnLimit:     120
-IndentWidth:     4
+IndentWidth:     2
 UseTab:          Never
 AlignConsecutiveAssignments: true
 ---

--- a/proto/kuksa/val/v1/types.proto
+++ b/proto/kuksa/val/v1/types.proto
@@ -1,0 +1,285 @@
+// Copyright Robert Bosch GmbH, 2022. Part of the Eclipse Kuksa Project.
+//
+// All rights reserved. This configuration file is provided to you under the
+// terms and conditions of the Eclipse Distribution License v1.0 which
+// accompanies this distribution, and is available at
+// http://www.eclipse.org/org/documents/edl-v10.php
+
+syntax = "proto3";
+
+// I added V1 as in databroker. Is this good practice?
+package kuksa.val.v1;
+import "google/protobuf/timestamp.proto";
+
+
+// A Value. 
+message Value {
+  google.protobuf.Timestamp timestamp = 1;
+
+  oneof value {
+    string string            = 11;
+    bool bool                = 12;
+    sint32 int32             = 13;
+    sint64 int64             = 14;
+    uint32 uint32            = 15;
+    uint64 uint64            = 16;
+    float float              = 17;
+    double double            = 18;
+    StringArray string_array = 21;
+    BoolArray bool_array     = 22;
+    Int32Array int32_array   = 23;
+    Int64Array int64_array   = 24;
+    Uint32Array uint32_array = 25;
+    Uint64Array uint64_array = 26;
+    FloatArray float_array   = 27;
+    DoubleArray double_array = 28;
+  }
+}
+
+// Describes a VSS datapoint, includes everything there is
+// to know about it. Most fields optional
+message Datapoint {
+  // Defines the full VSS path of the datapoint.
+  string path = 1;
+
+  // The value of the datapoint
+  Value value = 2;
+
+  // The VSS data type of the entry.
+  //
+  // NOTE: protobuf doesn't have int8, int16, uint8 or uint16 so the actual
+  // value will be serialized as int32 and uint32 respectively
+  // (in the `value` field).
+  //
+  oneof optional_data_type {
+    DataType data_type = 3;
+  }
+
+  // Describes the meaning and content of the datapoint.
+  oneof optional_description {
+    string description = 4;
+  }
+
+  // [optional]
+  // A comment can be used to provide additional informal information
+  // on a datapoint.
+  oneof optional_comment {
+    string comment = 10;
+  }
+
+  // [optional]
+  // Whether this datapoint is deprecated.
+  oneof optional_deprecation {
+    string deprecation = 11;
+  }
+
+  // [optional]
+  // The unit of measurement
+  oneof optional_unit {
+    string unit = 12;
+  }
+
+  // [optional]
+  // Restrict which values are allowed.
+  // Only restrictions matching the DataType {datatype} above is valid/used.
+
+  ValueRestriction value_restriction = 13;
+
+  // Data entry type
+  // Adds specific fields
+  oneof entry_type {
+    Actuator actuator   = 30;
+    Sensor sensor       = 31;
+    Attribute attribute = 32;
+  }
+
+}
+
+///////////////////////
+// Actuator specific fields
+message Actuator {
+  // Target value of the actuator
+  // NOTE: This is what you set in order to command the the actuator
+  //       to move.
+  Value target = 30;
+}
+
+////////////////////////
+// Sensor specific
+message Sensor {
+//nothing for now
+}
+
+////////////////////////
+// Attribute specific
+message Attribute {
+  // nothing for now.
+}
+
+
+
+// Value restriction
+//
+// One ValueRestriction{type} for each type, since
+// they don't make sense unless the types match
+//
+message ValueRestriction {
+  oneof restriction_type {
+    ValueRestrictionsString string_restriction = 1;
+    ValueRestrictionInt int_restriciton        = 2; //for all signed VSS integers
+    ValueRestrictionUint uint_restiction       = 3; //for all unsigned VSS integers
+    ValueRestrictionFloat float_restriction    = 4; //for VSS float and double
+  }
+}
+
+
+message ValueRestrictionInt {
+  oneof optional_min {
+    sint64 min = 1;
+  }
+  oneof optional_max {
+    sint64 max = 2;
+  }
+  repeated sint64 allowed_values = 3;
+}
+
+message ValueRestrictionUint {
+  oneof optional_min {
+    uint64 min = 1;
+  }
+  oneof optional_max {
+    uint64 max = 2;
+  }
+  repeated uint64 allowed_values = 3;
+}
+
+message ValueRestrictionFloat {
+  oneof optional_min {
+    double min = 1;
+  }
+  oneof optional_max {
+    double max = 2;
+  }
+  repeated double allowed_values = 3; //allowed for doubles/floats not recommended
+}
+
+message ValueRestrictionDouble {
+  oneof optional_min {
+    double min = 1;
+  }
+  oneof optional_max {
+    double max = 2;
+  }
+  repeated double allowed_values = 3;
+}
+
+
+// min, max doesn't make much sense for a string
+message ValueRestrictionsString {
+  repeated string allowed_values = 3;
+}
+
+
+// VSS Data type of a signal
+//
+// Protobuf doesn't support int8, int16, uint8 or uint16.
+// These are mapped to int32 and uint32 respectively.
+//
+enum DataType {
+  STRING          = 0;
+  BOOLEAN         = 1;
+  INT8            = 2;
+  INT16           = 3;
+  INT32           = 4;
+  INT64           = 5;
+  UINT8           = 6;
+  UINT16          = 7;
+  UINT32          = 8;
+  UINT64          = 9;
+  FLOAT           = 10;
+  DOUBLE          = 11;
+  TIMESTAMP       = 12;
+  STRING_ARRAY    = 20;
+  BOOLEAN_ARRAY   = 21;
+  INT8_ARRAY      = 22;
+  INT16_ARRAY     = 23;
+  INT32_ARRAY     = 24;
+  INT64_ARRAY     = 25;
+  UINT8_ARRAY     = 26;
+  UINT16_ARRAY    = 27;
+  UINT32_ARRAY    = 28;
+  UINT64_ARRAY    = 29;
+  FLOAT_ARRAY     = 30;
+  DOUBLE_ARRAY    = 31;
+}
+
+
+enum View {
+  VIEW_CURRENT_VALUE = 0;  // this is default, every implementation shall support this
+  VIEW_TARGET_VALUE  = 1;  // this is a set point of an actuator
+  VIEW_DATATYPE      = 2;  // VSS datatype of an element as string ("branch" in case of a VSS branch)
+  VIEW_UNIT          = 3;   // VSS unit of an element as string
+  VIEW_CHILDREN      = 4;   // Names of all direct children as string
+  VIEW_ALL_METADATA  = 100; // All available metadata defined in VSS model
+  VIEW_ALL           = 200; // All available data
+}
+
+enum Field {
+    VALUE = 0;  // this is default, every implementation shall support this
+    ACTUATOR_TARGET = 1;  // this is a set point of an actuator
+    DATA_TYPE      = 2;  // VSS datatype of an element as string ("branch" in case of a   VSS branch)
+    UNIT          = 3;   // VSS unit of an element as string
+    DESCRIPTION = 4;
+    COMMENT = 5;
+    DEPRECATION = 6;
+    VALUE_RESTRICTION = 7;
+    ACTUATOR = 8;
+    SENSOR = 9;
+    ATTRIBUTE = 10;  
+}
+
+// General status. Status response shall be an HTTP-like code
+// shall follow https://www.w3.org/TR/viss2-transport/#status-codes where it makes sense
+message Error {
+  uint32 code        = 1;
+  string reason      = 2;
+  string description = 3;
+}
+
+// used in get/set requests to optionally report status on indivusal paths
+message DatapointError {
+  string path = 1; //vss path
+  Error  error = 2;
+}
+
+message StringArray {
+  repeated string values = 1;
+}
+
+message BoolArray {
+  repeated bool values = 1;
+}
+
+message Int32Array {
+  repeated sint32 values = 1;
+}
+
+message Int64Array {
+  repeated sint64 values = 1;
+}
+
+message Uint32Array {
+  repeated uint32 values = 1;
+}
+
+message Uint64Array {
+  repeated uint64 values = 1;
+}
+
+message FloatArray {
+  repeated float values = 1;
+}
+
+message DoubleArray {
+  repeated double values = 1;
+}

--- a/proto/kuksa/val/v1/val.proto
+++ b/proto/kuksa/val/v1/val.proto
@@ -1,0 +1,117 @@
+// Copyright Robert Bosch GmbH, 2022. Part of the Eclipse Kuksa Project.
+//
+// All rights reserved. This configuration file is provided to you under the
+// terms and conditions of the Eclipse Distribution License v1.0 which
+// accompanies this distribution, and is available at
+// http://www.eclipse.org/org/documents/edl-v10.php
+
+// This is a base proto file for databroker and kuksa-val-basic
+// function set
+
+syntax = "proto3";
+
+package kuksa.val.v1;
+
+import "kuksa/val/v1/types.proto";
+
+option go_package = "/kuksa_grpc_proto";
+
+/*
+Note on autorization: We assume to send auth-token or auth-uuid in metadata
+Token is a JWT compliant token as the examples found here:
+https://github.com/eclipse/kuksa.val/tree/master/kuksa_certificates/jwt
+See also https://github.com/eclipse/kuksa.val/blob/master/doc/jwt.md
+Upon reception of auth-token, server shall generate an auth_uuid in metadata
+that the client can use instead of auth_token in subsequent calls.
+*/
+
+// The connecting service definition.
+service VAL {
+  //  Get data points..
+  rpc Get(GetRequest) returns (GetResponse);
+
+  // Set datapoints
+  rpc Set(SetRequest) returns (SetResponse);
+  
+  // Subscribe to a set of data points
+   //
+   // Returns a stream of replies.
+   //
+   // InvalidArgument is returned if the request is malformed.
+  //
+  // Returns a stream of replies.
+  //
+  // InvalidArgument is returned if the request is malformed.
+  rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
+
+  // Shall return a string identifier that allows the client to determine with what
+  // server/server implementation/version it is talking
+  // eg. kuksa-databroker 0.5.1
+  rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
+}
+
+// Describing which data we want
+message DataGetRequest {
+  string path = 1;
+  View view   = 2 ;
+} 
+
+// Request a number of VSS paths. 
+message GetRequest {
+  repeated DataGetRequest get = 1;
+}
+
+
+// Status is overall status, there may be  
+// individual status information, 
+message GetResponse {
+  repeated Datapoint datapoints    = 1;
+  repeated DatapointError errors   = 2;
+  Error error                      = 3;
+}
+
+// Describing which data we want
+message DataSetRequest {
+  string path = 1;
+  repeated Field fields =2 ;
+  Datapoint datapoint = 3;
+} 
+
+// A list of datapoints to be set
+message SetRequest {
+  repeated DataSetRequest set = 1;
+}
+
+// Usually it is fine to only return global status for set requests.
+// It is possible to return status messages for indiviudal VSS
+// paths. It is not expected that you get a ResponseValue for 
+// all set points, or that they contain any value
+message SetResponse {
+  Error error = 1;
+  repeated DatapointError datapoint_errors = 2;
+}
+
+
+// A subscribe request either subscribes a simple VSS Path
+// or can be given in form of an SQL query
+// Simple queries for CURRENT_VALUE and TARGET_VALUE
+// shall be supported as minimum by all implementations
+message SubscribeRequest {
+  repeated DataGetRequest simplesub = 1;
+}
+
+// In case of simple queries, a list of length 1 will be returned when
+// a subscribed datapoint is updated. In case of complex queries 
+// SELECT a,b ... more than one datapoint might be in the notification
+message SubscribeResponse {
+  repeated Datapoint datapoints = 1;
+}
+
+message GetServerInfoRequest {
+
+}
+
+message GetServerInfoResponse {
+  string name = 1;
+  string version = 2;
+}


### PR DESCRIPTION
Hi guys,

too many meetings... I did a first horrible copy&paste orgy with some of the discussed things.

At this point it likely doesn't even run trough protoc compiler, however I think such a "fake PR" makes discussion easier.

Please feel free at this point to just push changes to this branch (of something comes out of it in the end, we can squash).

Idea is to have basic get/set/subscribe

Some comments in file. Still open points

 - Do we want the "Update" streaming also in base? It does seem useful for some feeders (even though can feeder is not using it atm)

 - We still need to think how/if at all we want to unify some of the metadata things. kuksa.databroker and kuksa.val-server differ a little bit here: val-server can do "everything"; but basically because it does not care at all, it just gives you verbatim JSON snippets of the underlying VSS model. databroker gives out structured data, but that of course then is limited to the field it supports directly. One important thing, that probably apps/feeders might want to know is at least querying the datatype of an entry. Also the "registering" of datapoints is almost but not quite entirely unlike the updateMetadata/tree in val-server and again, teaching the server new entries during runtime is a valid thing

works towards #308 
