### PR TITLE
Add documentation for Proto files.

### DIFF
--- a/doc/protocol/README.md
+++ b/doc/protocol/README.md
@@ -1,7 +1,8 @@
 # KUKSA.val Protocol
-KUKSA.val supports parts of VISS V1 https://www.w3.org/TR/vehicle-information-service/ as well as parts of the upcomming VISS2 standard ([Gen2 Core](https://raw.githack.com/w3c/automotive/gh-pages/spec/VISSv2_Core.html), [Gen2 Transport](https://raw.githack.com/w3c/automotive/gh-pages/spec/VISSv2_Transport.html)), that are applicable to in-vehicle VSS servers. KUKSA.val also has a gRPC interface to communicate.
+KUKSA.val supports parts of VISS V1 https://www.w3.org/TR/vehicle-information-service/ as well as parts of the upcoming VISS2 standard ([Gen2 Core](https://raw.githack.com/w3c/automotive/gh-pages/spec/VISSv2_Core.html), [Gen2 Transport](https://raw.githack.com/w3c/automotive/gh-pages/spec/VISSv2_Transport.html)), that are applicable to in-vehicle VSS servers.
+KUKSA.val also has a gRPC interface to communicate.
 
-The following document will detail, what is supported on the websocket (aka KUKSA.val server) and gRPC Interface (aka data broker):
+The following document describes what is supported on the websocket (aka KUKSA.val Server) and gRPC Interface (aka Databroker):
 
 
 ## [supported features](support.md)

--- a/doc/protocol/support.md
+++ b/doc/protocol/support.md
@@ -22,7 +22,7 @@ KUKSA.val only supports the Websocket transport defined in VISS v2.
 Support of VISSv2:
 
 ### Security model
-KUKSA.val does not support the VISS V2 security model and currently we are not planning to support. KUKSA.val server does support authenticated access to VSS ressources. For details check [here.](../KUKSA.val_server/jwt.md).
+KUKSA.val does not support the VISS V2 security model and currently we are not planning to support. KUKSA.val server does support authenticated access to VSS resources. For details check [here.](../KUKSA.val_server/jwt.md).
 
 ### Supported VISS (v2) calls
 
@@ -65,5 +65,4 @@ The VISS Standard is not applicable for gRPC protocol. Here is an overview what 
     * Subscribing sensor values
     * Subscribing current or target value for actuators
 
-Authorization is currently not supported, but planned.
 

--- a/kuksa-client/kuksa/val/v1/README.md
+++ b/kuksa-client/kuksa/val/v1/README.md
@@ -1,0 +1,1 @@
+../../../../proto/kuksa/val/v1/README.md

--- a/kuksa-val-server/protos/README.md
+++ b/kuksa-val-server/protos/README.md
@@ -1,0 +1,7 @@
+# kuksa protobuf API
+
+*Note: This API is deprecated and may be removed in a future version of KUKSA.val*
+*Consider using KUKSA.val Databroker instead and one of the APIs supported by KUKSA.val Databroker*
+
+This directory contain a Protobuf API supported by KUKSA.val Server.
+This API is not supported by any clients in this repository.

--- a/kuksa_databroker/proto/kuksa/val/v1/README.md
+++ b/kuksa_databroker/proto/kuksa/val/v1/README.md
@@ -1,0 +1,1 @@
+../../../../../proto/kuksa/val/v1/README.md

--- a/kuksa_databroker/proto/sdv/databroker/v1/README.md
+++ b/kuksa_databroker/proto/sdv/databroker/v1/README.md
@@ -1,0 +1,12 @@
+# sdv.databroker.v1 protobuf API
+
+This directory contain a Protobuf API supported by KUKSA.val Databroker.
+
+As of today KUKSA.val Databroker supports both this API and the
+[kuksa.val.v1](https://github.com/eclipse/kuksa.val/tree/master/proto/kuksa/val/v1) API.
+The [kuksa.val.v1](https://github.com/eclipse/kuksa.val/tree/master/proto/kuksa/val/v1) API is the newer API and is still
+in development. It does not yet support all features supported by this API.
+
+This API may in the future be deprecated. It is recommended to use
+the [kuksa.val.v1](https://github.com/eclipse/kuksa.val/tree/master/proto/kuksa/val/v1) API, unless you need
+functionality currently only provided by this API.

--- a/proto/kuksa/val/v1/README.md
+++ b/proto/kuksa/val/v1/README.md
@@ -1,0 +1,6 @@
+# kuksa.val.v1 protobuf API
+
+This directory contain a Protobuf API supported by KUKSA.val Databroker, KUKSA.val Python Client and KUKSA.val Go Client.
+
+This API is under development and will eventually replace the
+[sdv.databroker.v1](https://github.com/eclipse/kuksa.val/tree/master/kuksa_databroker/proto/sdv/databroker/v1) API.


### PR DESCRIPTION
Background:

We currently have 3 sets of Protobuf APIs,
but it is not that easy by looking in repo to know how they are intended to be used.