### PR TITLE
Fix license classifier for Pypi

### DIFF
--- a/kuksa_viss_client/setup.cfg
+++ b/kuksa_viss_client/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
     Development Status :: 3 - Alpha
     Environment :: Console
     Programming Language :: Python :: 3
-    License :: OSI Approved :: Apache Software License  (Apache-2.0)
+    License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Topic :: Software Development
     


### PR DESCRIPTION
Fixes the license classifier for Python, otherwise Pypi does not accept the Python package

Note: The used classifier DOES refer to the Apache 2.0 license even though the official string does omit "2.0".
See here for many examples for Apache 2.0 licensed python packages: https://pypi.org/search/?c=License+%3A%3A+OSI+Approved+%3A%3A+Apache+Software+License