### PR TITLE
Use default time (24h) for ttl images

### DIFF
--- a/.github/workflows/kuksa-client.yml
+++ b/.github/workflows/kuksa-client.yml
@@ -92,7 +92,7 @@ jobs:
         context: .
         file: kuksa-client/Dockerfile
         push: false
-        tags: "ttl.sh/kuksa.val/kuksa-client-${{github.sha}}:1h"
+        tags: "ttl.sh/kuksa.val/kuksa-client-${{github.sha}}"
         labels: ${{ steps.meta.outputs.labels }}
         
 

--- a/.github/workflows/kuksa_val_docker.yml
+++ b/.github/workflows/kuksa_val_docker.yml
@@ -66,7 +66,7 @@ jobs:
         push: true
         tags: | 
           ${{ steps.meta.outputs.tags }}
-          ttl.sh/kuksa.val/kuksa-server-${{github.sha}}:1h
+          ttl.sh/kuksa.val/kuksa-server-${{github.sha}}
         labels: ${{ steps.meta.outputs.labels }}
 
     - name: Build ephemereal kuksa-val docker and push to ttl.sh
@@ -79,5 +79,5 @@ jobs:
         file: ./kuksa-val-server/docker/Dockerfile
         context: .
         push: true
-        tags: ttl.sh/kuksa.val/kuksa-server-${{github.sha}}:1h
+        tags: ttl.sh/kuksa.val/kuksa-server-${{github.sha}}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Use default lifetime (24 hours) instead of 1h/8h, to be able to use e.g. a image build last night the following morning. 

Fixes #598