### PR TITLE
KUKSA client fails because at startup it is unauthenticated

### DIFF
--- a/kuksa-client/kuksa_client/__init__.py
+++ b/kuksa-client/kuksa_client/__init__.py
@@ -52,8 +52,8 @@ class KuksaClientThread(threading.Thread):
         self.backend.stop()
 
     # Do authorization by passing a jwt token or a token file
-    def authorize(self, token=None, timeout=5):
-        return self.backend.authorize(token, timeout)
+    def authorize(self, token_or_tokenfile=None, timeout=5):
+        return self.backend.authorize(token_or_tokenfile, timeout)
 
     # Update VSS Tree Entry
     def updateVSSTree(self, jsonStr, timeout=5):

--- a/kuksa-client/kuksa_client/__main__.py
+++ b/kuksa-client/kuksa_client/__main__.py
@@ -264,6 +264,7 @@ class TestClient(Cmd):
         self.subscribeIds = set()
         self.commThread = None
         self.token_or_tokenfile = token_or_tokenfile
+        self.insecure = insecure
 
         print("Welcome to Kuksa Client version " + str(_metadata.__version__))
         print()
@@ -272,18 +273,18 @@ class TestClient(Cmd):
         print("Default tokens directory: " + self.getDefaultTokenDir())
 
         print()
-        self.connect(insecure)
+        self.connect()
 
     @with_category(COMM_SETUP_COMMANDS)
     @with_argparser(ap_authorize)
     def do_authorize(self, args):
         """Authorize the client to interact with the server"""
+        if args.token_or_tokenfile is not None:
+            self.token_or_tokenfile = args.token_or_tokenfile
         if self.checkConnection():
-            if args.token_or_tokenfile is not None:
-                self.token_or_tokenfile = args.token_or_tokenfile
             resp = self.commThread.authorize(self.token_or_tokenfile)
             print(highlight(resp, lexers.JsonLexer(),
-                  formatters.TerminalFormatter()))
+                    formatters.TerminalFormatter()))
 
     @with_category(VSS_COMMANDS)
     @with_argparser(ap_setValue)
@@ -474,7 +475,7 @@ class TestClient(Cmd):
             self.connect()
         return self.commThread.checkConnection()
 
-    def connect(self, insecure=False):
+    def connect(self):
         """Connect to the VISS/gRPC Server"""
         if hasattr(self, "commThread"):
             if self.commThread is not None:
@@ -482,7 +483,7 @@ class TestClient(Cmd):
                 self.commThread = None
         config = {'ip': self.serverIP,
                   'port': self.serverPort,
-                  'insecure': insecure,
+                  'insecure': self.insecure,
                   'protocol': self.serverProtocol,
                   'token_or_tokenfile': self.token_or_tokenfile,
                   }
@@ -505,7 +506,8 @@ class TestClient(Cmd):
     @with_category(COMM_SETUP_COMMANDS)
     @with_argparser(ap_connect)
     def do_connect(self, args):
-        self.connect(args.insecure)
+        self.insecure = args.insecure
+        self.connect()
 
     @with_category(COMM_SETUP_COMMANDS)
     @with_argparser(ap_setServerAddr)

--- a/kuksa-client/kuksa_client/__main__.py
+++ b/kuksa-client/kuksa_client/__main__.py
@@ -279,7 +279,7 @@ class TestClient(Cmd):
     def do_authorize(self, args):
         """Authorize the client to interact with the server"""
         if self.checkConnection():
-            if args.tokenfile != None:
+            if args.tokenfile is not None:
                 self.tokenfile = args.tokenfile
             resp = self.commThread.authorize(self.tokenfile)
             print(highlight(resp, lexers.JsonLexer(),

--- a/kuksa-client/kuksa_client/__main__.py
+++ b/kuksa-client/kuksa_client/__main__.py
@@ -584,7 +584,7 @@ def main():
         '--logging-config', default=os.path.join(scriptDir, 'logging.ini'), help="Path to logging configuration file",
     )
     parser.add_argument(
-        '--token_or_tokenfile', default=None, help="Path to jwt token file (.token)",
+        '--token_or_tokenfile', default=None, help="JWT token or path to a JWT token file (.token)",
     )
     args = parser.parse_args()
 

--- a/kuksa-client/kuksa_client/__main__.py
+++ b/kuksa-client/kuksa_client/__main__.py
@@ -147,7 +147,7 @@ class TestClient(Cmd):
     tokenfile_completer_method = functools.partial(Cmd.path_complete,
                                                    path_filter=lambda path: (os.path.isdir(path) or path.endswith(".token")))
     ap_authorize.add_argument(
-        'tokenfile',
+        'token_or_tokenfile',
         help='JWT(or the file storing the token) for authorizing the client.',
         completer_method=tokenfile_completer_method,)
     ap_setServerAddr = argparse.ArgumentParser()
@@ -248,7 +248,7 @@ class TestClient(Cmd):
         "Json", help="Json tree to update VSS", completer_method=jsonfile_completer_method)
 
     # Constructor
-    def __init__(self, server_ip=None, server_port=None, server_protocol=None, insecure=False, tokenfile=None):
+    def __init__(self, server_ip=None, server_port=None, server_protocol=None, insecure=False, token_or_tokenfile=None):
         super().__init__(
             persistent_history_file=".vssclient_history", persistent_history_length=100, allow_cli_args=False,
         )
@@ -263,7 +263,7 @@ class TestClient(Cmd):
         self.pathCompletionItems = []
         self.subscribeIds = set()
         self.commThread = None
-        self.tokenfile = tokenfile
+        self.token_or_tokenfile = token_or_tokenfile
 
         print("Welcome to Kuksa Client version " + str(_metadata.__version__))
         print()
@@ -279,9 +279,9 @@ class TestClient(Cmd):
     def do_authorize(self, args):
         """Authorize the client to interact with the server"""
         if self.checkConnection():
-            if args.tokenfile is not None:
-                self.tokenfile = args.tokenfile
-            resp = self.commThread.authorize(self.tokenfile)
+            if args.token_or_tokenfile is not None:
+                self.token_or_tokenfile = args.token_or_tokenfile
+            resp = self.commThread.authorize(self.token_or_tokenfile)
             print(highlight(resp, lexers.JsonLexer(),
                   formatters.TerminalFormatter()))
 
@@ -484,7 +484,7 @@ class TestClient(Cmd):
                   'port': self.serverPort,
                   'insecure': insecure,
                   'protocol': self.serverProtocol,
-                  'tokenfile': self.tokenfile,
+                  'token_or_tokenfile': self.token_or_tokenfile,
                   }
         self.commThread = KuksaClientThread(config)
         self.commThread.start()
@@ -584,13 +584,13 @@ def main():
         '--logging-config', default=os.path.join(scriptDir, 'logging.ini'), help="Path to logging configuration file",
     )
     parser.add_argument(
-        '--tokenfile', default=None, help="Path to jwt token file (.token)",
+        '--token_or_tokenfile', default=None, help="Path to jwt token file (.token)",
     )
     args = parser.parse_args()
 
     logging.config.fileConfig(args.logging_config)
     clientApp = TestClient(args.ip, args.port, args.protocol,
-                           args.insecure, args.tokenfile)
+                           args.insecure, args.token_or_tokenfile)
     try:
         # We exit the loop when the user types "quit" or hits Ctrl-D.
         clientApp.cmdloop()

--- a/kuksa-client/kuksa_client/__main__.py
+++ b/kuksa-client/kuksa_client/__main__.py
@@ -147,10 +147,9 @@ class TestClient(Cmd):
     tokenfile_completer_method = functools.partial(Cmd.path_complete,
                                                    path_filter=lambda path: (os.path.isdir(path) or path.endswith(".token")))
     ap_authorize.add_argument(
-        'Token',
+        'tokenfile',
         help='JWT(or the file storing the token) for authorizing the client.',
-        completer_method=tokenfile_completer_method,
-    )
+        completer_method=tokenfile_completer_method,)
     ap_setServerAddr = argparse.ArgumentParser()
     ap_setServerAddr.add_argument(
         'IP', help='VISS/gRPC Server IP Address', default=DEFAULT_SERVER_ADDR)
@@ -249,7 +248,7 @@ class TestClient(Cmd):
         "Json", help="Json tree to update VSS", completer_method=jsonfile_completer_method)
 
     # Constructor
-    def __init__(self, server_ip=None, server_port=None, server_protocol=None, insecure=False):
+    def __init__(self, server_ip=None, server_port=None, server_protocol=None, insecure=False, tokenfile=None):
         super().__init__(
             persistent_history_file=".vssclient_history", persistent_history_length=100, allow_cli_args=False,
         )
@@ -264,6 +263,7 @@ class TestClient(Cmd):
         self.pathCompletionItems = []
         self.subscribeIds = set()
         self.commThread = None
+        self.tokenfile = tokenfile
 
         print("Welcome to Kuksa Client version " + str(_metadata.__version__))
         print()
@@ -279,7 +279,9 @@ class TestClient(Cmd):
     def do_authorize(self, args):
         """Authorize the client to interact with the server"""
         if self.checkConnection():
-            resp = self.commThread.authorize(args.Token)
+            if args.tokenfile != None:
+                self.tokenfile = args.tokenfile
+            resp = self.commThread.authorize(self.tokenfile)
             print(highlight(resp, lexers.JsonLexer(),
                   formatters.TerminalFormatter()))
 
@@ -481,7 +483,8 @@ class TestClient(Cmd):
         config = {'ip': self.serverIP,
                   'port': self.serverPort,
                   'insecure': insecure,
-                  'protocol': self.serverProtocol
+                  'protocol': self.serverProtocol,
+                  'tokenfile': self.tokenfile,
                   }
         self.commThread = KuksaClientThread(config)
         self.commThread.start()
@@ -580,10 +583,14 @@ def main():
     parser.add_argument(
         '--logging-config', default=os.path.join(scriptDir, 'logging.ini'), help="Path to logging configuration file",
     )
+    parser.add_argument(
+        '--tokenfile', default=None, help="Path to jwt token file (.token)",
+    )
     args = parser.parse_args()
 
     logging.config.fileConfig(args.logging_config)
-    clientApp = TestClient(args.ip, args.port, args.protocol, args.insecure)
+    clientApp = TestClient(args.ip, args.port, args.protocol,
+                           args.insecure, args.tokenfile)
     try:
         # We exit the loop when the user types "quit" or hits Ctrl-D.
         clientApp.cmdloop()

--- a/kuksa-client/kuksa_client/cli_backend/__init__.py
+++ b/kuksa-client/kuksa_client/cli_backend/__init__.py
@@ -20,6 +20,7 @@ import pathlib
 
 import kuksa_certificates
 
+
 class Backend:
     def __init__(self, config):
         self.serverIP = config.get('ip', "127.0.0.1")
@@ -29,10 +30,14 @@ class Backend:
         except AttributeError:
             self.insecure = config.get('insecure', False)
         self.default_cert_path = pathlib.Path(kuksa_certificates.__path__[0])
-        self.cacertificate = config.get('cacertificate', str(self.default_cert_path / 'CA.pem'))
-        self.certificate = config.get('certificate', str(self.default_cert_path / 'Client.pem'))
-        self.keyfile = config.get('key', str(self.default_cert_path / 'Client.key'))
-        self.tokenfile = config.get('token', str(self.default_cert_path / 'jwt/all-read-write.json.token'))
+        self.cacertificate = config.get(
+            'cacertificate', str(self.default_cert_path / 'CA.pem'))
+        self.certificate = config.get('certificate', str(
+            self.default_cert_path / 'Client.pem'))
+        self.keyfile = config.get('key', str(
+            self.default_cert_path / 'Client.key'))
+        self.tokenfile = config.get('tokenfile', str(
+            self.default_cert_path / 'jwt/all-read-write.json.token'))
 
     @staticmethod
     def from_config(config):

--- a/kuksa-client/kuksa_client/cli_backend/__init__.py
+++ b/kuksa-client/kuksa_client/cli_backend/__init__.py
@@ -36,7 +36,7 @@ class Backend:
             self.default_cert_path / 'Client.pem'))
         self.keyfile = config.get('key', str(
             self.default_cert_path / 'Client.key'))
-        self.tokenfile = config.get('tokenfile', str(
+        self.token_or_tokenfile = config.get('token_or_tokenfile', str(
             self.default_cert_path / 'jwt/all-read-write.json.token'))
 
     @staticmethod

--- a/kuksa-client/kuksa_client/cli_backend/grpc.py
+++ b/kuksa-client/kuksa_client/cli_backend/grpc.py
@@ -45,7 +45,7 @@ class Backend(cli_backend.Backend):
         self.cacertificate = pathlib.Path(self.cacertificate)
         self.keyfile = pathlib.Path(self.keyfile)
         self.certificate = pathlib.Path(self.certificate)
-        if self.tokenfile != None:
+        if self.tokenfile is not None:
             self.tokenfile = pathlib.Path(self.tokenfile)
             self.token = self.tokenfile.expanduser(
             ).read_text(encoding='utf-8').rstrip('\n')
@@ -205,7 +205,7 @@ class Backend(cli_backend.Backend):
             try:
                 if call == "get":
                     resp = await vss_client.get(**requestArgs)
-                    if resp != None:
+                    if resp is not None:
                         resp = [entry.to_dict() for entry in resp]
                         resp = resp[0] if len(resp) == 1 else resp
                 elif call == "set":

--- a/kuksa-client/kuksa_client/cli_backend/grpc.py
+++ b/kuksa-client/kuksa_client/cli_backend/grpc.py
@@ -45,6 +45,12 @@ class Backend(cli_backend.Backend):
         self.cacertificate = pathlib.Path(self.cacertificate)
         self.keyfile = pathlib.Path(self.keyfile)
         self.certificate = pathlib.Path(self.certificate)
+        if self.tokenfile != None:
+            self.tokenfile = pathlib.Path(self.tokenfile)
+            self.token = self.tokenfile.expanduser(
+            ).read_text(encoding='utf-8').rstrip('\n')
+        else:
+            self.token = ""
         self.grpcConnected = False
 
         self.sendMsgQueue = queue.Queue()
@@ -233,7 +239,8 @@ class Backend(cli_backend.Backend):
     # Main loop for handling gRPC communication
     async def mainLoop(self):
         if self.insecure:
-            async with kuksa_client.grpc.aio.VSSClient(self.serverIP, self.serverPort) as vss_client:
+
+            async with kuksa_client.grpc.aio.VSSClient(self.serverIP, self.serverPort, token=self.token) as vss_client:
                 print("gRPC channel connected.")
                 await self._grpcHandler(vss_client)
         else:
@@ -243,6 +250,7 @@ class Backend(cli_backend.Backend):
                 root_certificates=self.cacertificate,
                 private_key=self.keyfile,
                 certificate_chain=self.certificate,
+                token=self.token
             ) as vss_client:
                 print("Secure gRPC channel connected.")
                 await self._grpcHandler(vss_client)

--- a/kuksa-client/kuksa_client/cli_backend/ws.py
+++ b/kuksa-client/kuksa_client/cli_backend/ws.py
@@ -118,12 +118,14 @@ class Backend(cli_backend.Backend):
         self.stop()
 
     # Function to authorize against the kuksa.val server
-    def authorize(self, tokenfile=None, timeout=2):
-        if tokenfile is None:
-            tokenfile = self.tokenfile
-        tokenfile = pathlib.Path(tokenfile)
-        token = tokenfile.expanduser().read_text(encoding='utf-8')
-
+    def authorize(self, token_or_tokenfile=None, timeout=2):
+        if token_or_tokenfile is None:
+            token_or_tokenfile = self.token_or_tokenfile
+        if os.path.isfile(token_or_tokenfile):
+            token_or_tokenfile = pathlib.Path(token_or_tokenfile)
+            token = token_or_tokenfile.expanduser().read_text(encoding='utf-8')
+        else:
+            token = token_or_tokenfile
         req = {}
         req["action"] = "authorize"
         req["tokens"] = token

--- a/kuksa-client/kuksa_client/grpc/__init__.py
+++ b/kuksa-client/kuksa_client/grpc/__init__.py
@@ -479,7 +479,7 @@ class BaseVSSClient:
         private_key: Optional[Path] = None,
         certificate_chain: Optional[Path] = None,
         *,
-        ensure_startup_connection: bool = True,
+        ensure_startup_connection: bool = False,
         connected: bool = False,
     ):
         self.authorization_header = self.get_authorization_header(token)

--- a/kuksa-client/kuksa_client/grpc/__init__.py
+++ b/kuksa-client/kuksa_client/grpc/__init__.py
@@ -479,7 +479,7 @@ class BaseVSSClient:
         private_key: Optional[Path] = None,
         certificate_chain: Optional[Path] = None,
         *,
-        ensure_startup_connection: bool = False,
+        ensure_startup_connection: bool = True,
         connected: bool = False,
     ):
         self.authorization_header = self.get_authorization_header(token)

--- a/kuksa-client/kuksa_client/grpc/__init__.py
+++ b/kuksa-client/kuksa_client/grpc/__init__.py
@@ -572,8 +572,8 @@ class BaseVSSClient:
                 err, preserving_proto_field_name=True) for err in response.errors]
         else:
             errors = []
-        if (error and error['code'] != http.HTTPStatus.OK) or any(
-            sub_error['error']['code'] != http.HTTPStatus.OK for sub_error in errors
+        if (error and error['code'] is not http.HTTPStatus.OK) or any(
+            sub_error['error']['code'] is not http.HTTPStatus.OK for sub_error in errors
         ):
             raise VSSClientError(error, errors)
 

--- a/kuksa-client/kuksa_client/grpc/aio.py
+++ b/kuksa-client/kuksa_client/grpc/aio.py
@@ -342,11 +342,14 @@ class VSSClient(BaseVSSClient):
         logger.debug("%s: %s", type(req).__name__, req)
         try:
             resp = await self.client_stub.GetServerInfo(req, **rpc_kwargs)
+            logger.debug("%s: %s", type(resp).__name__, resp)
+            return ServerInfo.from_message(resp)
         except AioRpcError as exc:
-            raise VSSClientError.from_grpc_error(exc) from exc
-        logger.debug("%s: %s", type(resp).__name__, resp)
-
-        return ServerInfo.from_message(resp)
+            if exc.code() == grpc.StatusCode.UNAUTHENTICATED:
+                logger.info("Unauthenticated channel started")
+            else: 
+                raise VSSClientError.from_grpc_error(exc) from exc
+        return None
 
     async def get_value_types(self, paths: Collection[str], **rpc_kwargs) -> Dict[str, DataType]:
         """


### PR DESCRIPTION
This PR will fix the issue that the KUKSA client fails due to unathenticted state at the beginning. Alternatively we could give a default token which has no rights but the right structure (possible? @argerus). But I think we are good with not ensuring startup connection. Maybe we can even drop the ensure startup connection? it just calls ```get_server_info``` to ensure databroker is there. But for now I think this is a quick little fix. An other alternative could be to give the ability to set a token while strating the client through command line.