### PR TITLE
Upgrade Boost for KUKSA.val Server

### DIFF
--- a/kuksa-val-server/README.md
+++ b/kuksa-val-server/README.md
@@ -65,7 +65,7 @@ First install the required packages. On Ubuntu 20.04 this can be achieved by
 sudo apt install cmake build-essential libssl-dev libmosquitto-dev
 ```
 
-**Note**: If you use `cmake >= 3.14`, you do not need to install boost on your system. `cmake` will download the required boost for building. Otherwise you need install the [`boost==1.75`](https://www.boost.org/users/history/version_1_75_0.html) on the system.
+**Note**: If you use `cmake >= 3.14`, you do not need to install boost on your system. `cmake` will download the required boost for building. Otherwise you need install the [`boost==1.82`](https://www.boost.org/users/history/version_1_82_0.html) on the system.
 
 
 

--- a/kuksa-val-server/boost.cmake
+++ b/kuksa-val-server/boost.cmake
@@ -9,9 +9,17 @@
 #  Contributors:
 #      Robert Bosch GmbH 
 # *****************************************************************************
+#
+# If you want to update Boost version do like this:
+# 1. Change BOOST_VER below
+# 2. Look at the source page (e.g. https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/)
+#    and download the tar.bz2.json file
+#    (e.g. https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2.json)
+# 3. Extract the SHA from the file and add it to BOOST_URL_SHA256 below
+# 4. Change version in main README.md file for KUKSA.val Server
 
 set(Boost_USE_STATIC_LIBS OFF)
-set(BOOST_VER 1.75.0)
+set(BOOST_VER 1.82.0)
 set(Boost_NO_BOOST_CMAKE ON)
 set(BOOST_COMPONENTS filesystem program_options system log thread)
 ADD_DEFINITIONS(-DBOOST_LOG_DYN_LINK)
@@ -32,7 +40,7 @@ findBoost("")
 if(NOT Boost_FOUND)
   string(REPLACE "." "_" BOOST_VER_ ${BOOST_VER}) 
   set(BOOST_URL "https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VER}/source/boost_${BOOST_VER_}.tar.bz2" CACHE STRING "Boost download URL")
-  set(BOOST_URL_SHA256 "953db31e016db7bb207f11432bef7df100516eeb746843fa0486a222e3fd49cb" CACHE STRING "Boost download URL SHA256 checksum")
+  set(BOOST_URL_SHA256 "a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6" CACHE STRING "Boost download URL SHA256 checksum")
   option(BOOST_DISABLE_TESTS "Do not build test targets" OFF)
   include(FetchContent)
   set(FETCHCONTENT_QUIET OFF)

--- a/kuksa-val-server/src/OverlayLoader.cpp
+++ b/kuksa-val-server/src/OverlayLoader.cpp
@@ -24,6 +24,7 @@
 
 #include <stdexcept>
 #include <jsoncons/json.hpp>
+#include <fstream>
 
 #include "OverlayLoader.hpp"
 #include "kuksa.pb.h"


### PR DESCRIPTION
Background reason:

Newer gcc versions give more warnings, and we treat warnings as errors. We build our Docker container using alpine:3.11, but if you try to build locally there is big risk that you have a newer gcc version and runs into problems. The problems can be fixed by changing include and upgrading Boost version, as newer Boost has added a cast to the line below:

```
/home/erik/kuksa.val/kuksa-val-server/build/_deps/boost-build/include/boost/thread/pthread/thread_data.hpp:61:19: error: comparison of integer expressions of different signedness: ‘std::size_t’ {aka ‘long unsigned int’} and ‘long int’ [-Werror=sign-compare]
   61 |           if (size<PTHREAD_STACK_MIN) size=PTHREAD_STACK_MIN;
      |                   ^
compilation terminated due to -Wfatal-errors.
cc1plus: all warnings being treated as errors
```

Tests performed: 

- Building KUKSA.val Server and checking with kuksa-client that we can read and write a signal