### PR TITLE
kuksa_client: Use setuptools-git-versioning's default templates

### DIFF
--- a/kuksa-client/pyproject.toml
+++ b/kuksa-client/pyproject.toml
@@ -9,9 +9,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools-git-versioning]
 starting_version = "0.1.6"
-template = "{tag}"
-dev_template = "{tag}-{ccount}"
-dirty_template = "{tag}-{ccount}"
 tag_filter = "[0-9]+.[0-9]+.[0-9]+"
 
 [tool.pylint.design]


### PR DESCRIPTION
setuptools-git-versioning has more reasonable defaults for version templates than the custom ones we defined.
This commit fixes issue #254.