### PR TITLE
Added a switch -t/--type for forcing gRPC client to use a particular datatype

### DIFF
--- a/kuksa_viss_client/KuksaGrpcComm.py
+++ b/kuksa_viss_client/KuksaGrpcComm.py
@@ -127,13 +127,14 @@ class KuksaGrpcComm:
         return respJson 
 
     # Function to implement set
-    def setValue(self, path, value, attribute="value", timeout = 5):
+    def setValue(self, path, value, attribute="value", dt="none", timeout = 5):
         recvQueue = queue.Queue(maxsize=1)
 
         # Create Set Request
         req = kuksa_pb2.SetRequest()
         if attribute in self.AttrDict.keys():
-            dt = self.getDataType(path)
+            if dt=="none":
+                dt = self.getDataType(path)
             req.type = self.AttrDict[attribute]
             val = kuksa_pb2.Value()
             val.path = path
@@ -154,8 +155,11 @@ class KuksaGrpcComm:
                 if value in ["False", "false", "F", "f"]:
                     value = 0
                 val.valueBool = bool(value)
-            else:
+            elif dt=="string":
                 val.valueString = str(value)
+            else:
+                respJson = json.dumps({"error": "Invalid datatype"})
+                return respJson
 
             req.values.append(val)
 

--- a/kuksa_viss_client/KuksaWsComm.py
+++ b/kuksa_viss_client/KuksaWsComm.py
@@ -156,7 +156,8 @@ class KuksaWsComm:
         return self._sendReceiveMsg(req, timeout)
 
     # Set value to a given path
-    def setValue(self, path, value, attribute="value", timeout = 1):
+    def setValue(self, path, value, attribute="value", dt="none", timeout = 1):
+        # dt will be ignored as VISS requires everything to be a string.
         if 'nan' == value:
             print(path + " has an invalid value " + str(value))
             return

--- a/kuksa_viss_client/__init__.py
+++ b/kuksa_viss_client/__init__.py
@@ -63,8 +63,8 @@ class KuksaClientThread(threading.Thread):
         return self.KuksaClientObject.getMetaData(path, timeout)
 
     # Set value to a given path
-    def setValue(self, path, value, attribute="value", timeout = 1):
-        return self.KuksaClientObject.setValue(path, value, attribute, timeout)
+    def setValue(self, path, value, attribute="value", dt="none", timeout = 1):
+        return self.KuksaClientObject.setValue(path, value, attribute, dt, timeout)
 
     # Get value to a given path
     def getValue(self, path, attribute="value", timeout = 5):

--- a/kuksa_viss_client/__main__.py
+++ b/kuksa_viss_client/__main__.py
@@ -136,6 +136,7 @@ class TestClient(Cmd):
     ap_setValue.add_argument("Path", help="Path to be set", completer_method=path_completer)
     ap_setValue.add_argument("Value", help="Value to be set")
     ap_setValue.add_argument("-a", "--attribute", help="Attribute to be set", default="value")
+    ap_setValue.add_argument("-t", "--type", help="Datatype of the attribute to be set", default="none")
 
     ap_getValue = argparse.ArgumentParser()
     ap_getValue.add_argument("Path", help="Path to be read", completer_method=path_completer)
@@ -205,7 +206,7 @@ class TestClient(Cmd):
     def do_setValue(self, args):
         """Set the value of a path"""
         if self.checkConnection():
-            resp = self.commThread.setValue(args.Path, args.Value, args.attribute)
+            resp = self.commThread.setValue(args.Path, args.Value, args.attribute, args.type)
             print(highlight(resp, lexers.JsonLexer(), formatters.TerminalFormatter()))
         self.pathCompletionItems = []
 


### PR DESCRIPTION
You can force the kuksa client to set values using a specified datatype while using the gRPC interface.