### PR TITLE
Enable enforcement of allowed values

### DIFF
--- a/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -499,6 +499,7 @@ async fn test_update_datapoint_using_wrong_type() {
             broker::ChangeType::OnChange,
             broker::EntryType::Sensor,
             "Test datapoint 1".to_owned(),
+            None,
         )
         .await
         .expect("Register datapoint should succeed");

--- a/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -481,6 +481,7 @@ impl broker::EntryUpdate {
             entry_type: None,
             data_type: None,
             description: None,
+            allowed: None,
         }
     }
 }

--- a/kuksa_databroker/databroker/src/grpc/sdv_databroker_v1/broker.rs
+++ b/kuksa_databroker/databroker/src/grpc/sdv_databroker_v1/broker.rs
@@ -107,6 +107,7 @@ impl proto::broker_server::Broker for broker::DataBroker {
                                         entry_type: None,
                                         data_type: None,
                                         description: None,
+                                        allowed: None,
                                     },
                                 ));
                             }

--- a/kuksa_databroker/databroker/src/grpc/sdv_databroker_v1/collector.rs
+++ b/kuksa_databroker/databroker/src/grpc/sdv_databroker_v1/collector.rs
@@ -46,6 +46,7 @@ impl proto::collector_server::Collector for broker::DataBroker {
                         entry_type: None,
                         data_type: None,
                         description: None,
+                        allowed: None,
                     },
                 )
             })
@@ -99,7 +100,8 @@ impl proto::collector_server::Collector for broker::DataBroker {
                                                         actuator_target: None,
                                                         entry_type: None,
                                                         data_type: None,
-                                                        description: None
+                                                        description: None,
+                                                        allowed: None,
                                                     }
                                                 )
                                             )
@@ -167,6 +169,7 @@ impl proto::collector_server::Collector for broker::DataBroker {
                             broker::ChangeType::from(&change_type),
                             broker::types::EntryType::Sensor,
                             metadata.description,
+                            None,
                         )
                         .await
                     {

--- a/kuksa_databroker/databroker/src/main.rs
+++ b/kuksa_databroker/databroker/src/main.rs
@@ -154,6 +154,7 @@ async fn read_metadata_file(
                 databroker::broker::ChangeType::OnChange,
                 entry.entry_type,
                 entry.description,
+                entry.allowed,
             )
             .await;
 
@@ -170,6 +171,7 @@ async fn read_metadata_file(
                     entry_type: None,
                     data_type: None,
                     description: None,
+                    allowed: None,
                 },
             )];
             if let Err(errors) = broker.update_entries(ids).await {
@@ -288,6 +290,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     change_type.clone(),
                     entry_type.clone(),
                     description.to_string(),
+                    None,
                 )
                 .await
             {
@@ -310,6 +313,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 entry_type: None,
                                 data_type: None,
                                 description: None,
+                                allowed: None,
                             },
                         )])
                         .await


### PR DESCRIPTION
This adds another validation step before one can feed/set a path.

E.g. If you want to allow only a few options for setting you can do something like:
Vehicle.Body.Windshield.Front.Wiping.Mode - only allows: "OFF", "SLOW", "MEDIUM", "FAST", "INTERVAL", "RAIN_SENSOR"
Databroker now checks if the value you specified is in this list (if it is specified)