### PR TITLE
Fix clippy warning (and compiler error)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
 [profile.release]
 lto = true                 # Link time optimization (dead code removal etc...)
 opt-level = "s"
-split-debuginfo = "packed"
 codegen-units = 1
 incremental = false
 # debug = true               # for profiling (turn off otherwise)
+# split-debuginfo = "packed" # only enable when `debug = true``

--- a/kuksa_databroker/databroker-cli/src/main.rs
+++ b/kuksa_databroker/databroker-cli/src/main.rs
@@ -604,29 +604,22 @@ impl CliCompleter {
         let mut root = PathPart::new();
         for entry in metadata {
             let mut parent = &mut root;
-            let mut parts = entry.name.split('.');
-            loop {
-                let path = parts.next();
-                match path {
-                    Some(path) => {
-                        let full_path = match parent.full_path.as_str() {
-                            "" => path.to_owned(),
-                            _ => format!("{}.{}", parent.full_path, path),
-                        };
-                        let entry =
-                            parent
-                                .children
-                                .entry(path.to_lowercase())
-                                .or_insert(PathPart {
-                                    rel_path: path.to_owned(),
-                                    full_path,
-                                    children: HashMap::new(),
-                                });
-
-                        parent = entry;
-                    }
-                    None => break,
+            let parts = entry.name.split('.');
+            for part in parts {
+                let full_path = match parent.full_path.as_str() {
+                    "" => part.to_owned(),
+                    _ => format!("{}.{}", parent.full_path, part),
                 };
+                let entry = parent
+                    .children
+                    .entry(part.to_lowercase())
+                    .or_insert(PathPart {
+                        rel_path: part.to_owned(),
+                        full_path,
+                        children: HashMap::new(),
+                    });
+
+                parent = entry;
             }
         }
         CliCompleter { paths: root }
@@ -649,7 +642,7 @@ impl CliCompleter {
                             None => {
                                 // match partial
                                 for (path_part_lower, path_spec) in &path.children {
-                                    if path_part_lower.starts_with(&part) {
+                                    if path_part_lower.starts_with(part) {
                                         if !path_spec.children.is_empty() {
                                             // This is a branch
                                             res.push(Completion {

--- a/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/conversions.rs
+++ b/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/conversions.rs
@@ -318,7 +318,7 @@ impl From<proto::Datapoint> for broker::Datapoint {
 impl From<broker::EntryUpdate> for proto::DataEntry {
     fn from(from: broker::EntryUpdate) -> Self {
         Self {
-            path: from.path.unwrap_or_else(|| "".to_string()),
+            path: from.path.unwrap_or_default(),
             value: match from.datapoint {
                 Some(datapoint) => Option::<proto::Datapoint>::from(datapoint),
                 None => None,


### PR DESCRIPTION
Rust 1.65 introduced some clippy warnings and a compiler error.

- Fix clippy warning.
- Use `while let Some(..)` instead of `loop` as suggested by @flxo
- Remove split-debuginfo