### PR TITLE
Fix quoting in check_push_rights

### DIFF
--- a/.github/workflows/check_push_rights.yml
+++ b/.github/workflows/check_push_rights.yml
@@ -17,14 +17,14 @@ jobs:
     - name: check GITHUB_TOKEN allows GHCR push access
       id: check-secrets
       run: |
-          if [[ ${{ github.event_name }} == "push"  ]] &&  [[ ${{ github.repository }} == "eclipse/kuksa.val"  ]]; then
+          if [[ "${{ github.event_name }}" == "push"  ]] &&  [[ "${{ github.repository }}" == "eclipse/kuksa.val"  ]]; then
             echo "We are pushing to kuksa.val upstream, so we should have rights"
             echo "have_secrets=true" >> $GITHUB_OUTPUT
             exit 0
             # if it is a pull_request and my_repo is kuksa.val I can push to GHCR,
             # (note that some/all workflows int his repo might still opt to no push PR builds to GHCR)
           fi
-          if [[ ${{ github.event_name }} == "pull_request"  ]] &&  [[ ${{ github.event.pull_request.head.repo.full_name }} == "eclipse/kuksa.val"  ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request"  ]] &&  [[ "${{ github.event.pull_request.head.repo.full_name }}" == "eclipse/kuksa.val"  ]]; then
               echo "We are an internal pull request , so we should have rights"
               echo "have_secrets=true" >> $GITHUB_OUTPUT
               exit 0


### PR DESCRIPTION
Fix quoting, otherwise in certain conditions generates syntactically invalid if statements in bash, see e.g.

(https://github.com/boschglobal/kuksa.val/actions/runs/3910675145)