### PR TITLE
Fix websocket authorization

### DIFF
--- a/kuksa-client/kuksa_client/KuksaWsComm.py
+++ b/kuksa-client/kuksa_client/KuksaWsComm.py
@@ -36,6 +36,7 @@ class KuksaWsComm:
         self.cacertificate = config.get('cacertificate', os.path.join(scriptDir, "../kuksa_certificates/CA.pem"))
         self.certificate = config.get('certificate', os.path.join(scriptDir, "../kuksa_certificates/Client.pem"))
         self.keyfile = config.get('key', os.path.join(scriptDir, "../kuksa_certificates/Client.key"))
+        self.tokenfile = config.get('token', os.path.join(scriptDir, "../kuksa_certificates/jwt/all-read-write.json.token"))
         self.wsConnected = False
 
         self.subscriptionCallbacks = {}
@@ -116,7 +117,9 @@ class KuksaWsComm:
         print("Server disconnected.")
 
     # Function to authorize against the kuksa.val server
-    def authorize(self, token="", timeout=2):
+    def authorize(self, token=None, timeout=2):
+        if token == None:
+            token = self.tokenfile
         token = os.path.expanduser(token)
         if os.path.isfile(token):
             with open(token, "r") as f:


### PR DESCRIPTION
The current kuksa_viss_client for websocket seems to be broken, at least if you use it without a token file, like dbcfeeder.
Then you get "None" as default by `authorize` in `__init__.py` and an exception, as `os.path.expanduser` does not like None.


Adapting to same structure as used for gRPC

This practically reverse [229a63c931065778e21b854a97e3c86f7659c3f9](https://github.com/eclipse/kuksa.val/commit/229a63c931065778e21b854a97e3c86f7659c3f9). (@SebastianSchildt  - could you please check the rationale for that commit, why it should behave differently than for gRPC)

Note that dbc/gps feeders in https://github.com/eclipse/kuksa.val.feeders currently rely on default authorization given by kuksa-viss-client, there is no way to manually override with another token file.


Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>