### PR TITLE
Can parse defaults, but does not yet apply them

### DIFF
--- a/kuksa_databroker/databroker/src/vss.rs
+++ b/kuksa_databroker/databroker/src/vss.rs
@@ -15,6 +15,8 @@ use std::fmt;
 
 use crate::types;
 
+use tracing::{debug};
+
 use serde_json::Value;
 
 #[derive(Debug)]
@@ -22,6 +24,7 @@ pub struct MetadataEntry {
     pub name: String,
     pub data_type: types::DataType,
     pub description: Option<String>,
+    pub default: Option<Value>,
 }
 
 enum VssEntryType {
@@ -96,6 +99,13 @@ fn parse_entry(name: &str, entry: &Value, entries: &mut Vec<MetadataEntry>) -> R
                     name: name.to_owned(),
                     data_type,
                     description: entry["description"].as_str().map(|s| s.to_owned()),
+                    default: match entry.get("default") {
+                        Some(x) =>  {
+                            debug!("Parsing default value {} for path {}",x,name);
+                            Some(x.clone())
+                        },
+                        None => None,
+                    }
                 });
             }
         }


### PR DESCRIPTION
An _incomplete_ attempt to fix #339 as the Rust is weak within me.

What it currently does: Parsing default from JSON (keeping it as an "untyped" serde JSON value at that point), and during registering checking whether a default exist, and calling a function to apply it.

The challenge is, now the apply_default function would need a lot of code to convert the datatypes to the correct datapoints. Question @argerus , would that even be the right way to go? And if so, is now the right time, or will the new GRPC implementation change the required functions and structs a lot anyway?