### PR TITLE
Catch exception for the client when incorrect types supplied as value.

### DIFF
--- a/kuksa-client/kuksa_client/cli_backend/grpc.py
+++ b/kuksa-client/kuksa_client/cli_backend/grpc.py
@@ -200,6 +200,8 @@ class Backend(cli_backend.Backend):
                 responseQueue.put((resp, None))
             except kuksa_client.grpc.VSSClientError as exc:
                 responseQueue.put((None, exc.to_dict()))
+            except ValueError as exc:
+                responseQueue.put((None, {"error": "ValueError in casting the value."}))
 
         self.grpcConnected = False
 


### PR DESCRIPTION
Handling ValueError exception in the event of incorrect values. Should fix #498 