### PR TITLE
check_push rights depreaction fix 

### DIFF
--- a/.github/workflows/check_push_rights.yml
+++ b/.github/workflows/check_push_rights.yml
@@ -4,9 +4,6 @@ on:
       PUSH_CONTAINER_TOKEN:
         required: false
     outputs:
-      registry:
-        description: "Registry to push to"
-        value: ${{ jobs.check_push_rights.outputs.registry }}
       have_secrets:
         description: "In possession of ghcr.io tokens?"
         value: ${{ jobs.check_push_rights.outputs.have_secrets }}
@@ -17,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       have_secrets: ${{ steps.check-secrets.outputs.have_secrets }}
-      registry: ${{ steps.check-secrets.outputs.registry }}
 
     steps:
     #Check we have access to secrets. Forks fo not
@@ -26,10 +22,8 @@ jobs:
       run: |
           if [ ! -z "${{ secrets.PUSH_CONTAINER_TOKEN }}" ]; then
             echo "Running from base repo. Will push to ghcr.io"
-            echo "::set-output name=have_secrets::true"
-            echo "::set-output name=registry::ghcr.io"
+            echo "{have_secrets}={true}" >> $GITHUB_OUTPUT
           else
             echo "No secrets for pushing. Will push ephemeral images to ttl.sh"
-            echo "::set-output name=have_secrets::false"
-            echo "::set-output name=registry::ttl.sh"
+            echo "{have_secrets}={false}" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Use non-deprecated way to set outputs, removed unused output