### PR TITLE
Update Cargo package version for databroker in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "databroker"
-version = "0.17.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
Otherwise Cargo.lock is updated during build leading to -dirty working copy when vergen checks