### PR TITLE
Fix wrong error code when subscribing to a non-existing path

### DIFF
--- a/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -24,6 +24,7 @@ use tracing::debug;
 
 use crate::broker;
 use crate::broker::ReadError;
+use crate::broker::SubscriptionError;
 use crate::permissions::Permissions;
 
 #[tonic::async_trait]
@@ -326,10 +327,16 @@ impl proto::val_server::Val for broker::DataBroker {
                 let stream = convert_to_proto_stream(stream);
                 Ok(tonic::Response::new(Box::pin(stream)))
             }
-            Err(e) => Err(tonic::Status::new(
+            Err(SubscriptionError::NotFound) => {
+                Err(tonic::Status::new(tonic::Code::NotFound, "Path not found"))
+            }
+            Err(SubscriptionError::InvalidInput) => Err(tonic::Status::new(
                 tonic::Code::InvalidArgument,
-                format!("{e:?}"),
+                "Invalid Argument",
             )),
+            Err(SubscriptionError::InternalError) => {
+                Err(tonic::Status::new(tonic::Code::Internal, "Internal Error"))
+            }
         }
     }
 


### PR DESCRIPTION
This closes https://github.com/eclipse/kuksa.val/issues/553

Since SubscribeResponse does not return a protobuf error, the current approach is to use a tonic error as the return ErrorCode. This means that the error code returned will not be 404, but rather the tonic error code. However, it might be necessary to modify the SubscribeResponse to include DataEntryError as well.