### PR TITLE
Kuksa Python & Go client: Refactor array handling and add tests

### DIFF
--- a/.github/workflows/kuksa-go.yml
+++ b/.github/workflows/kuksa-go.yml
@@ -1,0 +1,46 @@
+# /********************************************************************************
+# * Copyright (c) 2022 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+name: kuksa_go_client
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    paths:
+    - ".github/workflows/kuksa-go.yml"
+    - "kuksa_go_client/**"
+  workflow_dispatch:
+
+jobs:
+
+  kuksa-go-client-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout kuksa.val
+        uses: actions/checkout@v3
+      - name: Run go tests
+        run: |
+          cd kuksa_go_client
+          # We cannot use sudo apt install protobuf-compiler
+          # as default in Ubuntu 22.04 (3.12) consider optional as experimental feature
+          go run protocInstall/protocInstall.go
+          export PATH=$PATH:$HOME/protoc/bin
+          sudo chmod +x $HOME/protoc/bin/protoc
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          export PATH=$PATH:$HOME/go/bin
+          go generate .
+          go test .
+

--- a/kuksa-client/README.md
+++ b/kuksa-client/README.md
@@ -182,6 +182,79 @@ This is an example showing how some of the commands can be used:
 
 ![try kuksa-client out](https://raw.githubusercontent.com/eclipse/kuksa.val/master/doc/pictures/testclient_basic.gif "test client usage")
 
+### Syntax for specifying data in the command line interface
+
+Values used as argument to for example `setValue` shall match the type given. Quotes (single and double) are 
+generally not needed, except in a few special cases. A few valid examples on setting float is shown below:
+
+```
+setValue Vehicle.Speed 43
+setValue Vehicle.Speed "45"
+setValue Vehicle.Speed '45.2'
+```
+
+For strings escaped quotes are needed if you want quotes to be sent to Server/Databroker, like if you want to store
+`Almost "red"` as value. Alternatively you can use outer single quotes and inner double quotes.
+
+The two examples below are equal:
+
+```
+setValue Vehicle.Cabin.Light.InteractiveLightBar.Effect 'Almost \"red\"'
+setValue Vehicle.Cabin.Light.InteractiveLightBar.Effect 'Almost "red"'
+```
+
+Alternatively you can use inner single quotes, but then the value will be represented by double quotes (`Almost "blue"`)
+when stored anyhow.
+
+```
+setValue Vehicle.Cabin.Light.InteractiveLightBar.Effect "Almost 'blue'"
+setValue Vehicle.Cabin.Light.InteractiveLightBar.Effect "Almost \'blue\'"
+```
+
+If not using outer quotes the inner quotes will be lost, the examples below are equal.
+Leading/trialing spaces are ignored.
+
+```
+setValue Vehicle.Cabin.Light.InteractiveLightBar.Effect Almost 'green'
+setValue Vehicle.Cabin.Light.InteractiveLightBar.Effect Almost green
+setValue Vehicle.Cabin.Light.InteractiveLightBar.Effect 'Almost green'
+setValue Vehicle.Cabin.Light.InteractiveLightBar.Effect "Almost green"
+setValue Vehicle.Cabin.Light.InteractiveLightBar.Effect 'Almost green         '
+```
+
+
+It is possible to set array values. Setting a string array with simple identifiers is not a problem. Also not if they
+contain blanks
+
+```
+// Array with two elements
+setValue Vehicle.OBD.DTCList [abc,def]
+// Array with two elements, "hello there" and "def"
+setValue Vehicle.OBD.DTCList [hello there,def]
+```
+
+Setting values that includes comma or quotation marks is more tricky, as the shell argument parser handling affects
+how they are interpreted. The recommended approach is to have outer quotes of one type and user inner quotes of the
+other type.
+
+Example 1: First item should be `hello, there`
+
+```
+setValue Vehicle.OBD.DTCList '[ "hello, there",def]'
+```
+
+Example 2: First item should be `hello, "there"`
+
+```
+setValue Vehicle.OBD.DTCList '["hello, \"there\"",def]'
+```
+
+Example 3: First item should be `hello, 'there'`
+
+```
+setValue Vehicle.OBD.DTCList "['hello, \'there\'',def]"
+```
+
 ### Updating VSS Structure
 
 Using the test client, it is also possible to update and extend the VSS data structure.

--- a/kuksa-client/kuksa_client/__main__.py
+++ b/kuksa-client/kuksa_client/__main__.py
@@ -301,6 +301,20 @@ class TestClient(Cmd):
     def do_setValue(self, args):
         """Set the value of a path"""
         if self.checkConnection():
+            # If there is a blank before a single/double quote on the kuksa-client cli then
+            # the argparser shell will remove it, there is nothing we can do to it
+            # This gives off behavior for examples like:
+            # setValue Vehicle.OBD.DTCList [ "dtc1, dtc2", ddd]
+            # which will be treated as input of 3 elements
+            # The recommended approach is to have quotes (of a different type) around the whole value
+            # if your strings includes quotes, commas or other items
+            # setValue Vehicle.OBD.DTCList '[ "dtc1, dtc2", ddd]'
+            # or
+            # setValue Vehicle.OBD.DTCList "[ 'dtc1, dtc2', ddd]"
+            # If you really need to include a quote in the values use backslash and use the quote type
+            # you want as inner value:
+            # setValue Vehicle.OBD.DTCList "[ 'dtc1, \'dtc2', ddd]"
+            # Will result in two elements in the array; "dtc1, 'dtc2" and "ddd"
             value = str(' '.join(args.Value))
             resp = self.commThread.setValue(
                 args.Path, value, args.attribute)

--- a/kuksa-client/tests/test_datapoint.py
+++ b/kuksa-client/tests/test_datapoint.py
@@ -1,0 +1,163 @@
+# /********************************************************************************
+# * Copyright (c) 2023 Contributors to the Eclipse Foundation
+# *
+# * See the NOTICE file(s) distributed with this work for additional
+# * information regarding copyright ownership.
+# *
+# * This program and the accompanying materials are made available under the
+# * terms of the Apache License 2.0 which is available at
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# ********************************************************************************/
+
+import pytest
+from kuksa_client.grpc import Datapoint
+
+#
+# Client rules:
+# For simple strings like abd it is optional to quote them ("abc") or not (abc)
+# Quotes are needed if you have commas ("ab, c")
+# If you have duoble quotes in strings you must escape them
+
+def test_array_parse_no_quote():
+    """
+    No need for quotes just because you have a blank
+    """
+    test_str = r'[say hello, abc]'
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 2
+    assert my_array[0] == "say hello"
+    assert my_array[1] == "abc"
+
+def test_array_parse_no_inside_quote():
+    """Quotes are OK"""
+    test_str = r'["say hello","abc"]'
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 2
+    assert my_array[0] == "say hello"
+    assert my_array[1] == "abc"
+
+def test_array_parse_no_inside_quote_single():
+    """Quotes are OK"""
+    test_str = "['say hello','abc']"
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 2
+    assert my_array[0] == "say hello"
+    assert my_array[1] == "abc"
+
+def test_array_parse_double_quote():
+    test_str = r'["say \"hello\"","abc"]'
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 2
+    assert my_array[0] == "say \"hello\""
+    assert my_array[1] == "abc"
+
+def test_array_parse_single_quote():
+    test_str = r'[say \'hello\',abc]'
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 2
+    assert my_array[0] == "say 'hello'"
+    assert my_array[1] == "abc"
+
+def test_array_parse_comma():
+    test_str = r'["say, hello","abc"]'
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 2
+    assert my_array[0] == r'say, hello'
+    assert my_array[1] == "abc"
+
+def test_array_square():
+    """No problem having square brackets as part of strings"""
+    test_str = r'[say hello[], abc]'
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 2
+    assert my_array[0] == "say hello[]"
+    assert my_array[1] == "abc"
+
+def test_array_empty_string_quoted():
+    test_str = r'["", abc]'
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 2
+    assert my_array[0] == ""
+    assert my_array[1] == "abc"
+
+def test_array_empty_string_not_quoted():
+    """In this case the first item is ignored"""
+    test_str = r'[, abc]'
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 1
+    assert my_array[0] == "abc"
+
+def test_double_comma():
+    """In this case the middle item is ignored"""
+    test_str = r'[def,, abc]'
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 2
+    assert my_array[0] == "def"
+    assert my_array[1] == "abc"
+
+def test_quotes_in_string_values():
+    """Escaped double quotes, so in total 4 items"""
+    test_str = r'["dtc1, dtc2", dtc3, \" dtc4, dtc4\"]'
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 4
+    assert my_array[0] == "dtc1, dtc2"
+    assert my_array[1] == "dtc3"
+    assert my_array[2] == "\" dtc4"
+    assert my_array[3] == "dtc4\""
+
+def test_quotes_in_string_values_2():
+    """Doubee quotes in double quotes so in total three values"""
+    test_str = "['dtc1, dtc2', dtc3, \" dtc4, dtc4\"]"
+    my_array = list(Datapoint.cast_array_values(Datapoint.cast_str,test_str))
+    assert len(my_array) == 3
+    assert my_array[0] == 'dtc1, dtc2'
+    assert my_array[1] == "dtc3"
+    assert my_array[2] == " dtc4, dtc4"
+
+def test_int_no_quote():
+    test_str = r'[123,456]'
+    my_array = list(Datapoint.cast_array_values(int,test_str))
+    assert len(my_array) == 2
+    assert my_array[0] == 123
+    assert my_array[1] == 456
+
+def test_int_quote():
+    """Quoting individual int values is not allowed"""
+    test_str = r'["123","456"]'
+    with pytest.raises(ValueError):
+        my_array = list(Datapoint.cast_array_values(int,test_str))
+        
+
+def test_float_no_quote():
+    test_str = r'[123,456.23]'
+    my_array = list(Datapoint.cast_array_values(float,test_str))
+    assert len(my_array) == 2
+    assert my_array[0] == 123
+    assert my_array[1] == 456.23
+
+def test_cast_str():
+    """Unquoted quotation marks shall be removed, quoted kept without quotes"""
+    test_str = r'"say hello"'
+    assert Datapoint.cast_str(test_str) == r'say hello'
+    test_str = r'"say \"hello\""'
+    assert Datapoint.cast_str(test_str) == r'say "hello"'
+    test_str = r'say "hello"'
+    assert Datapoint.cast_str(test_str) == r'say "hello"'
+
+def test_cast_bool():
+    assert Datapoint.cast_bool("true") is True
+    assert Datapoint.cast_bool("True") is True
+    assert Datapoint.cast_bool("T") is True
+    assert Datapoint.cast_bool("t") is True
+    assert Datapoint.cast_bool("false") is False
+    assert Datapoint.cast_bool("False") is False
+    assert Datapoint.cast_bool("F") is False
+    assert Datapoint.cast_bool("f") is False
+
+    # And then some other, treated as true for now
+    assert Datapoint.cast_bool("Ja") is True
+    assert Datapoint.cast_bool("Nein") is True
+    assert Datapoint.cast_bool("Doch") is True
+

--- a/kuksa_go_client/client_test.go
+++ b/kuksa_go_client/client_test.go
@@ -1,0 +1,127 @@
+
+//********************************************************************************
+// Copyright (c) 2022 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License 2.0 which is available at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// ********************************************************************************/
+
+package main
+
+import (
+	"testing"
+	"github.com/eclipse/kuksa.val/kuksa_go_client/kuksa_client"
+)
+
+// Note: Go support two methods to write a string
+//
+// Using double quotes
+// var myvar := "hello \"there\""
+//
+// Using back quotes (raw strings)
+// var myvar := `hello "there"`
+//
+// Single quotes only allowed for literals/runes, like 'w'
+
+func TestArrayParseNoQuote(t *testing.T) {
+
+	array, _ := kuksa_client.GetArrayFromInput[string](`[say hello, abc]`)
+	if len(array) != 2 { t.Fail()}
+	if array[0] != "say hello" { t.Fail()}
+	if array[1] != "abc" { t.Fail()}
+}
+
+func TestArrayParseNoInsideQuote(t *testing.T) {
+
+	array, _ := kuksa_client.GetArrayFromInput[string](`["say hello","abc"]`)
+	if len(array) != 2 { t.Fail()}
+	if array[0] != "say hello" { t.Fail()}
+	if array[1] != "abc" { t.Fail()}
+}
+
+func TestArrayParseNoInsideQuoteSingle(t *testing.T) {
+
+	array, _ := kuksa_client.GetArrayFromInput[string](`['say hello','abc']`)
+	if len(array) != 2 { t.Fail()}
+	if array[0] != "say hello" { t.Fail()}
+	if array[1] != "abc" { t.Fail()}
+}
+
+func TestArrayParseDoubleQuote(t *testing.T) {
+
+	array, _ := kuksa_client.GetArrayFromInput[string](`["say \"hello\"","abc"]`)
+	if len(array) != 2 { t.Fail()}
+	if array[0] != `say "hello"` { t.Fail()}
+	if array[1] != "abc" { t.Fail()}
+}
+
+func TestArrayParseSingleQuote(t *testing.T) {
+
+	array, _ := kuksa_client.GetArrayFromInput[string](`[say \'hello\',"abc"]`)
+	if len(array) != 2 { t.Fail()}
+	if array[0] != `say 'hello'` { t.Fail()}
+	if array[1] != "abc" { t.Fail()}
+}
+	
+func TestArrayParseComma(t *testing.T) {
+
+	array, _ := kuksa_client.GetArrayFromInput[string](`["say, hello","abc"]`)
+	if len(array) != 2 { t.Fail()}
+	if array[0] != `say, hello` { t.Fail()}
+	if array[1] != "abc" { t.Fail()}
+}
+
+func TestArraySquare(t *testing.T) {
+
+	array, _ := kuksa_client.GetArrayFromInput[string](`[say hello[], abc]`)
+	if len(array) != 2 { t.Fail()}
+	if array[0] != `say hello[]` { t.Fail()}
+	if array[1] != "abc" { t.Fail()}
+}
+
+func TestArrayEmptyStringQuoted(t *testing.T) {
+
+	array, _ := kuksa_client.GetArrayFromInput[string](`["", abc]`)
+	if len(array) != 2 { t.Fail()}
+	if array[0] != `` { t.Fail()}
+	if array[1] != "abc" { t.Fail()}
+}
+
+func TestArrayEmptyStringNotQuoted(t *testing.T) {
+	// First item shall be ignored
+	array, _ := kuksa_client.GetArrayFromInput[string](`[, abc]`)
+	if len(array) != 1 { t.Fail()}
+	if array[0] != "abc" { t.Fail()}
+}
+
+func TestDoubleComma(t *testing.T) {
+	// In this case the middle item is ignored
+	array, _ := kuksa_client.GetArrayFromInput[string](`[def,, abc]`)
+	if len(array) != 2 { t.Fail()}
+	if array[0] != "def" { t.Fail()}
+	if array[1] != "abc" { t.Fail()}
+}
+
+func TestQuotesInStringValues(t *testing.T) {
+	array, _ := kuksa_client.GetArrayFromInput[string](`["dtc1, dtc2", dtc3, \" dtc4, dtc4\"]`)
+	if len(array) != 4 { t.Fail()}
+	if array[0] != "dtc1, dtc2" { t.Fail()}
+	if array[1] != "dtc3" { t.Fail()}
+	if array[2] != "\" dtc4" { t.Fail()}
+	if array[3] != "dtc4\"" { t.Fail()}
+}
+
+func TestQuotesInStringValues2(t *testing.T) {
+	array, _ := kuksa_client.GetArrayFromInput[string]("['dtc1, dtc2', dtc3, \" dtc4, dtc4\"]")
+	if len(array) != 3 { t.Fail()}
+	if array[0] != "dtc1, dtc2" { t.Fail()}
+	if array[1] != "dtc3" { t.Fail()}
+	if array[2] != " dtc4, dtc4" { t.Fail()}
+}
+

--- a/kuksa_go_client/main.go
+++ b/kuksa_go_client/main.go
@@ -106,11 +106,17 @@ if err != nil {
 	}
 
 	// set string with "" and \"
-	err = backend.SetValueFromKuksaVal("Vehicle.OBD.DTCList", "['dtc1, dtc2', dtc2, \"dtc3, dtc3\"]", "value")
+	// Expected result is 4 items in the list
+	// dtc1, dtc2
+	// dtc2
+	// dtc3, dtc3
+	// dtc4
+	var valstr = "['dtc1, dtc2', dtc2, \"dtc3, dtc3\", dtc4]"
+	err = backend.SetValueFromKuksaVal("Vehicle.OBD.DTCList", valstr, "value")
 	if err != nil {
 		log.Printf("Set Value Error: %v", err)
 	} else {
-		log.Printf("Vehicle.OBD.DTCList Set: ['dtc1, dtc2', dtc2, \"dtc3, dtc3\"]")
+		log.Printf("Vehicle.OBD.DTCList Set: " + valstr)
 	}
 
 	values, err = backend.GetValueFromKuksaVal("Vehicle.OBD.DTCList", "value")


### PR DESCRIPTION
This is work in progress. Background is that code scanning showed that the current regexp may be inefficient for certain strings. To see if it could be simplified without causing side effects a number of test cases has been added, which also partially proves as documentation on how it is intended to work. A similar change is one for the go client.