### PR TITLE
Add default VSS file to Dockerfile

### DIFF
--- a/kuksa_databroker/Dockerfile
+++ b/kuksa_databroker/Dockerfile
@@ -27,9 +27,13 @@ FROM --platform=$TARGETPLATFORM debian:buster-slim
 
 COPY --from=builder workdir/databroker /app/databroker
 
+COPY ./data/vss-core/vss_release_3.0.json vss_release_3.0.json
+
 ENV KUKSA_DATA_BROKER_ADDR=0.0.0.0
 ENV KUKSA_DATA_BROKER_PORT=55555
+ENV KUKSA_DATA_BROKER_METADATA_FILE=vss_release_3.0.json
 
 EXPOSE $KUKSA_DATA_BROKER_PORT
 
 ENTRYPOINT [ "/app/databroker" ]
+

--- a/kuksa_databroker/README.md
+++ b/kuksa_databroker/README.md
@@ -211,10 +211,12 @@ DOCKER_BUILDKIT=1 docker build -f kuksa_databroker/Dockerfile -t databroker:<tag
 
 The image creation may take around 2 minutes.
 After the image is created the databroker container can be ran from any directory of the project:
+
 ```shell
-#By default the container will execute the ./databroker command.
+#By default the container will execute the ./databroker command and load the latest VSS file.
 docker run --rm -it  -p 55555:55555/tcp databroker
 ```
+
 To run any specific command, just append you command at the end.
 
 ```shell


### PR DESCRIPTION
With this PR the databroker container will by default load the VSS 3.0 file

```
erik@debian3:~/kuksa.val$ docker run --rm -it  -p 55555:55555/tcp databroker
2022-08-23T08:45:05.334442Z  INFO databroker: Init logging from RUST_LOG (environment variable not found)
2022-08-23T08:45:05.334473Z  INFO databroker: Starting Kuksa Data Broker 0.17.0
2022-08-23T08:45:05.334480Z  INFO databroker: Populating metadata from file 'vss_release_3.0.json'
2022-08-23T08:45:05.339142Z  INFO databroker: Listening on 0.0.0.0:55555
2022-08-23T08:45:05.339172Z  INFO databroker::broker: Starting housekeeping task
^C2022-08-23T08:45:12.903682Z  INFO databroker: received SIGINT
2022-08-23T08:45:12.903722Z  INFO databroker::grpc_service: Shutting down

```

