### PR TITLE
Limit contents copied when building kuksa-client container

### DIFF
--- a/kuksa_viss_client/Dockerfile
+++ b/kuksa_viss_client/Dockerfile
@@ -10,7 +10,8 @@
 
 FROM python:3.10-alpine as build
 RUN apk update && apk add git alpine-sdk linux-headers
-ADD . /kuksa.val
+COPY kuksa_viss_client /kuksa.val/kuksa_viss_client/
+COPY kuksa_certificates /kuksa.val/kuksa_certificates/
 WORKDIR /kuksa.val/kuksa_viss_client
 RUN pip install --upgrade pip build grpcio grpcio-tools
 RUN rm -rf dist 

--- a/kuksa_viss_client/setup.py
+++ b/kuksa_viss_client/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     package_dir={'kuksa_viss_client': '.' },
     packages=['kuksa_viss_client'],
     data_files=[
-        ("kuksa_certificates", glob('../kuksa_certificates/C*')), #Cleint and CA.pem
+        ("kuksa_certificates", glob('../kuksa_certificates/C*')), #Client and CA.pem
         ("kuksa_certificates/jwt", glob('../kuksa_certificates/jwt/*')),
         ],
     package_data={ "kuksa_viss_client": ["logo"] },


### PR DESCRIPTION
This is a minor improvement that could save some time for local builds of the kuksa-client docker container.
Without this change all content of current working directory is copied. That is typically not that much if starting on fresh clone, but if you have built e.g. databroker before you may copy a lot of unused data.

It has been verified that building and running containers works with this change.

COPY is typically preferred over DD, see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>