### PR TITLE
Refactoring SPDX check

### DIFF
--- a/.github/actions/spdx/README.md
+++ b/.github/actions/spdx/README.md
@@ -11,3 +11,11 @@ that files modified in a Pull Request has an SPDX license identifier.
 It shall be possible to use this action from other repositories by referencing:
 
 `- uses: eclipse/kuksa.val/.github/actions/spdx@master`
+
+If you accept multiple licenses it can be specified like:
+
+```
+    - name: Set license
+      run: |
+        echo "licenses=Apache-2.0, MIT" >> $GITHUB_ENV
+```

--- a/.github/actions/spdx/action.yml
+++ b/.github/actions/spdx/action.yml
@@ -12,9 +12,8 @@ inputs:
     default: ''
   licenses:
     description: >
-      A space-separated list of all accepted licenses. For example:
-
-      Apache-2.0 MIT
+      A comma-separated list of all accepted licenses. For example:
+      Apache-2.0,MIT
     required: true
     default: ''
 runs:

--- a/.github/actions/spdx/verify-spdx-headers
+++ b/.github/actions/spdx/verify-spdx-headers
@@ -63,12 +63,15 @@ class Index:
     }
 
     def __init__(self):
+        """
+        This can be relaxed as needed
+        """
         self.__languages = {
-            'python': Language('#+', shebang=True),
+            'python': Language('#+.*', shebang=True),
             'ruby': Language('#+', shebang=True),
-            'c': Language('//+', ('/\\*', '\\*/')),
-            'c++': Language('//+', ('/\\*', '\\*/')),
-            'rust': Language('//+', '//!', ('/\\*', '\\*/')),
+            'c': Language('//+', '.*', ('/\\*', '\\*/')),
+            'c++': Language('//+', '.*',  ('/\\*', '\\*/')),
+            'rust': Language('//+', '.*', '//!', ('/\\*', '\\*/')),
             'protobuf': Language('//+', '//!', ('/\\*', '\\*/')),
         }
 
@@ -113,31 +116,32 @@ class Index:
 
 if __name__ == '__main__':
     import sys
-    import json
 
     # Validate the arguments
-    licenses = os.getenv('INPUT_LICENSES')
-    if licenses is None:
-        licenses = sys.argv[1:]
-    else:
-        licenses = json.loads(licenses)
+    license_arg = os.getenv('licenses')
+    if license_arg is None:
+        license_arg = sys.argv[1:]
+
+    licenses = [x.strip() for x in license_arg.split(',')]
+    print(f"{len(licenses)} will be accepted!")
     for license in licenses:
         if not SLUG.match(license):
             print("Invalid license '%s'!" % license)
             raise SystemExit(1)
+        print(f"Allowed license: {license}")
 
-    rv = 0
     index = Index()
     failed = False
     for (path, license) in index.scan():
         if license not in licenses:
+            failed = True
             if license == None:
-                failed = True
                 print(f"NO SPDX {path}")
             else:
-                print(f"{license:16} {path}")
-            rv = 1
+                print(f"WRONG LICENSE: {license:16} {path}")
+        else:
+            print(f"OK: {license:16} {path}")
     if failed:
         raise Exception("Check the output, some files have not the right licenses!")
 
-    raise SystemExit(rv)
+    raise SystemExit(0)

--- a/.github/workflows/check_license.yaml
+++ b/.github/workflows/check_license.yaml
@@ -17,8 +17,12 @@ jobs:
     - name: Get changed files
       run: |
         echo "files=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | tr '\n' ',')" >> $GITHUB_ENV
+
+    - name: Set license
+      run: |
+        echo "licenses=Apache-2.0" >> $GITHUB_ENV
         
     - uses: ./.github/actions/spdx
       with:
         files: "${{ env.files }}"
-        licenses: Apache-2.0
+        licenses: "${{ env.licenses }}"


### PR DESCRIPTION
Make sure that defined licenses are forwarded as arguments.
Increase scope of what is considered as comments
(Do not only check one-line comments)
Make sure to support comma separated list of comments

Example output checking for Apache or MIT
```
Prepare all required actions
Run ./.github/actions/spdx
Run $GITHUB_ACTION_PATH//verify-spdx-headers
2 will be accepted!
Allowed license: Apache-2.0
Allowed license: MIT
OK: Apache-2.0       /home/runner/work/kuksa.val/kuksa.val/kuksa-val-server/src/main.cpp
NO SPDX /home/runner/work/kuksa.val/kuksa.val/kuksa-val-server/test/unit-test/KuksavalUnitTest.cpp
OK: Apache-2.0       /home/runner/work/kuksa.val/kuksa.val/kuksa-val-server/test/unit-test/VssDatabaseTests.cpp
OK: Apache-2.0       /home/runner/work/kuksa.val/kuksa.val/kuksa_databroker/integration_test/test_databroker.py
OK: Apache-2.0       /home/runner/work/kuksa.val/kuksa.val/test/stresstest/broker.py
Traceback (most recent call last):
  File "/home/runner/work/kuksa.val/kuksa.val/./.github/actions/spdx//verify-spdx-headers", line 146, in <module>
    raise Exception("Check the output, some files have not the right licenses!")
Exception: Check the output, some files have not the right licenses!
Error: Process completed with exit code 1.
```