### PR TITLE
Rework badges and reorder items in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,24 +7,24 @@ This is KUKSA.val, the KUKSA **V**ehicle **A**bstration **L**ayer.
 KUKSA.val provides in-vehicle software components for working with in-vehicle signals modelled using the [COVESA VSS data model](https://github.com/COVESA/vehicle_signal_specification).
 
 
-
+[![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) 
 [![Gitter](https://badges.gitter.im/kuksa-val.svg)](https://gitter.im/kuksa-val)
 
-![Build kuksa-val-server](https://github.com/eclipse/kuksa.val/actions/workflows/kuksa_val_docker.yml/badge.svg)
-
+[![Build kuksa-val-server](https://github.com/eclipse/kuksa.val/actions/workflows/kuksa_val_docker.yml/badge.svg)](https://github.com/eclipse/kuksa.val/actions/workflows/kuksa_val_docker.yml?query=branch%3Amaster)
+[![Build kuksa-databroker](https://github.com/eclipse/kuksa.val/actions/workflows/kuksa_databroker_build.yml/badge.svg)](https://github.com/eclipse/kuksa.val/actions/workflows/kuksa_databroker_build.yml?query=branch%3Amaster)
 [![codecov](https://codecov.io/gh/eclipse/kuksa.val/branch/master/graph/badge.svg?token=M4FT175771)](https://codecov.io/gh/eclipse/kuksa.val)
 
-This repository contains several components
+KUKSA.val contains several components
 
-| License | Component      | Description |
-| --------| -------------- | ----------- |
-| [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) | [kuksa-val-server](kuksa-val-server) | Feature rich in-vehicle data server written in C++ providing authorized access to VSS data using W3C VISS websocket protocol or GRPC       |
-| [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) | [Python SDK](./kuksa-client)   | Python library for easy interaction with kuksa-val-server
-| [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) | [GO SDK](./kuksa_go_client)   | GOlang libraryfor easy interaction with kuksa-val-server
-| [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) | [kuksa-client](./kuksa-client)   | Command line tool to interactively explore and modify the VSS data points and data structure        |
-| [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) | [Examples](./kuksa_apps) | Multiple example apps for different programming languages and frameworks
-| [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) | [Feeders](https://github.com/eclipse/kuksa.val.feeders/) | Multiple feeders to gathering vehicle data and transforming it to VSS suitable for kuksa-val-server
-| [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) | [kuksa-databroker](./kuksa_databroker) | Efficient in-vehicle signal broker written in RUST
+| Component      | Description |
+| -------------- | ----------- |
+| [kuksa-val-server](kuksa-val-server) | Feature rich in-vehicle data server written in C++ providing authorized access to VSS data using W3C VISS websocket protocol or GRPC       |
+| [kuksa-databroker](./kuksa_databroker) | Efficient in-vehicle signal broker written in RUST
+| [Python SDK](./kuksa-client)   | Python library for easy interaction with kuksa-val-server
+|  [GO SDK](./kuksa_go_client)   | GOlang libraryfor easy interaction with kuksa-val-server
+| [kuksa-client](./kuksa-client)   | Command line tool to interactively explore and modify the VSS data points and data structure        |
+| [Examples](./kuksa_apps) | Multiple example apps for different programming languages and frameworks
+| [Feeders](https://github.com/eclipse/kuksa.val.feeders/) | Multiple feeders to gathering vehicle data and transforming it to VSS suitable for kuksa-val-server
 
 
 


### PR DESCRIPTION
Minor PR: Since everything is APACHE in kuksa.val for a while, there is no need to list license for individual components.


While at it, added a badge for databroker build, and moved databroker  up from the bottom of the list 