### PR TITLE
Change kuksa-client version handling

### DIFF
--- a/.github/workflows/kuksa-client.yml
+++ b/.github/workflows/kuksa-client.yml
@@ -34,6 +34,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        # Fetch everything to get tags working as expected
+        fetch-depth: 0
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v4
@@ -48,15 +51,15 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-          
-    # only needed for runners without buildx setup, will be slow 
+
+    # only needed for runners without buildx setup, will be slow
     #- name: Set up QEMU
     #  uses: docker/setup-qemu-action@v2
-      
+
     #- name: Set up Docker Buildx
     #  id: buildx
     #  uses: docker/setup-buildx-action@v2
-    
+
     - name: Log in to the Container registry
       if: needs.checkrights.outputs.have_secrets == 'true'
       uses: docker/login-action@v2
@@ -94,7 +97,7 @@ jobs:
         push: false
         tags: "ttl.sh/kuksa.val/kuksa-client-${{github.sha}}"
         labels: ${{ steps.meta.outputs.labels }}
-        
+
 
   kuksa-client-test:
     runs-on: ubuntu-latest
@@ -118,4 +121,3 @@ jobs:
           cd kuksa-client
           pip install --upgrade build
           python -m build
-

--- a/kuksa-client/Dockerfile
+++ b/kuksa-client/Dockerfile
@@ -10,11 +10,10 @@
 
 FROM python:3.10-alpine as build
 RUN apk update && apk add git alpine-sdk linux-headers
-COPY kuksa-client /kuksa.val/kuksa-client/
-COPY kuksa_certificates /kuksa.val/kuksa_certificates/
-COPY proto/kuksa/val/v1/*.proto /kuksa.val/kuksa-client/kuksa/val/v1/
-WORKDIR /kuksa.val/kuksa-client
 RUN pip install --upgrade pip build
+# We must copy the whole repository otherwise version lookup by tag would not work
+COPY . /kuksa.val/
+WORKDIR /kuksa.val/kuksa-client
 RUN rm -rf dist
 RUN python3 -m build
 RUN mkdir /kuksa-client

--- a/kuksa-client/pyproject.toml
+++ b/kuksa-client/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "grpcio-tools>=1.46.0",
+    "grpcio-tools>=1.54.2",
     "setuptools>=42",
     "setuptools-git-versioning",
     "wheel",
@@ -8,8 +8,8 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools-git-versioning]
-starting_version = "0.1.6"
-tag_filter = "[0-9]+.[0-9]+.[0-9]+"
+# Starting version is just a dummy value that never shall be used in CI
+starting_version = "0.0.0"
 
 [tool.pylint.design]
 max-args = 8


### PR DESCRIPTION
The reason is that all docker builds on master previously got version v0.1.6 which gave odd behavior if downloading kuksa-client:master or even latest

**Current behavior**

If downloading `kuksa-client:master` and running it then it will report `Welcome to Kuksa Client version 0.1.6`
This also occurs if downloading [kuksa-client:latest](https://github.com/eclipse/kuksa.val/pkgs/container/kuksa.val%2Fkuksa-client/81633962?tag=latest)

**Expected behavior**

Either real tag or something that shows that it is not tagged.

With this PR in CI the version will be like:

`0.3.1.post84+git.3cba9d41`

i.e. 84 commits after v 0.3.1

I have not tested that it reports right version for tagged versions on official repository

**How to reproduce**

```
erik@debian3:~/kuksa.val/kuksa-client$ docker pull ghcr.io/eclipse/kuksa.val/kuksa-client:master
...
Status: Downloaded newer image for ghcr.io/eclipse/kuksa.val/kuksa-client:master

erik@debian3:~/kuksa.val/kuksa-client$ docker run --rm -it --net=host ghcr.io/eclipse/kuksa.val/kuksa-client:master --ip 127.0.0.1 --port 55555 --protocol grpc
Welcome to Kuksa Client version 0.1.6
```
