### PR TITLE
Dash-license support in CI

### DIFF
--- a/.github/actions/check-dash/action.yml
+++ b/.github/actions/check-dash/action.yml
@@ -1,0 +1,31 @@
+
+name: Checking dependencies with dash-license tool
+description: Check an input file via dash, and archive report. Print output in build step summary. Requires wget and an JRE on the runner
+
+inputs:
+  dashinput:
+    required: true
+    type: string
+    description: "Dash Input file"
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Run Dash"
+      shell: bash
+      run: |
+        wget -O dash.jar "https://repo.eclipse.org/service/local/artifact/maven/redirect?r=dash-licenses&g=org.eclipse.dash&a=org.eclipse.dash.licenses&v=LATEST"
+        java -jar dash.jar -summary ${{ inputs.dashinput }}.report  ${{ inputs.dashinput }} > ${{ inputs.dashinput }}.out 2>&1 || true
+        echo -e "Dash output: \n\`\`\` " >> $GITHUB_STEP_SUMMARY
+        cat ${{ inputs.dashinput }}.out >> $GITHUB_STEP_SUMMARY
+        echo -e "\n\`\`\`"
+    
+    - name: "Archive dash artifacts"
+      uses: actions/upload-artifact@v3
+      with:
+        name: "Dash data"
+        path: |
+         ${{ inputs.dashinput }}
+         ${{ inputs.dashinput }}.report
+         ${{ inputs.dashinput }}.out

--- a/.github/actions/copy-from-oci/action.yml
+++ b/.github/actions/copy-from-oci/action.yml
@@ -11,31 +11,30 @@ inputs:
       - linux/arm64
       - linux/amd64
       - linux/riscv64
-    image:
-      required: true
-      type: string
-      description: The OCI image
-    src:
-      required: true
-      type: string
-      description: Path inside container
-    id:
-      required: true
-      type: string
-      description: |
-        This will be the name of the temporary container, making sure we do not leave any stale containers around
-        (we try deleting and before and after running this, so we can recover should a workflow for a given id
-        fail before cleaning up)
-        Will be used for artifact name (if export=true) and to identify 
-        This will also be created as directory in cwd.
-        !No special characters allowed "/" !
-    export:
-      required: false
-      default: false
-      description: Archive dest and export as Action artifact
-    tar-transform:
-      required: false
-      description: Optionally applying chosen --transform to tar when export is set to true
+  image:
+    required: true
+    type: string
+    description: The OCI image
+  src:
+    required: true
+    type: string
+    description: Path inside container
+  id:
+    required: true
+    type: string
+    description: |
+      This will be the name of the temporary container, making sure we do not leave any stale containers around
+      (we try deleting and before and after running this, so we can recover should a workflow for a given id fail before cleaning up)
+      Will be used for artifact name (if export=true) and to identify 
+      This will also be created as directory in cwd.
+      !No special characters allowed "/" !
+  export:
+    required: false
+    default: false
+    description: Archive dest and export as Action artifact
+  transform:
+    required: false
+    description: Optionally applying chosen --transform to tar when export is set to true
       
 
 runs:

--- a/.github/actions/copy-from-oci/action.yml
+++ b/.github/actions/copy-from-oci/action.yml
@@ -3,7 +3,7 @@ name: Extract from OCI image
 description: Can copy files out of an OCI image
 
 inputs:
-  plattform:
+  platform:
     required: true
     type: choice
     description: Choose platform, e.g. linux/arm64

--- a/.github/workflows/kuksa_databroker-cli_build.yml
+++ b/.github/workflows/kuksa_databroker-cli_build.yml
@@ -1,5 +1,5 @@
 # /********************************************************************************
-# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 # *
 # * See the NOTICE file(s) distributed with this work for additional
 # * information regarding copyright ownership.
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Installing JVM
+        run: sudo apt-get install -y default-jre
       - name: Install Protoc
         run: sudo apt-get install -y protobuf-compiler
       - uses: actions/checkout@v3
@@ -41,6 +43,18 @@ jobs:
       - name: cargo clippy
         working-directory: ${{github.workspace}}
         run: cargo clippy --all-targets -- -W warnings -D warnings
+
+      - name: "Createbom: License check and Dash output generation"
+        working-directory: ${{github.workspace}}/kuksa_databroker/createbom
+        run: |
+         cargo install cargo-license
+         python3 createbom.py --dash ${{github.workspace}}/dash-databroker-cli-deps ../databroker-cli
+
+      - name: Dash license check
+        uses: ./.github/actions/check-dash
+        with:
+          dashinput: ${{github.workspace}}/dash-databroker-cli-deps
+
 
 
   checkrights:

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Installing JVM
+        run: sudo apt-get install -y default-jre
       - name: Install Protoc
         run: sudo apt-get install -y protobuf-compiler
       - uses: actions/checkout@v3
@@ -41,6 +43,17 @@ jobs:
       - name: cargo clippy
         working-directory: ${{github.workspace}}
         run: cargo clippy --all-targets -- -W warnings -D warnings
+
+      - name: "Createbom: License check and Dash output generation"
+        working-directory: ${{github.workspace}}/kuksa_databroker/createbom
+        run: |
+         cargo install cargo-license
+         python3 createbom.py --dash ${{github.workspace}}/dash-databroker-deps ../databroker
+
+      - name: Dash license check
+        uses: ./.github/actions/check-dash
+        with:
+          dashinput: ${{github.workspace}}/dash-databroker-deps
 
   test:
     name: Test
@@ -217,7 +230,7 @@ jobs:
 
     steps:
     
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         
       - name: Run integration test
         env:


### PR DESCRIPTION
Eclipse uses dash-licenses (https://github.com/eclipse/dash-licenses)  to vet license of dependencies.

This PR does two things to better integrate with Eclipse process with less manual work for our RUST components

 - it adds support to createbom to generate the inout file required by dash. I chose to create it via out existing tooling, instead of using the cmdline tricks in the dash-documentaiton example, so we have a "single source of truth" wrt to dependencies (i.e. what goes into the bom in the containers, is the same thing checked against dash).  In both cases this relies on cargo to get hte information
 - I added a composite action, that will take a Dash input file, run it, and archive the full report, as well as the stdout/stderr output form dash
 - I integrated into databroker and databroker-cli builds. I chose to extend an existing stage (lint), because otherwise we would need to set up a complete rust environment a fourth time in the build process
 - Dash check can never fail, only createbom can (and will) if it sees a non-whitelisted license. Rationale is, that sometimes the project may decide to add a component with a "fitting" license between releases, which may not yet have been cleared/scanned yet. So this avoids deadlock (at the price we might need to pull a dependency later. But this is how it has always been.)

Easiest way to check any new dependencies, is checking the build summary, where you get a post like this

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/3707124/229783586-74a84b9a-9753-4214-811b-945ecbf7842c.png">

See here for a complete run https://github.com/boschglobal/kuksa.val/actions/runs/4607432259

This is also a good example, where dash finds some deps that are still in the clearing process. If something new is coming up, the "dash data" aritfact contains the Dash input. This can be used by project leads, e.g. @bs-jokri  directly to trigger the scanning in Eclipse IP ticketing system

