### PR TITLE
Databroker updated container and binary export

### DIFF
--- a/.github/actions/copy-from-oci/action.yml
+++ b/.github/actions/copy-from-oci/action.yml
@@ -1,0 +1,61 @@
+
+name: Extract from OCI image
+description: Can copy files out of an OCI image
+
+inputs:
+  plattform:
+    required: true
+    type: choice
+    description: Choose platform, e.g. linux/arm64
+    options:
+      - linux/arm64
+      - linux/amd64
+      - linux/riscv64
+    image:
+      required: true
+      type: string
+      description: The OCI image
+    src:
+      required: true
+      type: string
+      description: Path inside container
+    id:
+      required: true
+      type: string
+      description: |
+        This will be the name of the temporary container, making sure we do not leave any stale containers around
+        (we try deleting and before and after running this, so we can recover should a workflow for a given id
+        fail before cleaning up)
+        Will be used for artifact name (if export=true) and to identify 
+        This will also be created as directory in cwd.
+        !No special characters allowed "/" !
+    export:
+      required: false
+      default: false
+      description: Archive dest and export as Action artifact
+      
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: | 
+        mkdir -p ${{ inputs.id }}
+        docker rm ${{ inputs.id }} || true
+        docker create --name ${{ inputs.id }} --platform  ${{ inputs.platform }}  ${{ inputs.image }}
+        docker cp ${{ inputs.id }}:${{ inputs.src }} ${{ inputs.id }}  
+        docker rm ${{ inputs.id }}
+
+        
+    - if: inputs.export == 'true'
+      shell: bash
+      run: tar -czf ${{ inputs.id }}.tar.gz -C ${{ inputs.id }} .
+         
+    - if: inputs.export == 'true'
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ inputs.id }}
+        path: ${{ inputs.id }}.tar.gz
+       
+      
+  

--- a/.github/actions/copy-from-oci/action.yml
+++ b/.github/actions/copy-from-oci/action.yml
@@ -33,6 +33,9 @@ inputs:
       required: false
       default: false
       description: Archive dest and export as Action artifact
+    tar-transform:
+      required: false
+      description: Optionally applying chosen --transform to tar when export is set to true
       
 
 runs:
@@ -49,7 +52,7 @@ runs:
         
     - if: inputs.export == 'true'
       shell: bash
-      run: tar -czf ${{ inputs.id }}.tar.gz -C ${{ inputs.id }} .
+      run: tar -czf ${{ inputs.id }}.tar.gz -C ${{ inputs.id }} --transform "${{ inputs.transform }}"  .
          
     - if: inputs.export == 'true'
       uses: actions/upload-artifact@v3

--- a/.github/actions/post-container-location/action.yml
+++ b/.github/actions/post-container-location/action.yml
@@ -1,0 +1,24 @@
+
+name: Post container location
+description: Post snippet to pull and run test container
+
+
+
+
+inputs:
+    image:
+      required: true
+      type: string
+      description: The OCI image
+ 
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        echo "## :hatching_chick: Moin!" >> $GITHUB_STEP_SUMMARY
+        echo "Something new is in the world" >> $GITHUB_STEP_SUMMARY 
+        echo -e "\nImages for testing temporarily available at \`${{ inputs.image }}\`" >> $GITHUB_STEP_SUMMARY
+        echo -e "\n\`\`\`\ndocker pull ${{ inputs.image }}\n\`\`\`" >> $GITHUB_STEP_SUMMARY
+        echo -e "\n\`\`\`\ndocker run --rm -it --net=host ${{ inputs.image }}\n\`\`\`" >> $GITHUB_STEP_SUMMARY
+      

--- a/.github/workflows/check_push_rights.yml
+++ b/.github/workflows/check_push_rights.yml
@@ -1,8 +1,5 @@
 on:
   workflow_call:
-    secrets:
-      PUSH_CONTAINER_TOKEN:
-        required: false
     outputs:
       have_secrets:
         description: "In possession of ghcr.io tokens?"
@@ -16,14 +13,25 @@ jobs:
       have_secrets: ${{ steps.check-secrets.outputs.have_secrets }}
 
     steps:
-    #Check we have access to secrets. Forks fo not
-    - name: check for secrets needed to run demo
+    #Check we have access to secrets for pushing to GHCR. Forks do not
+    - name: check GITHUB_TOKEN allows GHCR push access
       id: check-secrets
       run: |
-          if [ ! -z "${{ secrets.PUSH_CONTAINER_TOKEN }}" ]; then
-            echo "Running from base repo. Will push to ghcr.io"
-            echo "{have_secrets}={true}" >> $GITHUB_OUTPUT
-          else
-            echo "No secrets for pushing. Will push ephemeral images to ttl.sh"
-            echo "{have_secrets}={false}" >> $GITHUB_OUTPUT
+          if [[ ${{ github.event_name }} == "push"  ]] &&  [[ ${{ github.repository }} == "eclipse/kuksa.val"  ]]; then
+            echo "We are pushing to kuksa.val upstream, so we should have rights"
+            echo "have_secrets=true" >> $GITHUB_OUTPUT
+            exit 0
+            # if it is a pull_request and my_repo is kuksa.val I can push to GHCR,
+            # (note that some/all workflows int his repo might still opt to no push PR builds to GHCR)
           fi
+          if [[ ${{ github.event_name }} == "pull_request"  ]] &&  [[ ${{ github.event.pull_request.head.repo.full_name }} == "eclipse/kuksa.val"  ]]; then
+              echo "We are an internal pull request , so we should have rights"
+              echo "have_secrets=true" >> $GITHUB_OUTPUT
+              exit 0
+          fi
+          # Everything else
+          echo "Seems we do not have rights to push"
+          echo "We are event ${{ github.event_name }} running in ${{ github.repository }}"
+          echo "In case this is a PR it is coming from ${{ github.event.pull_request.head.repo.full_name }} "
+          echo "have_secrets=false" >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/workflows/kuksa_databroker-cli_build.yml
+++ b/.github/workflows/kuksa_databroker-cli_build.yml
@@ -131,6 +131,7 @@ jobs:
         image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h
         src: /app/
         export: true
+        transform: s/app/databroker-cli/
 
     - name: Extracting AMD64 binaries
       uses: ./.github/actions/copy-from-oci
@@ -140,5 +141,4 @@ jobs:
         image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h
         src: /app/
         export: true
-
-        
+        transform: s/app/databroker-cli/

--- a/.github/workflows/kuksa_databroker-cli_build.yml
+++ b/.github/workflows/kuksa_databroker-cli_build.yml
@@ -89,7 +89,7 @@ jobs:
 
     - name: Build kuksa.val databroker CLI container and push to ghcr.io (and ttl.sh)
       id: ghcr-build
-      if: needs.checkrights.outputs.have_secrets == 'true'
+      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
       uses: docker/build-push-action@v3
       with:
         platforms: |
@@ -104,7 +104,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Build ephemereal kuksa.val databroker container and push to ttl.sh
-      if: needs.checkrights.outputs.have_secrets == 'false'
+      if: ${{ needs.checkrights.outputs.have_secrets == 'false' || github.event_name == 'pull_request' }}
       id: tmp-build
       uses: docker/build-push-action@v3
       with:

--- a/.github/workflows/kuksa_databroker-cli_build.yml
+++ b/.github/workflows/kuksa_databroker-cli_build.yml
@@ -117,41 +117,28 @@ jobs:
         tags: "ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h"
         labels: ${{ steps.meta.outputs.labels }}
         
-    - name: Posting message
-      run: |
-        echo "## :hatching_chick: Moin!" >> $GITHUB_STEP_SUMMARY
-        echo "Something new is in the world" >> $GITHUB_STEP_SUMMARY 
-        echo -e "\nImages for testing temporarily available at \`ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h\`" >> $GITHUB_STEP_SUMMARY
-        echo -e "\n\`\`\`\ndocker pull ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h\n\`\`\`" >> $GITHUB_STEP_SUMMARY
-    
-    - name: Extracting AMD64 binaries
-      run: | 
-        docker rm cliamd || true
-        docker create --name cliamd --platform linux/amd64 ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h
-        docker cp cliamd:/app ./  
-        docker rm cliamd
-        mv ./app ./databroker-cli-amd64
-        tar -czf databroker-cli-amd64.tar.gz -C databroker-cli-amd64 .
 
-         
+    - name: Posting message
+      uses: ./.github/actions/post-container-location
+      with:
+        image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h
+      
     - name: Extracting ARM64 binaries
-      run: | 
-        docker rm cliarm || true
-        docker create --name cliarm --platform linux/arm64 ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h
-        docker cp cliarm:/app ./  
-        docker rm cliarm
-        mv ./app ./databroker-cli-arm64
-        tar -czf databroker-cli-arm64.tar.gz -C databroker-cli-arm64 .
-         
-    - name: Archive  AMD64 binaries
-      uses: actions/upload-artifact@v3
+      uses: ./.github/actions/copy-from-oci
       with:
-        name: databroker-cli-amd64
-        path: ./databroker-cli-amd64.tar.gz 
-         
-    - name: Archive  ARM64 binaries
-      uses: actions/upload-artifact@v3
+        platform: linux/arm64
+        id: databroker-cli-arm64
+        image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h
+        src: /app/
+        export: true
+
+    - name: Extracting AMD64 binaries
+      uses: ./.github/actions/copy-from-oci
       with:
-        name: databroker-cli-arm64
-        path: ./databroker-cli-arm64.tar.gz
+        platform: linux/amd64
+        id: databroker-cli-amd64
+        image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h
+        src: /app/
+        export: true
+
         

--- a/.github/workflows/kuksa_databroker-cli_build.yml
+++ b/.github/workflows/kuksa_databroker-cli_build.yml
@@ -83,7 +83,7 @@ jobs:
       if: needs.checkrights.outputs.have_secrets == 'true'
       uses: docker/login-action@v2
       with:
-          registry: ${{ needs.checkrights.outputs.registry }}
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -193,6 +193,8 @@ jobs:
         image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
         src: /app/
         export: true
+        transform: s/app/databroker/
+
         
     - name:  Extracting AMD64 binaries
       uses: ./.github/actions/copy-from-oci
@@ -202,6 +204,7 @@ jobs:
         image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
         src: /app/
         export: true
+        transform: s/app/databroker/
 
   integration-test:
     name: Run integration test

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -146,7 +146,7 @@ jobs:
       if: needs.checkrights.outputs.have_secrets == 'true'
       uses: docker/login-action@v2
       with:
-          registry: ${{ needs.checkrights.outputs.registry }}
+          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -115,13 +115,13 @@ jobs:
     needs: checkrights
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with: 
         submodules: recursive
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v3.5.0
+      uses: docker/metadata-action@v4
       with:
         # list of Docker images to use as base name for tags
         images: |
@@ -150,7 +150,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Build kuksa.val databroker container and push to ghcr.io
+    - name: Build kuksa.val databroker container container and push to ghcr.io (and ttl.sh)
       id: ghcr-build
       if: needs.checkrights.outputs.have_secrets == 'true'
       uses: docker/build-push-action@v3
@@ -169,7 +169,7 @@ jobs:
     - name: Build ephemereal kuksa.val databroker container and push to ttl.sh
       if: needs.checkrights.outputs.have_secrets == 'false'
       id: tmp-build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v3
       with:
         platforms: |
           linux/amd64
@@ -179,9 +179,44 @@ jobs:
         push: true
         tags: "ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h"
         labels: ${{ steps.meta.outputs.labels }}
+  
+    - name: Posting message
+      run: |
+        echo "## :hatching_chick: Moin!" >> $GITHUB_STEP_SUMMARY
+        echo "Something new is in the world" >> $GITHUB_STEP_SUMMARY 
+        echo -e "\nImages for testing temporarily available at \`ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h\`" >> $GITHUB_STEP_SUMMARY
+          echo -e "\n\`\`\`\ndocker pull ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h\n\`\`\`" >> $GITHUB_STEP_SUMMARY
 
+    - name: Extracting AMD64 binaries
+      run: | 
+        docker rm brokeramd || true
+        docker create --name brokeramd --platform linux/amd64 ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
+        docker cp brokeramd:/app ./  
+        docker rm brokeramd
+        mv ./app ./databroker-amd64
+        tar -czf databroker-amd64.tar.gz -C databroker-amd64 .
 
-    
+    - name: Extracting ARM64 binaries
+      run: | 
+        docker rm brokerarm || true
+        docker create --name brokerarm --platform linux/arm64 ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
+        docker cp brokerarm:/app ./  
+        docker rm brokerarm
+        mv ./app ./databroker-arm64
+        tar -czf databroker-arm64.tar.gz -C databroker-arm64 .  
+
+    - name: Archive  AMD64 binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: databroker-amd64
+        path: ./databroker-amd64.tar.gz 
+         
+    - name: Archive  ARM64 binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: databroker-arm64
+        path: ./databroker-arm64.tar.gz
+
   integration-test:
     name: Run integration test
     runs-on: ubuntu-latest

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -108,8 +108,8 @@ jobs:
     uses: ./.github/workflows/check_push_rights.yml
     secrets: inherit
 
-# Run on selfhosted, becasue our runner has native ARM build in a remote
-# builder (no need for qemu
+# Run on selfhosted, because our runner has native ARM build in a remote
+# builder (no need for qemu)
   build-container:
     runs-on: [ self-hosted ]
     needs: checkrights
@@ -181,41 +181,27 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
   
     - name: Posting message
-      run: |
-        echo "## :hatching_chick: Moin!" >> $GITHUB_STEP_SUMMARY
-        echo "Something new is in the world" >> $GITHUB_STEP_SUMMARY 
-        echo -e "\nImages for testing temporarily available at \`ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h\`" >> $GITHUB_STEP_SUMMARY
-          echo -e "\n\`\`\`\ndocker pull ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h\n\`\`\`" >> $GITHUB_STEP_SUMMARY
-
-    - name: Extracting AMD64 binaries
-      run: | 
-        docker rm brokeramd || true
-        docker create --name brokeramd --platform linux/amd64 ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
-        docker cp brokeramd:/app ./  
-        docker rm brokeramd
-        mv ./app ./databroker-amd64
-        tar -czf databroker-amd64.tar.gz -C databroker-amd64 .
-
-    - name: Extracting ARM64 binaries
-      run: | 
-        docker rm brokerarm || true
-        docker create --name brokerarm --platform linux/arm64 ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
-        docker cp brokerarm:/app ./  
-        docker rm brokerarm
-        mv ./app ./databroker-arm64
-        tar -czf databroker-arm64.tar.gz -C databroker-arm64 .  
-
-    - name: Archive  AMD64 binaries
-      uses: actions/upload-artifact@v3
+      uses: ./.github/actions/post-container-location
       with:
-        name: databroker-amd64
-        path: ./databroker-amd64.tar.gz 
-         
-    - name: Archive  ARM64 binaries
-      uses: actions/upload-artifact@v3
+        image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
+
+    - name:  Extracting ARM64 binaries
+      uses: ./.github/actions/copy-from-oci
       with:
-        name: databroker-arm64
-        path: ./databroker-arm64.tar.gz
+        platform: linux/arm64
+        id: databroker-arm64
+        image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
+        src: /app/
+        export: true
+        
+    - name:  Extracting AMD64 binaries
+      uses: ./.github/actions/copy-from-oci
+      with:
+        platform: linux/amd64
+        id: databroker-amd64
+        image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
+        src: /app/
+        export: true
 
   integration-test:
     name: Run integration test

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -152,7 +152,7 @@ jobs:
 
     - name: Build kuksa.val databroker container container and push to ghcr.io (and ttl.sh)
       id: ghcr-build
-      if: needs.checkrights.outputs.have_secrets == 'true'
+      if: ${{ needs.checkrights.outputs.have_secrets == 'true' && github.event_name != 'pull_request' }}
       uses: docker/build-push-action@v3
       with:
         platforms: |
@@ -167,7 +167,7 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Build ephemereal kuksa.val databroker container and push to ttl.sh
-      if: needs.checkrights.outputs.have_secrets == 'false'
+      if: ${{ needs.checkrights.outputs.have_secrets == 'false' || github.event_name == 'pull_request' }}
       id: tmp-build
       uses: docker/build-push-action@v3
       with:

--- a/kuksa_databroker/Dockerfile
+++ b/kuksa_databroker/Dockerfile
@@ -12,19 +12,54 @@
 # ********************************************************************************/
 
 # This is expected to be executed in the kuksa.val top-level directory
-FROM rust:1.63 as builder
 
+# This builds KUKSA databroker
 
+FROM rust:1.65-alpine as base
+RUN apk add git musl-dev python3 protoc ncurses-terminfo-base make 
 RUN rustup component add rustfmt
+
+
+FROM base AS builder-amd64
+RUN echo "AMD64 quirks"
+# it seems on AMD build some dependency requires zlib headers
+# also the grpc proto compilation always falls back to
+# some binaries downloaded by cargo that require glibc
+RUN apk add zlib-dev libc6-compat  libstdc++ gcompat
+
+
+FROM base AS builder-arm64
+RUN echo "ARM64 quirks"
+# Need flag for MUSL arm builds, to prevent linker error
+# on missing __getauxval symbol, see also
+# https://github.com/rust-lang/rust/issues/89626
+ENV CFLAGS=-mno-outline-atomics
+
+
+
+FROM builder-$TARGETARCH as builder
+ARG TARGETARCH
+# This will speed up fetching the crate.io index in the future, see
+# https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html
+ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
+
+RUN echo "Building for $TARGETARCH"
 
 RUN mkdir /build
 WORKDIR /build
+
+# See also https://github.com/rust-lang/cargo/issues/10583, 
+# without this needs more than 12GB in runner if somebody wants to buildx
+# it with the common qemu setup
+RUN ln -s /usr/bin/git /usr/local/cargo/bin/
+ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+
+RUN cargo install cargo-license
 
 ADD kuksa_databroker kuksa_databroker
 ADD proto proto
 
 # Creating BOM
-RUN cargo install cargo-license
 WORKDIR /build/kuksa_databroker/createbom
 RUN rm -rf ../thirdparty
 RUN python3 createbom.py ../databroker
@@ -32,11 +67,11 @@ RUN python3 createbom.py ../databroker
 WORKDIR /build/kuksa_databroker/databroker
 
 ENV RUSTFLAGS='-C link-arg=-s'
+
 RUN cargo build --bin databroker --release
 
 
-
-FROM  debian:buster-slim
+FROM  scratch
 
 COPY --from=builder /build/kuksa_databroker/databroker/target/release/databroker /app/databroker
 COPY --from=builder /build/kuksa_databroker/databroker/thirdparty /app/thirdparty


### PR DESCRIPTION
This changes the databroker docker file to build a static build running in a `FROM scratch` container (uncompresed container size < 7 MiB)

It also adapted the workflow to databroker-cli standard:
 - Posting locations of generated temporary images for easy testing in build summary
 - Extracting generated binaries from generated docker images providing them as build artifacts

Refactored the docker workflow, so that reusable parts now are composite actions, and also applied them for databroker-cli build -> Less code

Not sure CI in this PR will build correctly before this is merged upstream, for successful builds see 
https://github.com/boschglobal/kuksa.val/actions/runs/3854761392
and
https://github.com/boschglobal/kuksa.val/actions/runs/3854761389