### PR TITLE
Add support for access tokens to cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
 name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +170,7 @@ dependencies = [
  "clap",
  "databroker-proto",
  "jemallocator",
+ "jsonwebtoken",
  "prost",
  "prost-types",
  "serde",
@@ -580,6 +587,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
+dependencies = [
+ "base64",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +757,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +813,15 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "pem"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+dependencies = [
+ "base64",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1050,6 +1119,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,6 +1207,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1257,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqlparser"
@@ -1540,6 +1642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,6 +1707,70 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "which"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "indexmap",
+ "once_cell",
  "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -189,10 +204,13 @@ name = "databroker-cli"
 version = "0.3.1"
 dependencies = [
  "ansi_term",
+ "clap",
  "databroker-proto",
+ "http",
  "linefeed",
  "prost",
  "prost-types",
+ "regex",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -432,6 +450,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -971,7 +995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.3.3",
  "itertools",
  "lazy_static",
  "log",

--- a/kuksa_databroker/README.md
+++ b/kuksa_databroker/README.md
@@ -105,14 +105,14 @@ USAGE:
     databroker [OPTIONS]
 
 OPTIONS:
-        --address <ADDR>      Bind address [default: 127.0.0.1]
-        --port <PORT>         Bind port [default: 55555]
-        --metadata <FILE(S)>  Populate data broker with metadata from a
-                              (comma-separated) list of files.
-                              [env:KUKSA_DATA_BROKER_METADATA_FILE=]
-        --dummy-metadata      Populate data broker with dummy metadata
-    -h, --help                Print help information
-    -V, --version             Print version information
+        --address <ADDR>           Bind address [env: KUKSA_DATA_BROKER_ADDR=] [default: 127.0.0.1]
+        --port <PORT>              Bind port [env: KUKSA_DATA_BROKER_PORT=] [default: 55555]
+        --metadata <FILE>...       Populate data broker with metadata from (comma-separated) list of
+                                   files [env: KUKSA_DATA_BROKER_METADATA_FILE=]
+        --jwt-public-key <FILE>    Public key used to verify JWT access tokens
+        --dummy-metadata           Populate data broker with dummy metadata
+    -h, --help                     Print help information
+    -V, --version                  Print version information
 
 ```
 
@@ -157,14 +157,15 @@ This will enable `TAB`-completion for the available properties in the client. Ru
 
 Get data points by running "get"
 ```shell
-client> get Vehicle.ADAS.CruiseControl.Error
--> Vehicle.ADAS.CruiseControl.Error: NotAvailable
+sdv.databroker.v1 > get Vehicle.ADAS.CruiseControl.IsEnabled 
+[get]  OK
+Vehicle.ADAS.CruiseControl.IsEnabled: ( NotAvailable )
 ```
 
 Set data points by running "set"
 ```shell
-client> set Vehicle.ADAS.CruiseControl.Error Nooooooo!
--> Ok
+sdv.databroker.v1 > set Vehicle.ADAS.CruiseControl.IsEnabled false
+[set]  OK
 ```
 
 ### Data Broker Query Syntax
@@ -175,13 +176,14 @@ Detailed information about the databroker rule engine can be found in [QUERY.md]
 You can try it out in the client using the subscribe command in the client:
 
 ```shell
-client> subscribe
+sdv.databroker.v1 > subscribe
 SELECT
-  Vehicle.ADAS.ABS.Error
+  Vehicle.ADAS.ABS.IsError
 WHERE
-  Vehicle.ADAS.ABS.IsActive
+  Vehicle.ADAS.ABS.IsEngaged
 
--> status: OK
+[subscribe]  OK
+Subscription is now running in the background. Received data is identified by [1].
 ```
 
 ### Configuration
@@ -192,6 +194,7 @@ WHERE
 | dummy-metadata | <no active>   | --dummy-metadata | <no active>                       | Populate data broker with dummy metadata     |
 | listen_address | "127.0.0.1"   | --address        | KUKSA_DATA_BROKER_ADDR            | Listen for rpc calls                         |
 | listen_port    | 55555         | --port           | KUKSA_DATA_BROKER_PORT            | Listen for rpc calls                         |
+| jwt-public-key | <no active>   | --jwt-public-key | <no active>                       | Public key used to verify JWT access tokens
 
 To change the default configuration use the arguments during startup see [run section](#running) or environment variables.
 

--- a/kuksa_databroker/databroker-cli/Cargo.toml
+++ b/kuksa_databroker/databroker-cli/Cargo.toml
@@ -32,3 +32,10 @@ tokio = { version = "1.17.0", features = [
 tokio-stream = { version = "0.1.8", features = ["sync"] }
 linefeed = "0.6"
 ansi_term = "0.12"
+clap = { version = "3.1.10", default-features = false, features = [
+    "std",
+    "env",
+    "derive",
+] }
+regex = "1.6.0"
+http = "0.2.8"

--- a/kuksa_databroker/databroker-cli/src/client.rs
+++ b/kuksa_databroker/databroker-cli/src/client.rs
@@ -1,0 +1,188 @@
+/********************************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License 2.0 which is available at
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+use std::collections::HashMap;
+
+use databroker_proto::sdv::databroker as proto;
+use http::Uri;
+use tokio_stream::wrappers::BroadcastStream;
+use tonic::transport::Channel;
+
+pub struct Client {
+    pub uri: Uri,
+    pub channel: Option<tonic::transport::Channel>,
+    connection_state_subs: Option<tokio::sync::broadcast::Sender<ConnectionState>>,
+}
+
+#[derive(Clone)]
+pub enum ConnectionState {
+    Connected,
+    Disconnected,
+}
+
+#[derive(Debug)]
+pub enum ClientError {
+    Connection(String),
+    Status(tonic::Status),
+}
+
+impl std::error::Error for ClientError {}
+impl std::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClientError::Connection(con) => f.pad(con),
+            ClientError::Status(status) => f.pad(&format!("{status}")),
+        }
+    }
+}
+
+impl Client {
+    pub fn new(uri: Uri) -> Self {
+        Client {
+            uri,
+            channel: None,
+            connection_state_subs: None,
+        }
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.channel.is_some()
+    }
+
+    pub fn subscribe_to_connection_state(&mut self) -> BroadcastStream<ConnectionState> {
+        match &self.connection_state_subs {
+            Some(stream) => BroadcastStream::new(stream.subscribe()),
+            None => {
+                let (tx, rx1) = tokio::sync::broadcast::channel(1);
+                self.connection_state_subs = Some(tx);
+                BroadcastStream::new(rx1)
+            }
+        }
+    }
+
+    async fn try_create_channel(&mut self) -> Result<&Channel, ClientError> {
+        match tonic::transport::Channel::builder(self.uri.clone())
+            .connect()
+            .await
+        {
+            Ok(channel) => {
+                if let Some(subs) = &self.connection_state_subs {
+                    subs.send(ConnectionState::Connected).map_err(|err| {
+                        ClientError::Connection(format!(
+                            "Failed to notify connection state change: {err}"
+                        ))
+                    })?;
+                }
+                self.channel = Some(channel);
+                Ok(self.channel.as_ref().expect("Channel should exist"))
+            }
+            Err(err) => {
+                if let Some(subs) = &self.connection_state_subs {
+                    subs.send(ConnectionState::Disconnected).unwrap_or_default();
+                }
+                Err(ClientError::Connection(format!(
+                    "Failed to connect to {}: {}",
+                    self.uri, err
+                )))
+            }
+        }
+    }
+
+    pub async fn try_connect(&mut self) -> Result<(), ClientError> {
+        self.try_create_channel().await?;
+        Ok(())
+    }
+
+    pub async fn try_connect_to(&mut self, uri: tonic::transport::Uri) -> Result<(), ClientError> {
+        self.uri = uri;
+        self.try_create_channel().await?;
+        Ok(())
+    }
+
+    pub async fn get_channel(&mut self) -> Result<&Channel, ClientError> {
+        if self.channel.is_none() {
+            self.try_create_channel().await
+        } else {
+            match &self.channel {
+                Some(channel) => Ok(channel),
+                None => unreachable!(),
+            }
+        }
+    }
+
+    pub async fn get_metadata(
+        &mut self,
+        paths: Vec<String>,
+    ) -> Result<Vec<proto::v1::Metadata>, ClientError> {
+        let mut client =
+            proto::v1::broker_client::BrokerClient::new(self.get_channel().await?.clone());
+        // Empty vec == all property metadata
+        let args = tonic::Request::new(proto::v1::GetMetadataRequest { names: paths });
+        match client.get_metadata(args).await {
+            Ok(response) => {
+                let message = response.into_inner();
+                Ok(message.list)
+            }
+            Err(err) => Err(ClientError::Status(err)),
+        }
+    }
+
+    pub async fn get_datapoints(
+        &mut self,
+        paths: Vec<impl AsRef<str>>,
+    ) -> Result<
+        HashMap<std::string::String, databroker_proto::sdv::databroker::v1::Datapoint>,
+        ClientError,
+    > {
+        let mut client =
+            proto::v1::broker_client::BrokerClient::new(self.get_channel().await?.clone());
+        let args = tonic::Request::new(proto::v1::GetDatapointsRequest {
+            datapoints: paths.iter().map(|path| path.as_ref().into()).collect(),
+        });
+        match client.get_datapoints(args).await {
+            Ok(response) => {
+                let message = response.into_inner();
+                Ok(message.datapoints)
+            }
+            Err(err) => Err(ClientError::Status(err)),
+        }
+    }
+
+    pub async fn subscribe(
+        &mut self,
+        query: String,
+    ) -> Result<tonic::Streaming<proto::v1::SubscribeReply>, ClientError> {
+        let mut client =
+            proto::v1::broker_client::BrokerClient::new(self.get_channel().await?.clone());
+        let args = tonic::Request::new(proto::v1::SubscribeRequest { query });
+
+        match client.subscribe(args).await {
+            Ok(response) => Ok(response.into_inner()),
+            Err(err) => Err(ClientError::Status(err)),
+        }
+    }
+
+    pub async fn update_datapoints(
+        &mut self,
+        datapoints: HashMap<i32, proto::v1::Datapoint>,
+    ) -> Result<proto::v1::UpdateDatapointsReply, ClientError> {
+        let mut client =
+            proto::v1::collector_client::CollectorClient::new(self.get_channel().await?.clone());
+
+        let request = tonic::Request::new(proto::v1::UpdateDatapointsRequest { datapoints });
+        match client.update_datapoints(request).await {
+            Ok(response) => Ok(response.into_inner()),
+            Err(err) => Err(ClientError::Status(err)),
+        }
+    }
+}

--- a/kuksa_databroker/databroker-cli/src/main.rs
+++ b/kuksa_databroker/databroker-cli/src/main.rs
@@ -228,6 +228,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             match client.set_access_token(args) {
                                 Ok(()) => {
                                     print_info("Access token set.")?;
+                                    match client.get_metadata(vec![]).await {
+                                        Ok(metadata) => {
+                                            interface.set_completer(Arc::new(
+                                                CliCompleter::from_metadata(&metadata),
+                                            ));
+                                            properties = metadata;
+                                        }
+                                        Err(ClientError::Status(status)) => {
+                                            print_resp_err("metadata", &status)?;
+                                        }
+                                        Err(ClientError::Connection(msg)) => {
+                                            print_error("metadata", msg)?;
+                                        }
+                                    }
                                 }
                                 Err(err) => print_error(cmd, &format!("Malformed token: {err}"))?,
                             }
@@ -243,7 +257,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             let token_filename = args.trim();
                             match std::fs::read_to_string(token_filename) {
                                 Ok(token) => match client.set_access_token(token) {
-                                    Ok(()) => print_info("Access token set.")?,
+                                    Ok(()) => {
+                                        print_info("Access token set.")?;
+                                        match client.get_metadata(vec![]).await {
+                                            Ok(metadata) => {
+                                                interface.set_completer(Arc::new(
+                                                    CliCompleter::from_metadata(&metadata),
+                                                ));
+                                                properties = metadata;
+                                            }
+                                            Err(ClientError::Status(status)) => {
+                                                print_resp_err("metadata", &status)?;
+                                            }
+                                            Err(ClientError::Connection(msg)) => {
+                                                print_error("metadata", msg)?;
+                                            }
+                                        }
+                                    }
                                     Err(err) => {
                                         print_error(cmd, &format!("Malformed token: {err}"))?
                                     }

--- a/kuksa_databroker/databroker-cli/src/main.rs
+++ b/kuksa_databroker/databroker-cli/src/main.rs
@@ -11,110 +11,68 @@
 * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
-extern crate ansi_term;
-extern crate linefeed;
-
+use client::{ClientError, ConnectionState};
 use databroker_proto::sdv::databroker as proto;
+use http::uri::Uri;
 use prost_types::Timestamp;
+use tokio_stream::StreamExt;
 
 use std::collections::HashMap;
+use std::io::Write;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use std::{fmt, io};
 
 use ansi_term::Color;
 
+use clap::{Parser, Subcommand};
+
 use linefeed::complete::{Completer, Completion, Suffix};
 use linefeed::terminal::Terminal;
 use linefeed::{Command, DefaultTerminal, Function, Interface, Prompter, ReadResult};
 
+mod client;
+
 const TIMEOUT: Duration = Duration::from_millis(500);
 
-const CLI_COMMANDS: &[(&str, &str)] = &[
-    ("get", "Get a HAL property"),
-    ("set", "Set a HAL property"),
-    ("feed", "Set a HAL property (from vehicle side)"),
-    ("connect", "Connect"),
-    ("subscribe", "Subscribe to properties"),
-    ("metadata", "Get datapoint metadata"),
-    ("help", "You're looking at it"),
-    ("quit", "Quit the demo"),
+const CLI_COMMANDS: &[(&str, &str, &str)] = &[
+    ("connect", "[URI]", "Connect to server"),
+    ("get", "<PATH> [[PATH] ...]", "Get signal value(s)"),
+    ("set", "<PATH> <VALUE>", "Set actuator signal"),
+    ("subscribe", "<QUERY>", "Subscribe to signals with QUERY"),
+    ("feed", "<PATH> <VALUE>", "Publish signal value"),
+    (
+        "metadata",
+        "[PATTERN]",
+        "Fetch metadata. Provide PATTERN to list metadata of signals matching pattern.",
+    ),
+    ("help", "", "You're looking at it."),
+    ("quit", "", "Quit"),
 ];
 
-static APP_NAME: &str = "client";
+#[derive(Debug, Parser)]
+#[clap(author, version, about, long_about = None)]
+struct Cli {
+    /// Server to connect to
+    #[clap(long, display_order = 1, default_value = "http://127.0.0.1:55555")]
+    server: String,
 
-fn set_connected_prompt(interface: &Arc<Interface<DefaultTerminal>>) {
-    let connected_prompt = format!(
-        "\x01{prefix}\x02{text}\x01{suffix}\x02> ",
-        prefix = Color::Green.bold().prefix(),
-        text = APP_NAME,
-        suffix = Color::Green.bold().suffix()
-    );
-    interface.set_prompt(&connected_prompt).unwrap();
+    // #[clap(short, long)]
+    // port: Option<u16>,
+
+    // Sub command
+    #[clap(subcommand)]
+    command: Option<Commands>,
 }
 
-fn set_disconnected_prompt(interface: &Arc<Interface<DefaultTerminal>>) {
-    let disconnected_prompt = format!(
-        "\x01{prefix}\x02{text}\x01{suffix}\x02> ",
-        prefix = Color::Red.bold().prefix(),
-        text = APP_NAME,
-        suffix = Color::Red.bold().suffix()
-    );
-    interface.set_prompt(&disconnected_prompt).unwrap();
-}
-
-fn addr_to_uri(addr: impl AsRef<str>) -> Option<tonic::transport::Uri> {
-    match addr.as_ref().parse::<tonic::transport::Uri>() {
-        Ok(uri) => {
-            let mut parts = uri.into_parts();
-
-            if parts.scheme.is_none() {
-                parts.scheme = Some("http".parse().unwrap());
-            }
-            if parts.path_and_query.is_none() {
-                parts.path_and_query = Some("".parse().unwrap());
-            }
-            Some(tonic::transport::Uri::from_parts(parts).unwrap())
-        }
-        Err(_) => None,
-    }
-}
-
-async fn connect(
-    uri: &tonic::transport::Uri,
-    interface: &Arc<Interface<DefaultTerminal>>,
-) -> Option<tonic::transport::Channel> {
-    match tonic::transport::Channel::builder(uri.clone())
-        .connect()
-        .await
-    {
-        Ok(connection) => {
-            set_connected_prompt(interface);
-            Some(connection)
-        }
-        Err(err) => {
-            set_disconnected_prompt(interface);
-            writeln!(interface, "{err}").unwrap();
-            None
-        }
-    }
-}
-
-async fn get_metadata(channel: &tonic::transport::Channel) -> Option<Vec<proto::v1::Metadata>> {
-    let mut client = proto::v1::broker_client::BrokerClient::new(channel.clone());
-    // Empty vec == all property metadata
-    let args = tonic::Request::new(proto::v1::GetMetadataRequest { names: Vec::new() });
-    match client.get_metadata(args).await {
-        Ok(response) => {
-            let message = response.into_inner();
-            Some(message.list)
-        }
-        Err(err) => {
-            println!("-> status: {}", code_to_text(&err.code()));
-            println!("{}", err.message());
-            None
-        }
-    }
+#[derive(Debug, Subcommand)]
+enum Commands {
+    /// Get one or more datapoint(s)
+    Get {
+        #[clap(value_name = "PATH")]
+        paths: Vec<String>,
+    },
+    // Subscribe,
 }
 
 #[tokio::main]
@@ -122,42 +80,101 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut properties = Vec::<proto::v1::Metadata>::new();
     let mut subscription_nbr = 1;
 
-    let cli = CliCompleter::new();
+    let completer = CliCompleter::new();
     let interface = Arc::new(Interface::new("client")?);
-    interface.set_completer(Arc::new(cli));
+    interface.set_completer(Arc::new(completer));
 
     interface.define_function("enter-function", Arc::new(EnterFunction));
     interface.bind_sequence("\r", Command::from_str("enter-function"));
     interface.bind_sequence("\n", Command::from_str("enter-function"));
 
-    let addr = std::env::var("KUKSA_DATA_BROKER_ADDR").unwrap_or_else(|_| "127.0.0.1".to_owned());
-    let port = std::env::var("KUKSA_DATA_BROKER_PORT").unwrap_or_else(|_| "55555".to_owned());
-    let mut uri = match addr_to_uri(format!("{addr}:{port}")) {
-        Some(uri) => uri,
-        None => return Err(Box::new(ParseError {}).into()),
-    };
+    set_disconnected_prompt(&interface);
 
-    let mut channel = connect(&uri, &interface).await;
+    let cli = Cli::parse();
 
-    if let Some(connection) = &channel {
-        if let Some(metadata) = get_metadata(connection).await {
-            interface.set_completer(Arc::new(CliCompleter::from_metadata(&metadata)));
-            properties = metadata;
+    let mut client = client::Client::new(to_uri(cli.server)?);
+
+    let mut connection_state_subscription = client.subscribe_to_connection_state();
+    let interface_ref = interface.clone();
+
+    tokio::spawn(async move {
+        while let Some(state) = connection_state_subscription.next().await {
+            match state {
+                Ok(state) => match state {
+                    ConnectionState::Connected => {
+                        set_connected_prompt(&interface_ref);
+                    }
+                    ConnectionState::Disconnected => {
+                        set_disconnected_prompt(&interface_ref);
+                    }
+                },
+                Err(err) => {
+                    print_error(
+                        "connection",
+                        format!("Connection state subscription failed: {err}"),
+                    )
+                    .unwrap_or_default();
+                }
+            }
         }
-    }
+    });
+
+    match cli.command {
+        Some(Commands::Get { paths }) => {
+            match client.get_datapoints(paths).await {
+                Ok(datapoints) => {
+                    for (name, datapoint) in datapoints {
+                        println!("{}: {}", name, DisplayDatapoint(datapoint),);
+                    }
+                }
+                Err(err) => {
+                    eprintln!("{err}");
+                }
+            }
+            return Ok(());
+        }
+        None => {
+            // No subcommand => run interactive client
+            let version = match option_env!("CARGO_PKG_VERSION") {
+                Some(version) => format!("v{version}"),
+                None => String::new(),
+            };
+            print_logo(version);
+
+            match client.try_connect().await {
+                Ok(()) => {
+                    print_info(format!("Successfully connected to {}", &client.uri))?;
+                    match client.get_metadata(vec![]).await {
+                        Ok(metadata) => {
+                            interface
+                                .set_completer(Arc::new(CliCompleter::from_metadata(&metadata)));
+                            properties = metadata;
+                        }
+                        Err(ClientError::Status(status)) => {
+                            print_resp_err("metadata", &status)?;
+                        }
+                        Err(ClientError::Connection(msg)) => {
+                            print_error("metadata", msg)?;
+                        }
+                    }
+                }
+                Err(err) => {
+                    print_error("connect", format!("{err}"))?;
+                }
+            }
+        }
+    };
 
     loop {
         if let Some(res) = interface.read_line_step(Some(TIMEOUT))? {
             match res {
                 ReadResult::Input(line) => {
-                    // println!("input: {:?}", line);
                     let (cmd, args) = split_first_word(&line);
                     match cmd {
                         "help" => {
-                            println!("{APP_NAME} commands:");
                             println!();
-                            for &(cmd, help) in CLI_COMMANDS {
-                                println!("  {cmd:15} - {help}");
+                            for &(cmd, args, help) in CLI_COMMANDS {
+                                println!("  {:24} {}", format!("{cmd} {args}"), help);
                             }
                             println!();
                         }
@@ -165,56 +182,42 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             interface.add_history_unique(line.clone());
 
                             if args.is_empty() {
-                                println!("Usage: get PROPERTY_NAME");
+                                print_usage(cmd);
                                 continue;
                             }
-
-                            match &channel {
-                                Some(channel) => {
-                                    let mut client = proto::v1::broker_client::BrokerClient::new(
-                                        channel.clone(),
-                                    );
-                                    let args =
-                                        tonic::Request::new(proto::v1::GetDatapointsRequest {
-                                            datapoints: vec![args.to_owned()],
-                                        });
-                                    match client.get_datapoints(args).await {
-                                        Ok(response) => {
-                                            let message = response.into_inner();
-                                            for (name, datapoint) in message.datapoints {
-                                                println!(
-                                                    "-> {}: {}",
-                                                    name,
-                                                    DisplayDatapoint(datapoint)
-                                                )
-                                            }
-                                            set_connected_prompt(&interface);
-                                        }
-                                        Err(err) => {
-                                            println!("-> status: {}", code_to_text(&err.code()));
-                                            println!("{}", err.message());
-                                            // interface.set_prompt(&disconnected_prompt)?;
-                                        }
+                            let paths = args
+                                .split_whitespace()
+                                .map(|path| path.to_owned())
+                                .collect();
+                            match client.get_datapoints(paths).await {
+                                Ok(datapoints) => {
+                                    print_resp_ok(cmd)?;
+                                    for (name, datapoint) in datapoints {
+                                        println!("{}: {}", name, DisplayDatapoint(datapoint),);
                                     }
                                 }
-                                None => println!("Not connected"),
+                                Err(ClientError::Status(err)) => {
+                                    print_resp_err(cmd, &err)?;
+                                }
+                                Err(ClientError::Connection(msg)) => {
+                                    print_error(cmd, msg)?;
+                                }
                             }
                         }
-
                         "set" => {
                             interface.add_history_unique(line.clone());
 
-                            let (prop, value) = split_first_word(args);
+                            let (path, value) = split_first_word(args);
 
                             if value.is_empty() {
-                                println!("Usage: set ID VALUE");
+                                print_usage(cmd);
                                 continue;
                             }
 
                             let datapoint_metadata = {
                                 let mut datapoint_metadata = None;
                                 for metadata in properties.iter() {
-                                    if metadata.name == prop {
+                                    if metadata.name == path {
                                         datapoint_metadata = Some(metadata)
                                     }
                                 }
@@ -222,7 +225,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             };
 
                             if datapoint_metadata.is_none() {
-                                println!("Could not map name to id");
+                                print_info(format!(
+                                    "No metadata available for {path}. Needed to determine data type for serialization."
+                                ))?;
                                 continue;
                             }
 
@@ -233,83 +238,76 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 );
                                 if data_value.is_err() {
                                     println!(
-                                        "Could not parse \"{}\" as {:?}",
-                                        value,
+                                        "Could not parse \"{value}\" as {:?}",
                                         proto::v1::DataType::from_i32(metadata.data_type).unwrap()
                                     );
                                     continue;
                                 }
-                                match &channel {
-                                    Some(channel) => {
-                                        let mut client =
-                                            proto::v1::broker_client::BrokerClient::new(
-                                                channel.clone(),
-                                            );
-                                        let ts = Timestamp::from(SystemTime::now());
-                                        let datapoints = HashMap::from([(
-                                            metadata.name.clone(),
-                                            proto::v1::Datapoint {
-                                                timestamp: Some(ts),
-                                                value: Some(data_value.unwrap()),
-                                            },
-                                        )]);
-                                        let request =
-                                            tonic::Request::new(proto::v1::SetDatapointsRequest {
-                                                datapoints,
-                                            });
 
-                                        match client.set_datapoints(request).await {
-                                            Ok(response) => {
-                                                let message = response.into_inner();
-                                                if message.errors.is_empty() {
-                                                    println!("-> Ok")
-                                                } else {
-                                                    for (id, error) in message.errors {
-                                                        match proto::v1::DatapointError::from_i32(
-                                                            error,
-                                                        ) {
-                                                            Some(error) => {
-                                                                println!(
-                                                                    "-> Error setting id {id}: {error:?}"
-                                                                )
-                                                            }
-                                                            None => {
-                                                                println!("-> Error setting id {id}")
-                                                            }
-                                                        }
+                                if metadata.entry_type != proto::v1::EntryType::Actuator.into() {
+                                    print_error(
+                                        cmd,
+                                        format!("{} is not an actuator.", metadata.name),
+                                    )?;
+                                    print_info(
+                                        "If you want to provide the signal value, use `feed`.",
+                                    )?;
+                                    continue;
+                                }
+
+                                let ts = Timestamp::from(SystemTime::now());
+                                let datapoints = HashMap::from([(
+                                    metadata.name.clone(),
+                                    proto::v1::Datapoint {
+                                        timestamp: Some(ts),
+                                        value: Some(data_value.unwrap()),
+                                    },
+                                )]);
+
+                                match client.set_datapoints(datapoints).await {
+                                    Ok(message) => {
+                                        if message.errors.is_empty() {
+                                            print_resp_ok(cmd)?;
+                                        } else {
+                                            for (id, error) in message.errors {
+                                                match proto::v1::DatapointError::from_i32(error) {
+                                                    Some(error) => {
+                                                        print_resp_ok(cmd)?;
+                                                        println!(
+                                                            "Error setting {}: {}",
+                                                            id,
+                                                            Color::Red.paint(format!("{error:?}")),
+                                                        );
                                                     }
+                                                    None => print_resp_ok_fmt(
+                                                        cmd,
+                                                        format_args!("Error setting id {id}"),
+                                                    )?,
                                                 }
-
-                                                // interface.set_prompt(&connected_prompt)?;
-                                            }
-                                            Err(err) => {
-                                                println!(
-                                                    "-> status: {}",
-                                                    code_to_text(&err.code())
-                                                );
-                                                println!("{}", err.message());
-                                                // interface.set_prompt(&disconnected_prompt)?;
                                             }
                                         }
                                     }
-                                    None => println!("Not connected"),
+                                    Err(ClientError::Status(status)) => {
+                                        print_resp_err(cmd, &status)?
+                                    }
+                                    Err(ClientError::Connection(msg)) => print_error(cmd, msg)?,
                                 }
                             }
                         }
                         "feed" => {
                             interface.add_history_unique(line.clone());
 
-                            let (prop, value) = split_first_word(args);
+                            let (path, value) = split_first_word(args);
 
                             if value.is_empty() {
-                                println!("Usage: feed ID VALUE");
+                                print_usage(cmd);
                                 continue;
                             }
 
                             let datapoint_metadata = {
                                 let mut datapoint_metadata = None;
                                 for metadata in properties.iter() {
-                                    if metadata.name == prop {
+                                    if metadata.name == path {
                                         datapoint_metadata = Some(metadata)
                                     }
                                 }
@@ -317,7 +315,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             };
 
                             if datapoint_metadata.is_none() {
-                                println!("Could not map name to id");
+                                print_info(
+                                    format!("No metadata available for {path}. Needed to determine data type for serialization."),
+                                )?;
                                 continue;
                             }
 
@@ -334,58 +334,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     );
                                     continue;
                                 }
-                                match &channel {
-                                    Some(channel) => {
-                                        let mut client =
-                                            proto::v1::collector_client::CollectorClient::new(
-                                                channel.clone(),
-                                            );
-                                        let ts = Timestamp::from(SystemTime::now());
-                                        let datapoints = HashMap::from([(
-                                            metadata.id,
-                                            proto::v1::Datapoint {
-                                                timestamp: Some(ts),
-                                                value: Some(data_value.unwrap()),
-                                            },
-                                        )]);
-                                        let request = tonic::Request::new(
-                                            proto::v1::UpdateDatapointsRequest { datapoints },
-                                        );
-                                        match client.update_datapoints(request).await {
-                                            Ok(response) => {
-                                                let message = response.into_inner();
-                                                if message.errors.is_empty() {
-                                                    println!("-> Ok")
-                                                } else {
-                                                    for (id, error) in message.errors {
-                                                        match proto::v1::DatapointError::from_i32(
-                                                            error,
-                                                        ) {
-                                                            Some(error) => {
-                                                                println!(
-                                                                    "-> Error setting id {id}: {error:?}"
-                                                                )
-                                                            }
-                                                            None => {
-                                                                println!("-> Error setting id {id}")
-                                                            }
-                                                        }
-                                                    }
+                                let ts = Timestamp::from(SystemTime::now());
+                                let datapoints = HashMap::from([(
+                                    metadata.id,
+                                    proto::v1::Datapoint {
+                                        timestamp: Some(ts),
+                                        value: Some(data_value.unwrap()),
+                                    },
+                                )]);
+                                match client.update_datapoints(datapoints).await {
+                                    Ok(message) => {
+                                        if message.errors.is_empty() {
+                                            print_resp_ok(cmd)?
+                                        } else {
+                                            for (id, error) in message.errors {
+                                                match proto::v1::DatapointError::from_i32(error) {
+                                                    Some(error) => print_resp_ok_fmt(
+                                                        cmd,
+                                                        format_args!(
+                                                            "Error setting id {id}: {error:?}"
+                                                        ),
+                                                    )?,
+                                                    None => print_resp_ok_fmt(
+                                                        cmd,
+                                                        format_args!("Error setting id {id}"),
+                                                    )?,
                                                 }
-
-                                                // interface.set_prompt(&connected_prompt)?;
-                                            }
-                                            Err(err) => {
-                                                println!(
-                                                    "-> status: {}",
-                                                    code_to_text(&err.code())
-                                                );
-                                                println!("{}", err.message());
-                                                // interface.set_prompt(&disconnected_prompt)?;
                                             }
                                         }
                                     }
-                                    None => println!("Not connected"),
+                                    Err(ClientError::Status(status)) => {
+                                        print_resp_err(cmd, &status)?
+                                    }
+                                    Err(ClientError::Connection(msg)) => print_error(cmd, msg)?,
                                 }
                             }
                         }
@@ -393,125 +374,229 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             interface.add_history_unique(line.clone());
 
                             if args.is_empty() {
-                                println!("Usage: subscribe QUERY");
+                                print_usage(cmd);
                                 continue;
                             }
 
                             let query = args.to_owned();
 
-                            match &channel {
-                                Some(channel) => {
-                                    let mut client = proto::v1::broker_client::BrokerClient::new(
-                                        channel.clone(),
-                                    );
+                            match client.subscribe(query).await {
+                                Ok(mut subscription) => {
                                     let iface = interface.clone();
-                                    let args =
-                                        tonic::Request::new(proto::v1::SubscribeRequest { query });
-                                    match client.subscribe(args).await {
-                                        Ok(response) => {
-                                            let sub_id = format!("subscription{subscription_nbr}");
-                                            subscription_nbr += 1;
-                                            tokio::spawn(async move {
-                                                let mut stream = response.into_inner();
-                                                loop {
-                                                    match stream.message().await {
-                                                        Ok(subscribe_resp) => {
-                                                            if let Some(resp) = subscribe_resp {
-                                                                // Build output before writing it
-                                                                // (to avoid interleaving confusion)
-                                                                use std::fmt::Write;
-                                                                let mut output = String::new();
-                                                                for (name, value) in resp.fields {
-                                                                    writeln!(
-                                                                        output,
-                                                                        "{}: {}",
-                                                                        name,
-                                                                        DisplayDatapoint(value)
-                                                                    )
-                                                                    .unwrap();
-                                                                }
-                                                                writeln!(
-                                                                    iface,
-                                                                    "-> {sub_id}:\n{output}"
+                                    tokio::spawn(async move {
+                                        let sub_disp = format!("[{subscription_nbr}]");
+                                        let sub_disp_pad = " ".repeat(sub_disp.len());
+                                        let sub_disp_color =
+                                            format!("{}", Color::White.dimmed().paint(&sub_disp));
+
+                                        loop {
+                                            match subscription.message().await {
+                                                Ok(subscribe_resp) => {
+                                                    if let Some(resp) = subscribe_resp {
+                                                        // Build output before writing it
+                                                        // (to avoid interleaving confusion)
+                                                        use std::fmt::Write;
+                                                        let mut output = String::new();
+                                                        let mut first_line = true;
+                                                        for (name, value) in resp.fields {
+                                                            if first_line {
+                                                                first_line = false;
+                                                                write!(
+                                                                    output,
+                                                                    "{} ",
+                                                                    &sub_disp_color,
+                                                                )
+                                                                .unwrap();
+                                                            } else {
+                                                                write!(
+                                                                    output,
+                                                                    "{} ",
+                                                                    &sub_disp_pad,
                                                                 )
                                                                 .unwrap();
                                                             }
-                                                        }
-                                                        Err(_) => {
                                                             writeln!(
-                                                                iface,
-                                                                "Server gone. Subscription stopped"
+                                                                output,
+                                                                "{}: {}",
+                                                                name,
+                                                                DisplayDatapoint(value)
                                                             )
                                                             .unwrap();
-                                                            break;
                                                         }
+                                                        write!(iface, "{output}").unwrap();
+                                                    } else {
+                                                        writeln!(
+                                                            iface,
+                                                            "{} {}",
+                                                            Color::Red.dimmed().paint(&sub_disp),
+                                                            Color::White.dimmed().paint(
+                                                                "Server gone. Subscription stopped"
+                                                            ),
+                                                        )
+                                                        .unwrap();
+                                                        break;
                                                     }
                                                 }
-                                            });
-                                            println!("-> status: OK")
+                                                Err(err) => {
+                                                    write!(
+                                                        iface,
+                                                        "{} {}",
+                                                        &sub_disp_color,
+                                                        Color::Red
+                                                            .dimmed()
+                                                            .paint(format!("Channel error: {err}"))
+                                                    )
+                                                    .unwrap();
+                                                    break;
+                                                }
+                                            }
                                         }
-                                        Err(err) => {
-                                            println!("-> status: {}", code_to_text(&err.code()));
-                                            println!("{}", err.message());
-                                            // interface.set_prompt(&disconnected_prompt)?;
-                                        }
-                                    }
+                                    });
+
+                                    print_resp_ok(cmd)?;
+                                    print_info(format!(
+                                                    "Subscription is now running in the background. Received data is identified by [{subscription_nbr}]."
+                                                )
+                                            )?;
+                                    subscription_nbr += 1;
                                 }
-                                None => println!("Not connected"),
+                                Err(ClientError::Status(status)) => print_resp_err(cmd, &status)?,
+                                Err(ClientError::Connection(msg)) => print_error(cmd, msg)?,
                             }
-                            // }
                         }
                         "connect" => {
                             interface.add_history_unique(line.clone());
-                            if channel.is_none() || !args.is_empty() {
+                            if !client.is_connected() || !args.is_empty() {
                                 if args.is_empty() {
-                                    channel = connect(&uri, &interface).await
-                                } else {
-                                    match addr_to_uri(args) {
-                                        Some(valid_uri) => {
-                                            uri = valid_uri;
-                                            channel = connect(&uri, &interface).await
+                                    match client.try_connect().await {
+                                        Ok(()) => {
+                                            print_info(format!(
+                                                "Successfully connected to {}",
+                                                &client.uri
+                                            ))?;
                                         }
-                                        None => println!("Failed to parse endpoint address"),
+                                        Err(err) => {
+                                            print_error(cmd, format!("{err}"))?;
+                                        }
+                                    }
+                                } else {
+                                    match to_uri(args) {
+                                        Ok(valid_uri) => {
+                                            match client.try_connect_to(valid_uri).await {
+                                                Ok(()) => {
+                                                    print_info(format!(
+                                                        "Successfully connected to {}",
+                                                        &client.uri
+                                                    ))?;
+                                                }
+                                                Err(err) => {
+                                                    print_error(cmd, format!("{err}"))?;
+                                                }
+                                            }
+                                        }
+                                        Err(err) => {
+                                            print_error(
+                                                cmd,
+                                                format!("Failed to parse endpoint address: {err}"),
+                                            )?;
+                                        }
                                     }
                                 };
-                                if let Some(connection) = &channel {
-                                    if let Some(metadata) = get_metadata(connection).await {
-                                        interface.set_completer(Arc::new(
-                                            CliCompleter::from_metadata(&metadata),
-                                        ));
-                                        properties = metadata;
+                                if client.is_connected() {
+                                    match client.get_metadata(vec![]).await {
+                                        Ok(metadata) => {
+                                            interface.set_completer(Arc::new(
+                                                CliCompleter::from_metadata(&metadata),
+                                            ));
+                                            properties = metadata;
+                                        }
+                                        Err(ClientError::Status(status)) => {
+                                            print_resp_err("metadata", &status)?;
+                                        }
+                                        Err(ClientError::Connection(msg)) => {
+                                            print_error("metadata", msg)?;
+                                        }
                                     }
                                 }
                             };
                         }
                         "metadata" => {
                             interface.add_history_unique(line.clone());
-                            match &channel {
-                                Some(channel) => {
-                                    if let Some(metadata) = get_metadata(channel).await {
-                                        for entry in &metadata {
-                                            println!(
-                                                "{}, data_type: {}",
-                                                entry.name, entry.data_type
-                                            );
-                                        }
-                                        properties = metadata;
-                                        interface.set_completer(Arc::new(
-                                            CliCompleter::from_metadata(&properties),
-                                        ));
-                                    }
+
+                            let paths = args.split_whitespace().collect::<Vec<_>>();
+                            match client.get_metadata(vec![]).await {
+                                Ok(mut metadata) => {
+                                    metadata.sort_by(|a, b| a.name.cmp(&b.name));
+                                    properties = metadata;
+                                    interface.set_completer(Arc::new(CliCompleter::from_metadata(
+                                        &properties,
+                                    )));
+                                    print_resp_ok(cmd)?;
                                 }
-                                None => println!("Not connected"),
+                                Err(ClientError::Status(status)) => {
+                                    print_resp_err(cmd, &status)?;
+                                }
+                                Err(ClientError::Connection(msg)) => {
+                                    print_error(cmd, msg)?;
+                                }
+                            }
+                            let mut filtered_metadata = Vec::new();
+                            if paths.is_empty() {
+                                print_info("If you want to list metadata of signals, use `metadata PATTERN`")?;
+                                // filtered_metadata.extend(&properties);
+                            } else {
+                                for path in &paths {
+                                    let path_re = path_to_regex(path);
+                                    let filtered =
+                                        properties.iter().filter(|item| match &path_re {
+                                            Ok(re) => re.is_match(&item.name),
+                                            Err(err) => {
+                                                print_info(format!("Invalid path: {err}"))
+                                                    .unwrap_or_default();
+                                                false
+                                            }
+                                        });
+                                    filtered_metadata.extend(filtered);
+                                }
+                            }
+
+                            if !filtered_metadata.is_empty() {
+                                let max_len_path =
+                                    filtered_metadata.iter().fold(0, |mut max_len, item| {
+                                        if item.name.len() > max_len {
+                                            max_len = item.name.len();
+                                        }
+                                        max_len
+                                    });
+
+                                print_info(format!(
+                                    "{:<max_len_path$} {:<10} {:<9}",
+                                    "Path", "Entry type", "Data type"
+                                ))?;
+
+                                for entry in &filtered_metadata {
+                                    println!(
+                                        "{:<max_len_path$} {:<10} {:<9}",
+                                        entry.name,
+                                        DisplayEntryType::from(proto::v1::EntryType::from_i32(
+                                            entry.entry_type
+                                        )),
+                                        DisplayDataType::from(proto::v1::DataType::from_i32(
+                                            entry.data_type
+                                        )),
+                                    );
+                                }
                             }
                         }
-                        "quit" => {
+                        "quit" | "exit" => {
                             println!("Bye bye!");
                             break;
                         }
                         "" => {} // Ignore empty input
                         _ => {
-                            println!("unknown command");
+                            println!(
+                                "Unknown command. See `help` for a list of available commands."
+                            );
                             interface.add_history_unique(line.clone());
                         }
                     }
@@ -521,15 +606,109 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     break;
                 }
                 ReadResult::Signal(sig) => {
-                    println!("received signal: {sig:?}");
+                    // println!("received signal: {:?}", sig);
+                    if sig == linefeed::Signal::Interrupt {
+                        interface.cancel_read_line()?;
+                    }
+
+                    let _ = writeln!(interface, "signal received: {sig:?}");
                 }
             }
         }
-
-        // interface.set_prompt("disconnected> ")?;
     }
 
     Ok(())
+}
+
+fn print_usage(command: impl AsRef<str>) {
+    for (cmd, usage, _) in CLI_COMMANDS {
+        if *cmd == command.as_ref() {
+            println!("Usage: {cmd} {usage}");
+        }
+    }
+}
+
+fn print_logo(version: impl fmt::Display) {
+    let mut output = io::stderr().lock();
+    writeln!(output).unwrap();
+    writeln!(
+        output,
+        "  {}{}",
+        Color::Fixed(23).paint("⠀⠀⠀⢀⣤⣶⣾⣿"),
+        Color::White.dimmed().paint("⢸⣿⣿⣷⣶⣤⡀")
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  {}{}",
+        Color::Fixed(23).paint("⠀⠀⣴⣿⡿⠋⣿⣿"),
+        Color::White.dimmed().paint("⠀⠀⠀⠈⠙⢿⣿⣦⠀")
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  {}{}",
+        Color::Fixed(23).paint("⠀⣾⣿⠋⠀⠀⣿⣿"),
+        Color::White.dimmed().paint("⠀⠀⣶⣿⠀⠀⠙⣿⣷   ")
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  {}{}",
+        Color::Fixed(23).paint("⣸⣿⠇⠀⠀⠀⣿⣿"),
+        Color::White
+            .dimmed()
+            .paint("⠠⣾⡿⠃⠀⠀⠀⠸⣿⣇⠀⠀⣶⠀⣠⡶⠂⠀⣶⠀⠀⢰⡆⠀⢰⡆⢀⣴⠖⠀⢠⡶⠶⠶⡦⠀⠀⠀⣰⣶⡀")
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  {}{}",
+        Color::Fixed(23).paint("⣿⣿⠀⠀⠀⠀⠿⢿⣷⣦⡀"),
+        Color::White
+            .dimmed()
+            .paint("⠀⠀⠀⠀⠀⣿⣿⠀⠀⣿⢾⣏⠀⠀⠀⣿⠀⠀⢸⡇⠀⢸⡷⣿⡁⠀⠀⠘⠷⠶⠶⣦⠀⠀⢠⡟⠘⣷")
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  {}{}{}{}",
+        Color::Fixed(23).paint("⢹⣿⡆⠀⠀⠀"),
+        Color::White.dimmed().paint("⣿⣶"),
+        Color::Fixed(23).paint("⠈⢻⣿⡆"),
+        Color::White
+            .dimmed()
+            .paint("⠀⠀⠀⢰⣿⡏⠀⠀⠿⠀⠙⠷⠄⠀⠙⠷⠶⠟⠁⠀⠸⠇⠈⠻⠦⠀⠐⠷⠶⠶⠟⠀⠠⠿⠁⠀⠹⠧")
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  {}{}{}{}",
+        Color::Fixed(23).paint("⠀⢿⣿⣄⠀⠀"),
+        Color::White.dimmed().paint("⣿⣿"),
+        Color::Fixed(23).paint("⠀⠀⠿⣿"),
+        Color::White.dimmed().paint("⠀⠀⣠⣿⡿"),
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  {}{}    {}",
+        Color::Fixed(23).paint("⠀⠀⠻⣿⣷⡄"),
+        Color::White.dimmed().paint("⣿⣿⠀⠀⠀⢀⣠⣾⣿⠟"),
+        Color::White
+            .dimmed()
+            .paint(format!("{:<30}", "databroker-cli")),
+    )
+    .unwrap();
+    writeln!(
+        output,
+        "  {}{}     {}",
+        Color::Fixed(23).paint("⠀⠀⠀⠈⠛⠇"),
+        Color::White.dimmed().paint("⢿⣿⣿⣿⣿⡿⠿⠛⠁"),
+        Color::White.dimmed().paint(format!("{version:<30}")),
+    )
+    .unwrap();
+    writeln!(output).unwrap();
 }
 
 fn split_first_word(s: &str) -> (&str, &str) {
@@ -683,6 +862,130 @@ impl CliCompleter {
     }
 }
 
+fn set_connected_prompt(interface: &Arc<Interface<DefaultTerminal>>) {
+    let connected_prompt = format!(
+        "\x01{prefix}\x02{text}\x01{suffix}\x02 > ",
+        prefix = Color::Green.prefix(),
+        text = "sdv.databroker.v1",
+        suffix = Color::Green.suffix()
+    );
+    interface.set_prompt(&connected_prompt).unwrap();
+}
+
+fn set_disconnected_prompt(interface: &Arc<Interface<DefaultTerminal>>) {
+    let disconnected_prompt = format!(
+        "\x01{prefix}\x02{text}\x01{suffix}\x02 > ",
+        prefix = Color::Red.prefix(),
+        text = "not connected",
+        suffix = Color::Red.suffix()
+    );
+    interface.set_prompt(&disconnected_prompt).unwrap();
+}
+
+fn to_uri(uri: impl AsRef<str>) -> Result<Uri, String> {
+    let uri = uri
+        .as_ref()
+        .parse::<tonic::transport::Uri>()
+        .map_err(|err| format!("{err}"))?;
+    let mut parts = uri.into_parts();
+
+    if parts.scheme.is_none() {
+        parts.scheme = Some("http".parse().expect("http should be valid scheme"));
+    }
+
+    match &parts.authority {
+        Some(_authority) => {
+            // match (authority.port_u16(), port) {
+            //     (Some(uri_port), Some(port)) => {
+            //         if uri_port != port {
+            //             parts.authority = format!("{}:{}", authority.host(), port)
+            //                 .parse::<Authority>()
+            //                 .map_err(|err| format!("{}", err))
+            //                 .ok();
+            //         }
+            //     }
+            //     (_, _) => {}
+            // }
+        }
+        None => return Err("No server uri specified".to_owned()),
+    }
+    parts.path_and_query = Some("".parse().expect("uri path should be empty string"));
+    tonic::transport::Uri::from_parts(parts).map_err(|err| format!("{err}"))
+}
+
+fn path_to_regex(path: impl AsRef<str>) -> Result<regex::Regex, regex::Error> {
+    let path_as_re = format!(
+        // Match the whole line (from left '^' to right '$')
+        "^{}$",
+        path.as_ref().replace('.', r"\.").replace('*', r"(.*)")
+    );
+    regex::Regex::new(&path_as_re)
+}
+
+fn print_resp_err(operation: impl AsRef<str>, err: &tonic::Status) -> io::Result<()> {
+    let mut output = io::stderr().lock();
+    output.write_fmt(format_args!(
+        "{} {} {}",
+        Color::White
+            .dimmed()
+            .paint(format!("[{}]", operation.as_ref())),
+        Color::White
+            .on(Color::Red)
+            .paint(format!(" {} ", code_to_text(&err.code()))),
+        err.message(),
+    ))?;
+    output.write_all(b"\n")?;
+    output.flush()
+}
+
+fn print_resp_ok_fmt(operation: impl AsRef<str>, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+    let mut stderr = io::stderr().lock();
+    let mut stdout = io::stdout().lock();
+    write_resp_ok(&mut stderr, operation)?;
+    stdout.write_fmt(fmt)?;
+    stdout.write_all(b"\n")?;
+    stdout.flush()
+}
+
+fn print_resp_ok(operation: impl AsRef<str>) -> io::Result<()> {
+    let mut output = io::stderr().lock();
+    write_resp_ok(&mut output, operation)?;
+    output.write_all(b"\n")?;
+    output.flush()
+}
+
+fn write_resp_ok(output: &mut impl Write, operation: impl AsRef<str>) -> io::Result<()> {
+    output.write_fmt(format_args!(
+        "{} {} ",
+        Color::White
+            .dimmed()
+            .paint(format!("[{}]", operation.as_ref())),
+        Color::Black.on(Color::Green).paint(" OK "),
+    ))
+}
+
+fn print_info(info: impl AsRef<str>) -> io::Result<()> {
+    let mut output = io::stderr().lock();
+    output.write_fmt(format_args!(
+        "{}\n",
+        Color::White.dimmed().paint(info.as_ref()),
+    ))?;
+    output.flush()
+}
+
+fn print_error(operation: impl AsRef<str>, msg: impl AsRef<str>) -> io::Result<()> {
+    let mut output = io::stderr().lock();
+    output.write_fmt(format_args!(
+        "{} {} {}\n",
+        Color::White
+            .dimmed()
+            .paint(format!("[{}]", operation.as_ref())),
+        Color::White.on(Color::Red).paint(" Error "),
+        msg.as_ref(),
+    ))?;
+    output.flush()
+}
+
 impl<Term: Terminal> Completer<Term> for CliCompleter {
     fn complete(
         &self,
@@ -700,7 +1003,7 @@ impl<Term: Terminal> Completer<Term> for CliCompleter {
             None => {
                 let mut compls = Vec::new();
 
-                for &(cmd, _) in CLI_COMMANDS {
+                for &(cmd, _, _) in CLI_COMMANDS {
                     if cmd.starts_with(word) {
                         compls.push(Completion {
                             completion: cmd.to_owned(),
@@ -713,13 +1016,14 @@ impl<Term: Terminal> Completer<Term> for CliCompleter {
                 Some(compls)
             }
             // Complete command parameters
-            Some("get") | Some("set") | Some("feed") => {
+            Some("set") | Some("feed") => {
                 if words.count() == 0 {
                     self.complete_entry_path(word)
                 } else {
                     None
                 }
             }
+            Some("get") | Some("metadata") => self.complete_entry_path(word),
             Some("subscribe") => match words.next() {
                 None => Some(vec![Completion::simple("SELECT".to_owned())]),
                 Some(next) => {
@@ -746,9 +1050,12 @@ impl<Term: Terminal> Function<Term> for EnterFunction {
             .starts_with("subscribe")
         {
             if prompter.buffer().ends_with('\n') {
+                let len = prompter.buffer().len();
+                prompter.delete_range(len - 1..len)?;
                 prompter.accept_input()
             } else if count > 0 {
-                prompter.insert(count as usize, '\n')
+                // Start multiline
+                prompter.insert_str("\n")
             } else {
                 Ok(())
             }
@@ -758,6 +1065,9 @@ impl<Term: Terminal> Function<Term> for EnterFunction {
     }
 }
 
+struct DisplayDataType(Option<proto::v1::DataType>);
+struct DisplayEntryType(Option<proto::v1::EntryType>);
+struct DisplayChangeType(Option<proto::v1::ChangeType>);
 struct DisplayDatapoint(proto::v1::Datapoint);
 
 fn display_array<T>(f: &mut fmt::Formatter<'_>, array: &[T]) -> fmt::Result
@@ -779,34 +1089,18 @@ impl fmt::Display for DisplayDatapoint {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0.value {
             Some(value) => match value {
-                proto::v1::datapoint::Value::BoolValue(value) => {
-                    f.write_fmt(format_args!("{value}"))
-                }
-                proto::v1::datapoint::Value::FailureValue(failure) => f.write_fmt(format_args!(
+                proto::v1::datapoint::Value::BoolValue(value) => f.pad(&format!("{value}")),
+                proto::v1::datapoint::Value::FailureValue(failure) => f.pad(&format!(
                     "( {:?} )",
                     proto::v1::datapoint::Failure::from_i32(*failure).unwrap()
                 )),
-                proto::v1::datapoint::Value::Int32Value(value) => {
-                    f.write_fmt(format_args!("{value}"))
-                }
-                proto::v1::datapoint::Value::Int64Value(value) => {
-                    f.write_fmt(format_args!("{value}"))
-                }
-                proto::v1::datapoint::Value::Uint32Value(value) => {
-                    f.write_fmt(format_args!("{value}"))
-                }
-                proto::v1::datapoint::Value::Uint64Value(value) => {
-                    f.write_fmt(format_args!("{value}"))
-                }
-                proto::v1::datapoint::Value::FloatValue(value) => {
-                    f.write_fmt(format_args!("{value:.2}"))
-                }
-                proto::v1::datapoint::Value::DoubleValue(value) => {
-                    f.write_fmt(format_args!("{value}"))
-                }
-                proto::v1::datapoint::Value::StringValue(value) => {
-                    f.write_fmt(format_args!("'{value}'"))
-                }
+                proto::v1::datapoint::Value::Int32Value(value) => f.pad(&format!("{value}")),
+                proto::v1::datapoint::Value::Int64Value(value) => f.pad(&format!("{value}")),
+                proto::v1::datapoint::Value::Uint32Value(value) => f.pad(&format!("{value}")),
+                proto::v1::datapoint::Value::Uint64Value(value) => f.pad(&format!("{value}")),
+                proto::v1::datapoint::Value::FloatValue(value) => f.pad(&format!("{value:.2}")),
+                proto::v1::datapoint::Value::DoubleValue(value) => f.pad(&format!("{value}")),
+                proto::v1::datapoint::Value::StringValue(value) => f.pad(&format!("'{value}'")),
                 proto::v1::datapoint::Value::StringArray(array) => display_array(f, &array.values),
                 proto::v1::datapoint::Value::BoolArray(array) => display_array(f, &array.values),
                 proto::v1::datapoint::Value::Int32Array(array) => display_array(f, &array.values),
@@ -816,7 +1110,51 @@ impl fmt::Display for DisplayDatapoint {
                 proto::v1::datapoint::Value::FloatArray(array) => display_array(f, &array.values),
                 proto::v1::datapoint::Value::DoubleArray(array) => display_array(f, &array.values),
             },
-            None => f.write_fmt(format_args!("None")),
+            None => f.pad("None"),
+        }
+    }
+}
+
+impl From<Option<proto::v1::EntryType>> for DisplayEntryType {
+    fn from(input: Option<proto::v1::EntryType>) -> Self {
+        DisplayEntryType(input)
+    }
+}
+
+impl fmt::Display for DisplayEntryType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(entry_type) => f.pad(&format!("{entry_type:?}")),
+            None => f.pad("Unknown"),
+        }
+    }
+}
+
+impl From<Option<proto::v1::DataType>> for DisplayDataType {
+    fn from(input: Option<proto::v1::DataType>) -> Self {
+        DisplayDataType(input)
+    }
+}
+
+impl fmt::Display for DisplayDataType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(data_type) => f.pad(&format!("{data_type:?}")),
+            None => f.pad("Unknown"),
+        }
+    }
+}
+
+impl From<Option<proto::v1::ChangeType>> for DisplayChangeType {
+    fn from(input: Option<proto::v1::ChangeType>) -> Self {
+        DisplayChangeType(input)
+    }
+}
+impl fmt::Display for DisplayChangeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Some(data_type) => f.pad(&format!("{data_type:?}")),
+            None => f.pad("Unknown"),
         }
     }
 }
@@ -888,143 +1226,157 @@ fn try_into_data_value(
     }
 }
 
-#[test]
-fn test_parse_values() {
-    // String
-    assert!(matches!(
-        try_into_data_value("test", proto::v1::DataType::String),
-        Ok(proto::v1::datapoint::Value::StringValue(value)) if value == "test"
-    ));
+#[cfg(test)]
+mod test {
+    use super::*;
 
-    // Bool
-    assert!(matches!(
-        try_into_data_value("true", proto::v1::DataType::Bool),
-        Ok(proto::v1::datapoint::Value::BoolValue(value)) if value
-    ));
-    assert!(matches!(
-        try_into_data_value("false", proto::v1::DataType::Bool),
-        Ok(proto::v1::datapoint::Value::BoolValue(value)) if !value
-    ));
-    assert!(matches!(
-        try_into_data_value("truefalse", proto::v1::DataType::Bool),
-        Err(_)
-    ));
+    #[test]
+    fn test_parse_values() {
+        // String
+        assert!(matches!(
+            try_into_data_value("test", proto::v1::DataType::String),
+            Ok(proto::v1::datapoint::Value::StringValue(value)) if value == "test"
+        ));
 
-    // Int8
-    assert!(matches!(
-        try_into_data_value("100", proto::v1::DataType::Int8),
-        Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == 100
-    ));
-    assert!(matches!(
-        try_into_data_value("-100", proto::v1::DataType::Int8),
-        Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == -100
-    ));
-    assert!(matches!(
-        try_into_data_value("300", proto::v1::DataType::Int8),
-        Err(_)
-    ));
-    assert!(matches!(
-        try_into_data_value("-300", proto::v1::DataType::Int8),
-        Err(_)
-    ));
-    assert!(matches!(
-        try_into_data_value("-100.1", proto::v1::DataType::Int8),
-        Err(_)
-    ));
+        // Bool
+        assert!(matches!(
+            try_into_data_value("true", proto::v1::DataType::Bool),
+            Ok(proto::v1::datapoint::Value::BoolValue(value)) if value
+        ));
+        assert!(matches!(
+            try_into_data_value("false", proto::v1::DataType::Bool),
+            Ok(proto::v1::datapoint::Value::BoolValue(value)) if !value
+        ));
+        assert!(matches!(
+            try_into_data_value("truefalse", proto::v1::DataType::Bool),
+            Err(_)
+        ));
 
-    // Int16
-    assert!(matches!(
-        try_into_data_value("100", proto::v1::DataType::Int16),
-        Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == 100
-    ));
-    assert!(matches!(
-        try_into_data_value("-100", proto::v1::DataType::Int16),
-        Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == -100
-    ));
-    assert!(matches!(
-        try_into_data_value("32000", proto::v1::DataType::Int16),
-        Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == 32000
-    ));
-    assert!(matches!(
-        try_into_data_value("-32000", proto::v1::DataType::Int16),
-        Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == -32000
-    ));
-    assert!(matches!(
-        try_into_data_value("33000", proto::v1::DataType::Int16),
-        Err(_)
-    ));
-    assert!(matches!(
-        try_into_data_value("-33000", proto::v1::DataType::Int16),
-        Err(_)
-    ));
-    assert!(matches!(
-        try_into_data_value("-32000.1", proto::v1::DataType::Int16),
-        Err(_)
-    ));
-}
+        // Int8
+        assert!(matches!(
+            try_into_data_value("100", proto::v1::DataType::Int8),
+            Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == 100
+        ));
+        assert!(matches!(
+            try_into_data_value("-100", proto::v1::DataType::Int8),
+            Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == -100
+        ));
+        assert!(matches!(
+            try_into_data_value("300", proto::v1::DataType::Int8),
+            Err(_)
+        ));
+        assert!(matches!(
+            try_into_data_value("-300", proto::v1::DataType::Int8),
+            Err(_)
+        ));
+        assert!(matches!(
+            try_into_data_value("-100.1", proto::v1::DataType::Int8),
+            Err(_)
+        ));
 
-#[test]
-fn test_entry_path_completion() {
-    let metadata = &[
-        proto::v1::Metadata {
-            id: 1,
-            name: "Vehicle.Test.Test1".into(),
-            data_type: proto::v1::DataType::Bool as i32,
-            change_type: proto::v1::ChangeType::OnChange as i32,
-            description: "".into(),
-        },
-        proto::v1::Metadata {
-            id: 2,
-            name: "Vehicle.AnotherTest.AnotherTest1".into(),
-            data_type: proto::v1::DataType::Bool as i32,
-            change_type: proto::v1::ChangeType::OnChange as i32,
-            description: "".into(),
-        },
-        proto::v1::Metadata {
-            id: 3,
-            name: "Vehicle.AnotherTest.AnotherTest2".into(),
-            data_type: proto::v1::DataType::Bool as i32,
-            change_type: proto::v1::ChangeType::OnChange as i32,
-            description: "".into(),
-        },
-    ];
-
-    let completer = CliCompleter::from_metadata(metadata);
-
-    assert_eq!(completer.paths.children.len(), 1);
-    assert_eq!(completer.paths.children["vehicle"].children.len(), 2);
-
-    match completer.complete_entry_path("") {
-        Some(completions) => {
-            assert_eq!(completions.len(), 1);
-            assert_eq!(completions[0].display(), "Vehicle.");
-        }
-        None => panic!("expected completions, got None"),
+        // Int16
+        assert!(matches!(
+            try_into_data_value("100", proto::v1::DataType::Int16),
+            Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == 100
+        ));
+        assert!(matches!(
+            try_into_data_value("-100", proto::v1::DataType::Int16),
+            Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == -100
+        ));
+        assert!(matches!(
+            try_into_data_value("32000", proto::v1::DataType::Int16),
+            Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == 32000
+        ));
+        assert!(matches!(
+            try_into_data_value("-32000", proto::v1::DataType::Int16),
+            Ok(proto::v1::datapoint::Value::Int32Value(value)) if value == -32000
+        ));
+        assert!(matches!(
+            try_into_data_value("33000", proto::v1::DataType::Int16),
+            Err(_)
+        ));
+        assert!(matches!(
+            try_into_data_value("-33000", proto::v1::DataType::Int16),
+            Err(_)
+        ));
+        assert!(matches!(
+            try_into_data_value("-32000.1", proto::v1::DataType::Int16),
+            Err(_)
+        ));
     }
 
-    match completer.complete_entry_path("v") {
-        Some(completions) => {
-            assert_eq!(completions.len(), 1);
-            assert_eq!(completions[0].display(), "Vehicle.");
+    #[test]
+    fn test_entry_path_completion() {
+        let metadata = &[
+            proto::v1::Metadata {
+                id: 1,
+                name: "Vehicle.Test.Test1".into(),
+                data_type: proto::v1::DataType::Bool.into(),
+                entry_type: proto::v1::EntryType::Sensor.into(),
+                change_type: proto::v1::ChangeType::OnChange.into(),
+                description: "".into(),
+            },
+            proto::v1::Metadata {
+                id: 2,
+                name: "Vehicle.AnotherTest.AnotherTest1".into(),
+                data_type: proto::v1::DataType::Bool.into(),
+                entry_type: proto::v1::EntryType::Sensor.into(),
+                change_type: proto::v1::ChangeType::OnChange.into(),
+                description: "".into(),
+            },
+            proto::v1::Metadata {
+                id: 3,
+                name: "Vehicle.AnotherTest.AnotherTest2".into(),
+                data_type: proto::v1::DataType::Bool.into(),
+                entry_type: proto::v1::EntryType::Sensor.into(),
+                change_type: proto::v1::ChangeType::OnChange.into(),
+                description: "".into(),
+            },
+        ];
+
+        let completer = CliCompleter::from_metadata(metadata);
+
+        assert_eq!(completer.paths.children.len(), 1);
+        assert_eq!(completer.paths.children["vehicle"].children.len(), 2);
+
+        match completer.complete_entry_path("") {
+            Some(completions) => {
+                assert_eq!(completions.len(), 1);
+                assert_eq!(completions[0].display(), "Vehicle.");
+            }
+            None => panic!("expected completions, got None"),
         }
-        None => panic!("expected completions, got None"),
+
+        match completer.complete_entry_path("v") {
+            Some(completions) => {
+                assert_eq!(completions.len(), 1);
+                assert_eq!(completions[0].display(), "Vehicle.");
+            }
+            None => panic!("expected completions, got None"),
+        }
+
+        match completer.complete_entry_path("vehicle.") {
+            Some(completions) => {
+                assert_eq!(completions.len(), 2);
+                assert_eq!(completions[0].display(), "AnotherTest.");
+                assert_eq!(completions[1].display(), "Test.");
+            }
+            None => panic!("expected completions, got None"),
+        }
+
+        match completer.complete_entry_path("vehicle") {
+            Some(completions) => {
+                assert_eq!(completions.len(), 2);
+                assert_eq!(completions[0].display(), "AnotherTest.");
+                assert_eq!(completions[1].display(), "Test.");
+            }
+            None => panic!("expected completions, got None"),
+        }
     }
 
-    match completer.complete_entry_path("vehicle.") {
-        Some(completions) => {
-            assert_eq!(completions.len(), 2);
-            assert_eq!(completions[0].display(), "AnotherTest.");
-            assert_eq!(completions[1].display(), "Test.");
-        }
-        None => panic!("expected completions, got None"),
-    }
-
-    match completer.complete_entry_path("vehicle") {
-        Some(completions) => {
-            assert_eq!(completions.len(), 2);
-            assert_eq!(completions[0].display(), "AnotherTest.");
-            assert_eq!(completions[1].display(), "Test.");
-        }
-        None => panic!("expected completions, got None"),
+    #[test]
+    fn test_alignment() {
+        let max = 7;
+        assert_eq!("hej     1    4", format!("{:<max$} {:<4} {}", "hej", 1, 4));
     }
 }

--- a/kuksa_databroker/databroker/Cargo.toml
+++ b/kuksa_databroker/databroker/Cargo.toml
@@ -47,13 +47,13 @@ clap = { version = "3.1.10", default-features = false, features = [
 sqlparser = "0.16.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+jsonwebtoken = "8.2.0"
 
 jemallocator = { version =  "0.5.0", optional = true }
 
 [features]
 # to enable jemalloc use --features jemalloc
 jemalloc = ["dep:jemallocator"]
-
 
 [build-dependencies]
 anyhow = "1.0"

--- a/kuksa_databroker/databroker/src/auth/mod.rs
+++ b/kuksa_databroker/databroker/src/auth/mod.rs
@@ -1,5 +1,5 @@
 /********************************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation
+* Copyright (c) 2023 Contributors to the Eclipse Foundation
 *
 * See the NOTICE file(s) distributed with this work for additional
 * information regarding copyright ownership.
@@ -11,9 +11,4 @@
 * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
-pub mod auth;
-pub mod broker;
-pub mod grpc;
-pub mod query;
-pub mod types;
-pub mod vss;
+pub mod token_decoder;

--- a/kuksa_databroker/databroker/src/auth/token_decoder.rs
+++ b/kuksa_databroker/databroker/src/auth/token_decoder.rs
@@ -1,0 +1,78 @@
+/********************************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License 2.0 which is available at
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
+use serde::Deserialize;
+
+#[derive(Debug)]
+pub enum TokenError {
+    PublicKeyError(String),
+    DecodeError(String),
+}
+
+impl std::error::Error for TokenError {}
+impl std::fmt::Display for TokenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{self:?}"))
+    }
+}
+
+#[derive(Clone)]
+pub struct TokenDecoder {
+    decoding_key: DecodingKey,
+    validator: Validation,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Claims {
+    #[allow(dead_code)]
+    sub: String, // Subject (whom token refers to)
+    #[allow(dead_code)]
+    iss: String, // Issuer
+    // aud: String, // Audience
+    #[allow(dead_code)]
+    iat: u64, // Issued at (as UTC timestamp)
+    // nbf: usize, // Optional. Not Before (as UTC timestamp)
+    #[allow(dead_code)]
+    exp: u64, // Expiration time (as UTC timestamp)
+}
+
+impl TokenDecoder {
+    pub fn new(public_key: impl Into<String>) -> Result<TokenDecoder, TokenError> {
+        let decoding_key = match DecodingKey::from_rsa_pem(public_key.into().as_bytes()) {
+            Ok(decoding_key) => decoding_key,
+            Err(err) => {
+                return Err(TokenError::PublicKeyError(format!(
+                    "Error processing public key: {err}"
+                )))
+            }
+        };
+
+        let validator = Validation::new(Algorithm::RS256);
+        // validator.leeway = 5;
+        // validator.set_audience(..);
+        // validator.set_issuer(..);
+
+        Ok(TokenDecoder {
+            decoding_key,
+            validator,
+        })
+    }
+
+    pub fn decode(&self, token: impl AsRef<str>) -> Result<Claims, TokenError> {
+        match decode::<Claims>(token.as_ref(), &self.decoding_key, &self.validator) {
+            Ok(token) => Ok(token.claims),
+            Err(err) => Err(TokenError::DecodeError(err.to_string())),
+        }
+    }
+}

--- a/kuksa_databroker/databroker/src/grpc/sdv_databroker_v1/conversions.rs
+++ b/kuksa_databroker/databroker/src/grpc/sdv_databroker_v1/conversions.rs
@@ -273,6 +273,16 @@ impl From<&broker::DataType> for proto::DataType {
     }
 }
 
+impl From<&broker::EntryType> for proto::EntryType {
+    fn from(entry_type: &broker::EntryType) -> Self {
+        match entry_type {
+            broker::EntryType::Sensor => proto::EntryType::Sensor,
+            broker::EntryType::Attribute => proto::EntryType::Attribute,
+            broker::EntryType::Actuator => proto::EntryType::Actuator,
+        }
+    }
+}
+
 impl From<&proto::ChangeType> for broker::ChangeType {
     fn from(change_type: &proto::ChangeType) -> Self {
         match change_type {
@@ -287,6 +297,7 @@ impl From<&broker::Metadata> for proto::Metadata {
     fn from(metadata: &broker::Metadata) -> Self {
         proto::Metadata {
             id: metadata.id,
+            entry_type: proto::EntryType::from(&metadata.entry_type) as i32,
             name: metadata.path.to_owned(),
             data_type: proto::DataType::from(&metadata.data_type) as i32,
             change_type: proto::ChangeType::Continuous as i32, // TODO: Add to metadata

--- a/kuksa_databroker/databroker/src/grpc/server.rs
+++ b/kuksa_databroker/databroker/src/grpc/server.rs
@@ -14,12 +14,46 @@
 use std::{future::Future, time::Duration};
 
 use tonic::transport::Server;
-use tracing::info;
+use tracing::{debug, info, warn};
 
 use databroker_proto::{kuksa, sdv};
 
-use crate::broker;
+use crate::{
+    auth::{self, token_decoder::TokenDecoder},
+    broker,
+};
 
+#[derive(Clone)]
+struct AuthorizationInterceptor {
+    token_decoder: auth::token_decoder::TokenDecoder,
+}
+
+impl tonic::service::Interceptor for AuthorizationInterceptor {
+    fn call(
+        &mut self,
+        mut request: tonic::Request<()>,
+    ) -> Result<tonic::Request<()>, tonic::Status> {
+        match request.metadata().get("authorization") {
+            Some(header) => match header.to_str() {
+                Ok(header) if header.starts_with("Bearer ") => {
+                    let token: &str = header[7..].into();
+                    match self.token_decoder.decode(token) {
+                        Ok(claims) => {
+                            request.extensions_mut().insert(claims);
+                            Ok(request)
+                        }
+                        Err(_) => Err(tonic::Status::unauthenticated("Invalid auth token")),
+                    }
+                }
+                Ok(_) | Err(_) => Err(tonic::Status::unauthenticated("Invalid auth token")),
+            },
+            None => {
+                debug!("No auth token provided");
+                Err(tonic::Status::unauthenticated("No auth token provided"))
+            }
+        }
+    }
+}
 async fn shutdown<F>(databroker: broker::DataBroker, signal: F)
 where
     F: Future<Output = ()>,
@@ -31,7 +65,48 @@ where
     databroker.shutdown().await;
 }
 
-pub async fn serve_with_shutdown<F>(
+pub async fn serve_authorized<F>(
+    addr: &str,
+    broker: broker::DataBroker,
+    token_decoder: TokenDecoder,
+    signal: F,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    F: Future<Output = ()>,
+{
+    let addr = addr.parse()?;
+
+    let authorization_interceptor = AuthorizationInterceptor { token_decoder };
+    broker.start_housekeeping_task();
+
+    info!("Listening on {}", addr);
+
+    Server::builder()
+        .http2_keepalive_interval(Some(Duration::from_secs(10)))
+        .http2_keepalive_timeout(Some(Duration::from_secs(20)))
+        .add_service(
+            sdv::databroker::v1::broker_server::BrokerServer::with_interceptor(
+                broker.clone(),
+                authorization_interceptor.clone(),
+            ),
+        )
+        .add_service(
+            sdv::databroker::v1::collector_server::CollectorServer::with_interceptor(
+                broker.clone(),
+                authorization_interceptor.clone(),
+            ),
+        )
+        .add_service(kuksa::val::v1::val_server::ValServer::with_interceptor(
+            broker.clone(),
+            authorization_interceptor.clone(),
+        ))
+        .serve_with_shutdown(addr, shutdown(broker, signal))
+        .await?;
+
+    Ok(())
+}
+
+pub async fn serve<F>(
     addr: &str,
     broker: broker::DataBroker,
     signal: F,
@@ -42,6 +117,9 @@ where
     let addr = addr.parse()?;
 
     broker.start_housekeeping_task();
+
+    warn!("Authorization is not enabled");
+    info!("Listening on {}", addr);
 
     Server::builder()
         .http2_keepalive_interval(Some(Duration::from_secs(10)))

--- a/kuksa_databroker/proto/sdv/databroker/v1/types.proto
+++ b/kuksa_databroker/proto/sdv/databroker/v1/types.proto
@@ -59,6 +59,13 @@ enum DatapointError {
   OUT_OF_BOUNDS     = 4;
 }
 
+enum EntryType {
+  ENTRY_TYPE_UNSPECIFIED = 0;
+  ENTRY_TYPE_SENSOR      = 1;
+  ENTRY_TYPE_ACTUATOR    = 2;
+  ENTRY_TYPE_ATTRIBUTE   = 3;
+}
+
 enum ChangeType {
   STATIC    = 0;   // Value never changes
   ON_CHANGE = 1;   // Updates are provided every time the value changes (i.e.
@@ -142,6 +149,7 @@ message Metadata {
   // Id to be used in "get" and "subscribe" requests. Ids stay valid during
   // one power cycle, only.
   int32 id               = 1;
+  EntryType entry_type   = 2;
   string name            = 4;
   DataType data_type     = 5;
   ChangeType change_type = 6;  // CONTINUOUS or STATIC or ON_CHANGE


### PR DESCRIPTION
Adds support for access tokens to databroker-cli.

Included are a number of other improvements. Some necessary for adding this support, some not. E.g.

* Add support for command line arguments
* Add initial support for subcommands
* Start moving GRPC related parts into client.rs
* A number of small updates to the interface
