### PR TITLE
Remove KUKSA-val gRPC client

### DIFF
--- a/kuksa-val-server/README.md
+++ b/kuksa-val-server/README.md
@@ -121,21 +121,3 @@ The jwt tokens for testing can also be found under [kuksa_certificates/jwt](../k
 You can also use the provided python sdk to develop your own `kuksa.val` clients. More details about `kuksa-client` can be found [here](../kuksa-client).
 
 Additionally, you can use the [example apps](../kuksa_apps) and [feeders](https://github.com/eclipse/kuksa.val.feeders/tree/main) to handle vehicle data, interacting with `kuksa-val-server`.
-
-## Using kuksa.val with a gRPC Client
-Additionally theres exists an experimental gRPC server. The easiest way to test the server is the kuksa_grpc_client.
-To run the client follow these steps:
-
-```
-cd build/src
-./kuksa_grpc_client
-```
-
-If you do not know how to use the client:
-
-```
-./kuksa_grpc_client --help
-```
-
-
-

--- a/kuksa-val-server/src/CMakeLists.txt
+++ b/kuksa-val-server/src/CMakeLists.txt
@@ -22,7 +22,6 @@ set(SERVER_OBJ_LIB_NAME ${SERVER_EXE_NAME}-object )
 set(SERVER_LIB_NAME ${SERVER_EXE_NAME}-core )
 set(SERVER_LIB_STATIC_NAME ${SERVER_LIB_NAME}-static )
 set(GRPC_GENERATED_LIB_NAME kuksa_grpc_client_generated-object)
-set(GRPC_CLIENT_EXE_NAME kuksa_grpc_client)
 
 
 ###


### PR DESCRIPTION
Code does not exist, so just remove from documentation. server side support still exists, that is ok but we should not promote it