### PR TITLE
kuksa-client: Simplify grpc subscribe*() and add synchronous implementations

### DIFF
--- a/kuksa-client/docs/examples/async-grpc.md
+++ b/kuksa-client/docs/examples/async-grpc.md
@@ -143,9 +143,9 @@ asyncio.run(main())
 ```python
 import asyncio
 
-from kuksa_client.grpc.aio import Field
-from kuksa_client.grpc.aio import SubscribeEntry
-from kuksa_client.grpc.aio import View
+from kuksa_client.grpc import Field
+from kuksa_client.grpc import SubscribeEntry
+from kuksa_client.grpc import View
 from kuksa_client.grpc.aio import VSSClient
 
 async def main():

--- a/kuksa-client/kuksa_client/grpc/__init__.py
+++ b/kuksa-client/kuksa_client/grpc/__init__.py
@@ -463,7 +463,6 @@ class BaseVSSClient:
         self.certificate_chain = certificate_chain
         self.ensure_startup_connection = ensure_startup_connection
         self.client_stub = None
-        self.subscribers = {}
 
     def _load_creds(self) -> Optional[grpc.ChannelCredentials]:
         if all((self.root_certificates, self.private_key, self.certificate_chain)):

--- a/kuksa-client/kuksa_client/grpc/aio.py
+++ b/kuksa-client/kuksa_client/grpc/aio.py
@@ -274,13 +274,7 @@ class VSSClient(BaseVSSClient):
             rpc_kwargs
                 grpc.*MultiCallable kwargs e.g. timeout, metadata, credentials.
         """
-        req = val_pb2.SubscribeRequest()
-        for entry in entries:
-            entry_request = val_pb2.SubscribeEntry(path=entry.path, view=entry.view.value, fields=[])
-            for field in entry.fields:
-                entry_request.fields.append(field.value)
-            req.entries.append(entry_request)
-        logger.debug("%s: %s", type(req).__name__, req)
+        req = self._prepare_subscribe_request(entries)
         resp_stream = self.client_stub.Subscribe(req, **rpc_kwargs)
         try:
             async for resp in resp_stream:


### PR DESCRIPTION
`grpc.aio.VSSClient.subscribe*()` now return async iterators and no longer accept callbacks.
This allows easier subscriptions as one can now directly iterate over asynchronous updates using an `async for` loop.
This also removes the need for having a function (callback) call for every update we get on our subscription.
This also allows a similar API to exist for the synchronous API i.e. `grpc.VSSClient.subscribe*()`.
