### PR TITLE
NOT FOR MERGE: Testing build without Alpine

### DIFF
--- a/kuksa-val-server/docker/Dockerfile
+++ b/kuksa-val-server/docker/Dockerfile
@@ -5,23 +5,14 @@
 # accompanies this distribution, and is available at
 # http://www.eclipse.org/org/documents/edl-v10.php
 
-FROM alpine:3.11 as build
+FROM python:3.10-slim-bullseye as build
 
 LABEL maintainer="Sebastian Schildt <sebastian.schildt@de.bosch.com>"
 
 
 
-RUN apk update && apk add cmake wget alpine-sdk linux-headers openssl-dev libstdc++ mosquitto-dev
+RUN apt-get update -qqy && apt-get upgrade -qqy && apt-get install -qqy git cmake build-essential libssl-dev libmosquitto-dev libboost-all-dev
 
-
-#Build Boost 1.75
-ENV BOOST_VER=1.75.0
-ENV BOOST_VER_=1_75_0
-RUN wget   https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VER}/source/boost_${BOOST_VER_}.tar.bz2
-RUN tar xvjf boost_${BOOST_VER_}.tar.bz2
-WORKDIR /boost_${BOOST_VER_}
-RUN ./bootstrap.sh
-RUN ./b2 -j 6 install
 
 WORKDIR /
 # Build and install grpc
@@ -47,7 +38,7 @@ RUN ls
 RUN /kuksa.val/kuksa-val-server/docker/collect-deployment-artifacts.sh
 
 
-FROM alpine:3.11
+FROM python:3.10-slim-bullseye
 
 COPY --from=build /deploy /kuksa.val
 WORKDIR /kuksa.val

--- a/kuksa_viss_client/Dockerfile
+++ b/kuksa_viss_client/Dockerfile
@@ -8,8 +8,7 @@
 
 # Note: This dockerfile needs to be executed one level above in the root folder
 
-FROM python:3.10-alpine as build
-RUN apk update && apk add git alpine-sdk linux-headers
+FROM python:3.10-slim-bullseye as build
 COPY kuksa_viss_client /kuksa.val/kuksa_viss_client/
 COPY kuksa_certificates /kuksa.val/kuksa_certificates/
 COPY kuksa-val-server/protos/kuksa.proto /kuksa.val/kuksa_viss_client/kuksa.proto
@@ -20,9 +19,8 @@ RUN python3 setup.py bdist_wheel
 RUN mkdir /kuksa_viss_client
 RUN pip install --target /kuksa_viss_client --no-cache-dir dist/*.whl 
 
-FROM python:3.10-alpine
+FROM python:3.10-slim-bullseye
 
-RUN apk add --no-cache libstdc++
 COPY --from=build /kuksa_viss_client /kuksa_viss_client
 ENV PYTHONUNBUFFERED=yes
 ENV GRPC_ENABLE_FORK_SUPPORT=false


### PR DESCRIPTION
This is an example pull request showing a possible to change to get rid of Alpine.

At least for kuksa-viss-client (Python) this is beneficial as then prebuilt versions of grpcio can be used.
For kuksa-val-server (C++) the difference is more subtle as we anyway need to build grpicio manually