### PR TITLE
Add pre-commit checks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max_line_length = 120

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,16 @@
+name: pre-commit
+
+on: [pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # required to grab the history of the PR
+          fetch-depth: 0
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0
+        with:
+          extra_args: --color=always --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+        exclude_types: ["dbc"]
+    -   id: end-of-file-fixer
+        exclude_types: ["dbc", "json"]
+        exclude: \.token$
+    -   id: check-yaml
+    -   id: check-added-large-files
+
+-   repo: https://github.com/pycqa/flake8
+    rev: '6.0.0'
+    hooks:
+    -   id: flake8

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ KUKSA.val provides in-vehicle software components for working with in-vehicle si
 If you are new here, try the [Quickstart](doc/quickstart.md), which should not take more than 10 min of your time.
 
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0) 
+[![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Gitter](https://img.shields.io/gitter/room/kuksa-val/community)](https://gitter.im/kuksa-val/community)
 
 [![Build kuksa-val-server](https://github.com/eclipse/kuksa.val/actions/workflows/kuksa_val_docker.yml/badge.svg)](https://github.com/eclipse/kuksa.val/actions/workflows/kuksa_val_docker.yml?query=branch%3Amaster)
@@ -32,3 +32,9 @@ KUKSA.val contains several components
 
 * [KUKSA.val TLS Concept](doc/tls.md)
 
+## Pre-commit set up
+This repository is set up to use [pre-commit](https://pre-commit.com/) hooks.
+Use `pip install pre-commit` to install pre-commit.
+After you clone the project, run `pre-commit install` to install pre-commit into your git hooks.
+Pre-commit will now run on every commit.
+Every time you clone a project using pre-commit running pre-commit install should always be the first thing you do.


### PR DESCRIPTION
This will introduce pre-commit checks for kuksa-val. We already have it for kuksa.val.feeders

What it will do:

- For most files check that there is a line-break at end-of-file
- For most files verify that you do not have trailing blanks
- For python verify that flake8 pass, checking for instance line lengths

Suggest approach is to have a pre-commit hook installed on your local machine, then the check will be performed before you commit and this check shall be guaranteed to pass. But you may work reactively as well and fix issues if build fails and upload a new version. It only checks files affected by the commit/PR, but it checks the whole file, so initially you may need to fix some old sins.

Caveat: There might be cases where we do not want files to be changed, I took some settings "inherited" from kuksa.val.feeders. If you would notice that the checker wants to change files that should not be changed, then we may need to tweak the setting.