### PR TITLE
Update check_push_rights.yml

### DIFF
--- a/.github/workflows/check_push_rights.yml
+++ b/.github/workflows/check_push_rights.yml
@@ -29,6 +29,11 @@ jobs:
               echo "have_secrets=true" >> $GITHUB_OUTPUT
               exit 0
           fi
+          if [[ "${{ github.ref_type }}" == "tag"  ]] &&  [[ "${{ github.repository }}" == "eclipse/kuksa.val"  ]]; then
+              echo "We are an upstream release build , so we should have rights"
+              echo "have_secrets=true" >> $GITHUB_OUTPUT
+              exit 0
+          fi
           # Everything else
           echo "Seems we do not have rights to push"
           echo "We are event ${{ github.event_name }} running in ${{ github.repository }}"


### PR DESCRIPTION
This makes sure we actual push releases, e.g. building a tag, (which indicates a release) in  upstream (which means we do have the neccessary rights)  to GHCR