### PR TITLE
Support reading metadata from more than one file

### DIFF
--- a/kuksa_databroker/README.md
+++ b/kuksa_databroker/README.md
@@ -2,17 +2,17 @@
 
 - [Kuksa Databroker](#kuksa-data-broker)
   - [Intro](#intro)
-  - [Interface](#interface)
+  - [Interface](#grpc-interfaces)
   - [Relation to the COVESA Vehicle Signal Specification (VSS)](#relation-to-the-covesa-vehicle-signal-specification-vss)
   - [Building](#building)
     - [Build all](#build-all)
     - [Build all release](#build-all-release)
   - [Running](#running)
-    - [Broker](#broker)
-    - [Test the broker - run client/cli](#test-the-broker---run-clientcli)
-    - [Kuksa Data Broker Query Syntax](#databroker-query-syntax)
+    - [Broker](#databroker)
+    - [Test the broker - run client/cli](#test-the-databroker)
+    - [Kuksa Data Broker Query Syntax](#data-broker-query-syntax)
     - [Configuration](#configuration)
-    - [Build and run databroker container](#build-and-run-databroker-container)
+    - [Build and run databroker container](#build-and-run-databroker)
   - [Limitations](#limitations)
   - [GRPC overview](#grpc-overview)
 
@@ -20,13 +20,16 @@
 
 Kuksa Data Broker is a GRPC service acting as a broker of vehicle data / data points / signals.
 
-## GRPC Interface(s)
+## GRPC Interfaces
 
 Databroker implements a couple of GRPC interfaces.
+
 ### `kuksa.val.v1.VAL`
+
 This GRPC interface is under development and is meant to be used by kuksa-databroker, kuksa-val-server and the feeders.
 
 ### `sdv.databroker.v1.Broker`
+
 This interface is currently used by databroker clients. It is defined as follows (see [file](proto/sdv/databroker/v1/broker.proto) in the proto folder):
 
 ```protobuf
@@ -64,7 +67,7 @@ that's available in the [vss-tools](https://github.com/COVESA/vss-tools) reposit
 ./vss-tools/vspec2json.py -I spec spec/VehicleSignalSpecification.vspec vss.json
 ```
 
-The resulting vss.json can be loaded at startup my supplying the data broker with the command line argument:
+The resulting vss.json can be loaded at startup by supplying the data broker with the command line argument:
 
 ```shell
 --metadata vss.json
@@ -102,30 +105,33 @@ USAGE:
     databroker [OPTIONS]
 
 OPTIONS:
-        --address <ADDR>    Bind address [default: 127.0.0.1]
-        --port <PORT>       Bind port [default: 55555]
-        --metadata <FILE>   Populate data broker with metadata from file [env:
-                            KUKSA_DATA_BROKER_METADATA_FILE=]
-        --dummy-metadata    Populate data broker with dummy metadata
-    -h, --help              Print help information
-    -V, --version           Print version information
+        --address <ADDR>      Bind address [default: 127.0.0.1]
+        --port <PORT>         Bind port [default: 55555]
+        --metadata <FILE(S)>  Populate data broker with metadata from a
+                              (comma-separated) list of files.
+                              [env:KUKSA_DATA_BROKER_METADATA_FILE=]
+        --dummy-metadata      Populate data broker with dummy metadata
+    -h, --help                Print help information
+    -V, --version             Print version information
 
 ```
 
 ### :warning: Default port not working on Mac OS
-The databroker default port `55555` is not usable in many versions of Mac OS. You can not bind it, or if it seems bound you still can not receive messages. Therefore, on Mac OS you need to start databroker on another port, e.g.
+The databroker default port `55555` is not usable in many versions of Mac OS. You can not bind it, or if it seems bound you still can not receive messages.
+Therefore, on Mac OS you need to start databroker on another port, e.g.
 
 ```
 databroker --port 55556
 ```
 
-Please note, this also applies if you use a container environment like K3S or Docker on Mac OS. If you forward the port or exposing the host network interfaces, the same problem occurs.
+Please note, this also applies if you use a container environment like K3S or Docker on Mac OS. If you forward the port or exposing the host network
+interfaces, the same problem occurs.
 
 For more information see also https://developer.apple.com/forums/thread/671197 
 
 Currently, to run databroker-cli (see below), you do need to change the port it connects to in databroker-cli code and recompile it.
 
-### Test the databroker - run client/cli
+### Test the databroker
 
 Run the cli with:
 
@@ -182,10 +188,10 @@ WHERE
 
 | parameter      | default value | cli parameter    | environment variable              | description                                  |
 |----------------|---------------|------------------|-----------------------------------|----------------------------------------------|
-| metadata       | <no active>   | --metadata       | KUKSA_DATA_BROKER_METADATA_FILE | Populate data broker with metadata from file |
+| metadata       | <no active>   | --metadata       | KUKSA_DATA_BROKER_METADATA_FILE   | Populate data broker with metadata from file |
 | dummy-metadata | <no active>   | --dummy-metadata | <no active>                       | Populate data broker with dummy metadata     |
-| listen_address | "127.0.0.1"   | --address        | KUKSA_DATA_BROKER_ADDR          | Listen for rpc calls                         |
-| listen_port    | 55555         | --port           | KUKSA_DATA_BROKER_PORT          | Listen for rpc calls                         |
+| listen_address | "127.0.0.1"   | --address        | KUKSA_DATA_BROKER_ADDR            | Listen for rpc calls                         |
+| listen_port    | 55555         | --port           | KUKSA_DATA_BROKER_PORT            | Listen for rpc calls                         |
 
 To change the default configuration use the arguments during startup see [run section](#running) or environment variables.
 

--- a/kuksa_databroker/databroker/src/main.rs
+++ b/kuksa_databroker/databroker/src/main.rs
@@ -1,5 +1,5 @@
 /********************************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation
+* Copyright (c) 2022-2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
@@ -137,6 +137,59 @@ async fn shutdown_handler() {
     };
 }
 
+async fn read_metadata_file(
+    broker: &broker::DataBroker,
+    filename: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let path = filename.trim();
+    info!("Populating metadata from file '{}'", path);
+    let mut metadata_file = std::fs::OpenOptions::new().read(true).open(path)?;
+    // metadata_file
+    let mut data = String::new();
+    metadata_file.read_to_string(&mut data)?;
+    let entries = vss::parse_vss(&data)?;
+    for entry in entries {
+        debug!("Adding VSS datapoint type {}", entry.name);
+
+        let id = broker
+            .add_entry(
+                entry.name.clone(),
+                entry.data_type,
+                databroker::broker::ChangeType::OnChange,
+                entry.entry_type,
+                entry.description.unwrap_or_else(|| "".to_owned()),
+            )
+            .await;
+
+        if let (Ok(id), Some(default)) = (id, entry.default) {
+            let ids = [(
+                id,
+                broker::EntryUpdate {
+                    datapoint: Some(broker::Datapoint {
+                        ts: std::time::SystemTime::now(),
+                        value: default,
+                    }),
+                    path: None,
+                    actuator_target: None,
+                    entry_type: None,
+                    data_type: None,
+                    description: None,
+                },
+            )];
+            if let Err(errors) = broker.update_entries(ids).await {
+                // There's only one error (since we're only trying to set one)
+                if let Some(error) = errors.get(0) {
+                    info!(
+                        "Failed to set default value for {}: {:?}",
+                        entry.name, error.1
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let version = option_env!("VERGEN_GIT_SEMVER").unwrap_or("");
@@ -183,16 +236,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .value_name("PORT")
                 .required(false)
                 .env("KUKSA_DATA_BROKER_PORT")
+                .value_parser(clap::value_parser!(u16).range(1..))
                 .default_value("55555"),
         )
         .arg(
             Arg::new("metadata")
                 .display_order(4)
                 .long("metadata")
-                .help("Populate data broker with metadata from file")
+                .help("Populate data broker with metadata from (comma-separated) list of files")
                 .takes_value(true)
+                .use_value_delimiter(true)
+                .require_value_delimiter(true)
+                .multiple_values(true)
                 .value_name("FILE")
                 .env("KUKSA_DATA_BROKER_METADATA_FILE")
+                .value_parser(clap::builder::NonEmptyStringValueParser::new())
                 .required(false),
         )
         .arg(
@@ -212,7 +270,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = format!(
         "{}:{}",
         args.value_of("address").unwrap(),
-        args.value_of("port").unwrap()
+        args.get_one::<u16>("port").unwrap()
     );
 
     let broker = broker::DataBroker::new();
@@ -261,51 +319,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    if let Some(filename) = args.value_of("metadata") {
-        info!("Populating metadata... from file '{}'", filename);
-        let mut metadata_file = std::fs::OpenOptions::new().read(true).open(filename)?;
-        // metadata_file
-        let mut data = String::new();
-        metadata_file.read_to_string(&mut data)?;
-        let entries = vss::parse_vss(&data)?;
-        for entry in entries {
-            debug!("Adding {}", entry.name);
-
-            let id = broker
-                .add_entry(
-                    entry.name.clone(),
-                    entry.data_type,
-                    databroker::broker::ChangeType::OnChange,
-                    entry.entry_type,
-                    entry.description.unwrap_or_else(|| "".to_owned()),
-                )
-                .await;
-
-            if let (Ok(id), Some(default)) = (id, entry.default) {
-                let ids = [(
-                    id,
-                    broker::EntryUpdate {
-                        datapoint: Some(broker::Datapoint {
-                            ts: std::time::SystemTime::now(),
-                            value: default,
-                        }),
-                        path: None,
-                        actuator_target: None,
-                        entry_type: None,
-                        data_type: None,
-                        description: None,
-                    },
-                )];
-                if let Err(errors) = broker.update_entries(ids).await {
-                    // There's only one error (since we're only trying to set one)
-                    if let Some(error) = errors.get(0) {
-                        info!(
-                            "Failed to set default value for {}: {:?}",
-                            entry.name, error.1
-                        );
-                    }
-                }
-            }
+    if let Some(metadata_filenames) = args.get_many::<String>("metadata") {
+        for filename in metadata_filenames {
+            read_metadata_file(&broker, filename).await?;
         }
     }
 


### PR DESCRIPTION
The "--metadata" option now accepts a comma-separated list of file paths. This is helpful when supporting custom datapoints in addition to the standard ones.

Also made sure that the port parameter value is in the valid port range.
