### PR TITLE
Do not push release builds of kuksa-client to ttl.sh

### DIFF
--- a/.github/workflows/kuksa-client.yml
+++ b/.github/workflows/kuksa-client.yml
@@ -80,7 +80,6 @@ jobs:
         push: true
         tags: |
           ${{ steps.meta.outputs.tags }}
-          ttl.sh/kuksa.val/kuksa-client-${{github.sha}}:1h
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Build ephemereal kuksa command line client docker and push to ttl.sh


### PR DESCRIPTION
Containerd still not fixed, so push to ttl not working. Short term fix: Don't do on release build. Will need a real fix after release