### PR TITLE
Include top level Cargo.toml in databroker container build

### DIFF
--- a/kuksa_databroker/Dockerfile
+++ b/kuksa_databroker/Dockerfile
@@ -58,6 +58,7 @@ RUN cargo install cargo-license
 
 ADD kuksa_databroker kuksa_databroker
 ADD proto proto
+ADD Cargo.toml Cargo.toml
 
 # Creating BOM
 WORKDIR /build/kuksa_databroker/createbom
@@ -73,7 +74,7 @@ RUN cargo build --bin databroker --release
 
 FROM  scratch
 
-COPY --from=builder /build/kuksa_databroker/databroker/target/release/databroker /app/databroker
+COPY --from=builder /build/target/release/databroker /app/databroker
 COPY --from=builder /build/kuksa_databroker/databroker/thirdparty /app/thirdparty
 
 ADD ./data/vss-core/vss_release_3.0.json vss_release_3.0.json


### PR DESCRIPTION
Added toplevel Cargo.toml to databroker build as suggested in #443 


Result on arm

```
cs2rng@RNG-C-001JT kuksa.val % docker images | grep -e before -e after
databroker                                                                       after                  aa8915c2ffc0   20 seconds ago   3.89MB
databroker                                                                       before                 dce7ed03c82b   10 minutes ago   6.3MB
```

Please check @argerus 
