### PR TITLE
Change expiration of ttl.sh images

### DIFF
--- a/.github/workflows/kuksa_databroker-cli_build.yml
+++ b/.github/workflows/kuksa_databroker-cli_build.yml
@@ -100,7 +100,7 @@ jobs:
         push: true
         tags: |
           ${{ steps.meta.outputs.tags }}
-          ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h
+          ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Build ephemereal kuksa.val databroker container and push to ttl.sh
@@ -114,21 +114,21 @@ jobs:
         file: ./kuksa_databroker/Dockerfile-cli
         context: .
         push: true
-        tags: "ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h"
+        tags: "ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}"
         labels: ${{ steps.meta.outputs.labels }}
         
 
     - name: Posting message
       uses: ./.github/actions/post-container-location
       with:
-        image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h
+        image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}
       
     - name: Extracting ARM64 binaries
       uses: ./.github/actions/copy-from-oci
       with:
         platform: linux/arm64
         id: databroker-cli-arm64
-        image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h
+        image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}
         src: /app/
         export: true
         transform: s/app/databroker-cli/
@@ -138,7 +138,7 @@ jobs:
       with:
         platform: linux/amd64
         id: databroker-cli-amd64
-        image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}:1h
+        image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}
         src: /app/
         export: true
         transform: s/app/databroker-cli/

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -163,7 +163,7 @@ jobs:
         push: true
         tags: |
           ${{ steps.meta.outputs.tags }}
-          ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
+          ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Build ephemereal kuksa.val databroker container and push to ttl.sh
@@ -177,20 +177,20 @@ jobs:
         file: ./kuksa_databroker/Dockerfile
         context: .
         push: true
-        tags: "ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h"
+        tags: "ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}"
         labels: ${{ steps.meta.outputs.labels }}
   
     - name: Posting message
       uses: ./.github/actions/post-container-location
       with:
-        image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
+        image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}
 
     - name:  Extracting ARM64 binaries
       uses: ./.github/actions/copy-from-oci
       with:
         platform: linux/arm64
         id: databroker-arm64
-        image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
+        image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}
         src: /app/
         export: true
         transform: s/app/databroker/
@@ -201,7 +201,7 @@ jobs:
       with:
         platform: linux/amd64
         id: databroker-amd64
-        image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
+        image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}
         src: /app/
         export: true
         transform: s/app/databroker/
@@ -217,6 +217,6 @@ jobs:
         
       - name: Run integration test
         env:
-          DATABROKER_IMAGE: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}:1h
+          DATABROKER_IMAGE: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}
         run: |
           ${{github.workspace}}/kuksa_databroker/integration_test/run.sh


### PR DESCRIPTION
Unavailability of build runners will sometimes cause the ttl.sh images to expire before the integration test has a chance to run them.