### PR TITLE
Replace actions-rs/install build action

### DIFF
--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -59,21 +59,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-tarpaulin
-          version: latest
-
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cross
-          version: latest
-
-      - uses: actions-rs/install@v0.1
-        with:
-          crate: cargo-strip
-          version: latest
-
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install dependencies
+        run: |
+          cargo install cargo-tarpaulin
       - name: Show toolchain information
         working-directory: ${{github.workspace}}
         run: |


### PR DESCRIPTION
Old action is not maintained and uses Node.js 12, so will give us problems sooner or later

See https://github.com/actions-rs/toolchain/issues/216