### PR TITLE
Update kuksa-viss-client to support Python 3.10

### DIFF
--- a/kuksa_viss_client/Dockerfile
+++ b/kuksa_viss_client/Dockerfile
@@ -8,7 +8,7 @@
 
 # Note: This dockerfile needs to be executed one level above in the root folder
 
-FROM python:3.8-alpine as build
+FROM python:3.10-alpine as build
 RUN apk update && apk add git alpine-sdk linux-headers
 ADD . /kuksa.val
 WORKDIR /kuksa.val/kuksa_viss_client
@@ -18,7 +18,7 @@ RUN python3 setup.py bdist_wheel
 RUN mkdir /kuksa_viss_client
 RUN pip install --target /kuksa_viss_client --no-cache-dir dist/*.whl 
 
-FROM python:3.8-alpine
+FROM python:3.10-alpine
 
 RUN apk add --no-cache libstdc++
 COPY --from=build /kuksa_viss_client /kuksa_viss_client

--- a/kuksa_viss_client/KuksaWsComm.py
+++ b/kuksa_viss_client/KuksaWsComm.py
@@ -233,9 +233,12 @@ class KuksaWsComm:
     # Main loop for handling websocket communication
     async def mainLoop(self):
         if not self.insecure:
-            context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            context = ssl.create_default_context()
             context.load_cert_chain(certfile=self.certificate, keyfile=self.keyfile)
             context.load_verify_locations(cafile=self.cacertificate)
+            # Certificates in ../kuksa_certificates does not contain the IP address used for
+            # connection to server so hostname check must be disabled
+            context.check_hostname = False
             try:
                 print("connect to wss://"+self.serverIP+":"+str(self.serverPort))
                 async with websockets.connect("wss://"+self.serverIP+":"+str(self.serverPort), ssl=context) as ws:


### PR DESCRIPTION
SSH checks in Python 3.10 are stricter.
Using current version with Python 3.10 gives the following error:

`Disconnected!! Cannot create a client socket with a PROTOCOL_TLS_SERVER context (_ssl.c:801)`

This seems to be correct as [CLIENT_AUTH](https://docs.python.org/3/library/ssl.html#ssl.Purpose.CLIENT_AUTH) used today is intended for server side sockets.

Changing to default context (i.e. implictly Purpose.SERVER_AUTH)

Also ignoring hostname check as default certificate does not include correct hostname

`Disconnected!! [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: IP address mismatch, certificate is not valid for '127.0.0.1'. (_ssl.c:997)`

Updating Docker build to use Python 3.10

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>