### PR TITLE
Adapting SPDX checks for Proto files

### DIFF
--- a/.github/actions/spdx/verify-spdx-headers
+++ b/.github/actions/spdx/verify-spdx-headers
@@ -72,7 +72,7 @@ class Index:
             'c': Language('//+', '.*', ('/\\*', '\\*/')),
             'c++': Language('//+', '.*',  ('/\\*', '\\*/')),
             'rust': Language('//+', '.*', '//!', ('/\\*', '\\*/')),
-            'protobuf': Language('//+', '//!', ('/\\*', '\\*/')),
+            'protobuf': Language('//+', '//!', '.*', ('/\\*', '\\*/')),
         }
 
     def language(self, path):

--- a/kuksa-val-server/protos/kuksa.proto
+++ b/kuksa-val-server/protos/kuksa.proto
@@ -1,10 +1,15 @@
-// Copyright Robert Bosch GmbH, 2021. Part of the Eclipse Kuksa Project.
-//
-// All rights reserved. This configuration file is provided to you under the
-// terms and conditions of the Eclipse Distribution License v1.0 which
-// accompanies this distribution, and is available at
-// http://www.eclipse.org/org/documents/edl-v10.php
-
+/********************************************************************************
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License 2.0 which is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 syntax = "proto3";
 

--- a/proto/kuksa/val/v1/types.proto
+++ b/proto/kuksa/val/v1/types.proto
@@ -1,9 +1,15 @@
-// Copyright Robert Bosch GmbH, 2022. Part of the Eclipse Kuksa Project.
-//
-// All rights reserved. This configuration file is provided to you under the
-// terms and conditions of the Eclipse Distribution License v1.0 which
-// accompanies this distribution, and is available at
-// http://www.eclipse.org/org/documents/edl-v10.php
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License 2.0 which is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 syntax = "proto3";
 

--- a/proto/kuksa/val/v1/val.proto
+++ b/proto/kuksa/val/v1/val.proto
@@ -1,12 +1,15 @@
-// Copyright Robert Bosch GmbH, 2022. Part of the Eclipse Kuksa Project.
-//
-// All rights reserved. This configuration file is provided to you under the
-// terms and conditions of the Eclipse Distribution License v1.0 which
-// accompanies this distribution, and is available at
-// http://www.eclipse.org/org/documents/edl-v10.php
-
-// This is a base proto file for databroker and kuksa-val-basic
-// function set
+/********************************************************************************
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License 2.0 which is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 
 syntax = "proto3";
 


### PR DESCRIPTION
Making sure all Proto files are licensed with Apache-2.0 Adapting SPDX pattern to accept multi line comments when searching for SPDX identifiers