### PR TITLE
Align databroker cargo version to next release

### DIFF
--- a/kuksa_databroker/databroker/Cargo.toml
+++ b/kuksa_databroker/databroker/Cargo.toml
@@ -13,7 +13,7 @@
 
 [package]
 name = "databroker"
-version = "0.17.0"
+version = "0.3.0"
 authors = ["Robert Bosch GmbH"]
 edition = "2018"
 license = "Apache-2.0"

--- a/kuksa_databroker/databroker/build.rs
+++ b/kuksa_databroker/databroker/build.rs
@@ -26,7 +26,7 @@ fn main() -> Result<()> {
 
     // Enable VERGEN_GIT_SEMVER
     *git.semver_mut() = true;
-    *git.semver_kind_mut() = vergen::SemverKind::Normal;
+    *git.semver_kind_mut() = vergen::SemverKind::Lightweight;
     *git.semver_dirty_mut() = Some(" (dirty worktree)");
 
     // Enable VERGEN_GIT_SHA

--- a/kuksa_databroker/databroker/src/main.rs
+++ b/kuksa_databroker/databroker/src/main.rs
@@ -192,7 +192,8 @@ async fn read_metadata_file(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let version = option_env!("VERGEN_GIT_SEMVER").unwrap_or("");
+    let version = option_env!("VERGEN_GIT_SEMVER_LIGHTWEIGHT")
+        .unwrap_or(option_env!("VERGEN_GIT_SHA").unwrap_or("unknown"));
 
     let about = format!(
         concat!(


### PR DESCRIPTION
Just pushing version to next intended release.

Let's postpone "magic" to set this to the next minor release