### PR TITLE
Testing KUKSA Server Unittest

### DIFF
--- a/.github/actions/unit-test/Dockerfile
+++ b/.github/actions/unit-test/Dockerfile
@@ -11,8 +11,8 @@ FROM ubuntu:20.04 as build
 RUN apt-get  update && DEBIAN_FRONTEND="noninteractive" apt-get -y install libssl-dev  \
                         pkg-config \
                         build-essential \
-                        gnupg2 \ 
-                        wget \ 
+                        gnupg2 \
+                        wget \
                         software-properties-common \
                         git \
                         cmake \
@@ -30,7 +30,7 @@ RUN ./b2 -j 6 install
 
 WORKDIR /
 # Build and install grpc
-ENV GRPC_VER=1.40.0
+ENV GRPC_VER=1.44.0
 RUN git clone --recurse-submodules -b v${GRPC_VER} https://github.com/grpc/grpc
 RUN mkdir -p /grpc/build
 WORKDIR /grpc/build

--- a/.github/actions/unit-test/Dockerfile
+++ b/.github/actions/unit-test/Dockerfile
@@ -8,7 +8,7 @@
 
 FROM ubuntu:20.04 as build
 
-RUN apt-get  update && DEBIAN_FRONTEND="noninteractive" apt-get -y install libssl-dev  \
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get -y install libssl-dev  \
                         pkg-config \
                         build-essential \
                         gnupg2 \
@@ -18,30 +18,6 @@ RUN apt-get  update && DEBIAN_FRONTEND="noninteractive" apt-get -y install libss
                         cmake \
                         libmosquitto-dev \
                         gcovr lcov
-
-# Build and install Boost 1.75
-ENV BOOST_VER=1.75.0
-ENV BOOST_VER_=1_75_0
-RUN wget https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VER}/source/boost_${BOOST_VER_}.tar.bz2
-RUN tar xjf boost_${BOOST_VER_}.tar.bz2
-WORKDIR /boost_${BOOST_VER_}
-RUN ./bootstrap.sh
-RUN ./b2 -j 6 install
-
-WORKDIR /
-# Build and install grpc
-ENV GRPC_VER=1.44.0
-RUN git clone --recurse-submodules -b v${GRPC_VER} https://github.com/grpc/grpc
-RUN mkdir -p /grpc/build
-WORKDIR /grpc/build
-RUN cmake -DgRPC_INSTALL=ON  -DgRPC_BUILD_TESTS=OFF -DgRPC_SSL_PROVIDER=package ..
-RUN make -j 6
-RUN make install
-RUN mkdir -p /grpc/third_party/abseil-cpp/build
-WORKDIR /grpc/third_party/abseil-cpp/build
-RUN cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE ..
-RUN make -j 6
-RUN make install
 
 COPY run_tests.sh /entrypoint.sh
 

--- a/.github/actions/unit-test/run_tests.sh
+++ b/.github/actions/unit-test/run_tests.sh
@@ -15,7 +15,7 @@ while getopts ":b:a:h" opt; do
       ;;
     a ) artifactdir=$OPTARG
       ;;
-    h|\? ) printUsage 
+    h|\? ) printUsage
       ;;
   esac
 done
@@ -31,18 +31,18 @@ cd ${builddir}
 
 cmake -DBUILD_UNIT_TEST=ON -DCTEST_RESULT_CODE=no -DENABLE_COVERAGE=ON ..
 
-make -j8
+make -j 4
 
 rm -rf test/unit-test/results.xml
 rm -rf lcov/data/capture/all_targets.info
 
 ctest --output-on-failure
-make lcov 
+make lcov
 lcov --list lcov/data/capture/all_targets.info
 
 echo "archive artifacts under ${artifactdir}"
 cd ${basepath}
-if [ ! -d "${artifactdir}" ] 
+if [ ! -d "${artifactdir}" ]
 then
   mkdir -p ${artifactdir}
 fi

--- a/.github/workflows/kuksa_val_unittest.yml
+++ b/.github/workflows/kuksa_val_unittest.yml
@@ -2,24 +2,28 @@ name: kuksa_val_unittests
 
 on:
   push:
-    branches: [ disabled ]
-    tags:
-      - '0.*'
+    branches: [ master ]
   pull_request:
-    branches: [ disabled ]
-    
+    branches: [ master ]
+    paths:
+    - ".github/workflows/kuksa_val_unittest.yml"
+    - "kuksa-val-server/**"
+    - "kuksa_certificates/**"
+    - "proto/**"
+  workflow_dispatch:
+
 jobs:
   buildAndTest:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-      with: 
+    - uses: actions/checkout@v3
+      with:
         submodules: recursive
     - name: Unit test
       uses: ./.github/actions/unit-test
     - name: listing test results
-      run: ls out 
+      run: ls out
     - name: Upload unittests artifact
       uses: actions/upload-artifact@v2
       with:

--- a/doc/KUKSA.val_server/build-docker.md
+++ b/doc/KUKSA.val_server/build-docker.md
@@ -19,9 +19,8 @@ docker buildx build --platform=linux/arm64 -f ./kuksa-val-server/docker/Dockerfi
 ## Development Docker
 Not optimized at all, just gets  Ubuntu installed and does a first compile. Will drop you to a shell
 
-To build go to kuksa.val server main dir and do
+To build go to `kuksa.val` directory and do
 
 ```
-docker build -f ./kuksa-val-server/docker/Dockerfile.dev -t kuksavaltest . 
+docker build -f ./kuksa-val-server/docker/Dockerfile.dev -t kuksavaltest .
 ```
-

--- a/doc/KUKSA.val_server/build-docker.md
+++ b/doc/KUKSA.val_server/build-docker.md
@@ -17,7 +17,8 @@ docker buildx build --platform=linux/arm64 -f ./kuksa-val-server/docker/Dockerfi
 
 
 ## Development Docker
-Not optimized at all, just gets  Ubuntu installed and does a first compile. Will drop you to a shell
+Not optimized at all, just gets  Ubuntu installed and does compile KUKSA Server.
+When run it will start KUKSA Server with default configuration.
 
 To build go to `kuksa.val` directory and do
 

--- a/doc/KUKSA.val_server/liveUpdateVSSTree.md
+++ b/doc/KUKSA.val_server/liveUpdateVSSTree.md
@@ -13,12 +13,12 @@ We suggest not creating overlay JSON files directly, but instead writing YAML fi
 
 Lets make an example
 
-Consider you want to add a signal and change an existing VSS entry. 
+Consider you want to add a signal and change an existing VSS entry.
 
 Consider this VSS-compliant YAML file. We call it `roadster-elon.vspec`
 
 ```yaml
-# Extend kuksa-val model   
+# Extend kuksa-val model
 - Vehicle:
   type: branch
 
@@ -34,7 +34,7 @@ Consider this VSS-compliant YAML file. We call it `roadster-elon.vspec`
   type: sensor
 ```
 
-What happened here? 
+What happened here?
  - We changed the allowed max value for `Vehicle.Speed`. This value is already in the standard COVESA VSS data points, however in our use example we need to increase the allowed max value
  - We added a completely new signal `ThrustersActive` in the `Vehicle.Private` branch
 
@@ -49,14 +49,14 @@ python3 vspec2json.py -i :my.id -I ../spec/ roadster-elon.vspec  roadster-elon.j
 Now let's try on a running KUKSA.val instance with a vanilla VSS structure.
 Using the test client, you can update the VSS tree like this:
 ```
-updateVSSTree roadster-elon.json 
+updateVSSTree roadster-elon.json
 ```
 
 Then you can check, that the new signal is available and the max speed limit has increased:
 
 ![Alt text](../pictures/testclient_updateVSSTree.gif "test client update vss tree")
 
-**Note:** You may need the [super-admin.json.token](../../kuksa_certificates/jwt/super-admin.json.token) for authorization. 
+**Note:** You may need the [super-admin.json.token](../../kuksa_certificates/jwt/super-admin.json.token) for authorization.
 
 ## Hot-patching with updateMetaData
 if you just want to add or change a single metadata item in a signal or sensor, going through the whole VSS tooling may be a little cumbersome. Instead, you can use the testclient to update metadata of a single path directly, if you have the permission to modify metadata:
@@ -72,5 +72,5 @@ updateMetaData updateMetaData Vehicle.Speed '{"max":9999}'
 ## Limitations
 As the Input data to `updateVSSTree` as well as `updateMetaData`is merged with the existing data structure, there is no way to _remove_ previously added elements.
 
-**This feature schould be considered Beta quality.**
-Similar to the initial JSON, there is not much input verification going on. We _check_ that you provide syntactically valid JSON, we _trust_ that it is a valid VSS structure. Therefore, as a system design suggestion, we recommend you perform any neccesary, potentially dangerous, data structure modifcations during system initialization phase, preferably using the `--overlays` parameter of `kuksa-val-server`.
+**This feature should be considered Beta quality.**
+Similar to the initial JSON, there is not much input verification going on. We _check_ that you provide syntactically valid JSON, we _trust_ that it is a valid VSS structure. Therefore, as a system design suggestion, we recommend you perform any necessary, potentially dangerous, data structure modifications during system initialization phase, preferably using the `--overlays` parameter of `kuksa-val-server`.

--- a/kuksa-val-server/README.md
+++ b/kuksa-val-server/README.md
@@ -65,9 +65,6 @@ First install the required packages. On Ubuntu 20.04 this can be achieved by
 sudo apt install cmake build-essential libssl-dev libmosquitto-dev
 ```
 
-**Note**: If you use `cmake >= 3.14`, you do not need to install boost on your system. `cmake` will download the required boost for building. Otherwise you need install the [`boost==1.82`](https://www.boost.org/users/history/version_1_82_0.html) on the system.
-
-
 
 ### Compiling
 Create a build folder inside the kuksa-val-server folder and execute cmake

--- a/kuksa-val-server/docker/Dockerfile
+++ b/kuksa-val-server/docker/Dockerfile
@@ -7,39 +7,10 @@
 
 FROM alpine:3.11 as build
 
-LABEL maintainer="Sebastian Schildt <sebastian.schildt@de.bosch.com>"
-
-
-
 RUN apk update && apk add cmake wget alpine-sdk linux-headers openssl-dev libstdc++ mosquitto-dev
 
-
-#Build Boost 1.75
-ENV BOOST_VER=1.75.0
-ENV BOOST_VER_=1_75_0
-RUN wget   https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VER}/source/boost_${BOOST_VER_}.tar.bz2
-RUN tar xvjf boost_${BOOST_VER_}.tar.bz2
-WORKDIR /boost_${BOOST_VER_}
-RUN ./bootstrap.sh
-RUN ./b2 -j 6 install
-
-WORKDIR /
-# Build and install grpc
-ENV GRPC_VER=1.44.0
-RUN git clone --recurse-submodules -b v${GRPC_VER}  --single-branch --depth 1 --shallow-submodules https://github.com/grpc/grpc
-RUN mkdir -p /grpc/build
-WORKDIR /grpc/build
-RUN cmake -DgRPC_INSTALL=ON  -DgRPC_BUILD_TESTS=OFF -DgRPC_SSL_PROVIDER=package ..
-RUN make -j 6
-RUN make install
-RUN mkdir -p /grpc/third_party/abseil-cpp/build
-WORKDIR /grpc/third_party/abseil-cpp/build
-RUN cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE ..
-RUN make -j 6
-RUN make install
-
 ADD . /kuksa.val
-RUN  rm -rf /kuksa.val/kuksa-val-server/build  && mkdir  /kuksa.val/kuksa-val-server/build 
+RUN  rm -rf /kuksa.val/kuksa-val-server/build  && mkdir  /kuksa.val/kuksa-val-server/build
 WORKDIR /kuksa.val/kuksa-val-server/build
 RUN cmake ..
 RUN make -j 4
@@ -53,11 +24,9 @@ COPY --from=build /deploy /kuksa.val
 WORKDIR /kuksa.val
 
 ENV LOG_LEVEL=INFO
-#Usually you want this to be 0.0.0.0 when using porter port expose via -p. 
+#Usually you want this to be 0.0.0.0 when using porter port expose via -p.
 ENV BIND_ADDRESS=0.0.0.0
 
 EXPOSE 8090/tcp
 
 CMD /kuksa.val/startkuksaval.sh
-
-

--- a/kuksa-val-server/docker/Dockerfile.dev
+++ b/kuksa-val-server/docker/Dockerfile.dev
@@ -11,31 +11,18 @@ FROM ubuntu:20.04 as build
 RUN apt-get  update && DEBIAN_FRONTEND="noninteractive" apt-get -y install libssl-dev  \
                         pkg-config \
                         build-essential \
-                        gnupg2 \ 
-                        wget \ 
+                        gnupg2 \
+                        wget \
                         software-properties-common \
                         git \
                         cmake \
                         libmosquitto-dev \
                         gcovr
 
-#Build Boost 1.75
-ENV BOOST_VER=1.75.0
-ENV BOOST_VER_=1_75_0
-RUN mkdir /buildboost
-WORKDIR /buildboost
-RUN wget   https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VER}/source/boost_${BOOST_VER_}.tar.bz2
-RUN tar xvjf boost_${BOOST_VER_}.tar.bz2
-WORKDIR /buildboost/boost_${BOOST_VER_}
-RUN ./bootstrap.sh
-RUN ./b2 -j 6 install
-
-
 ADD . /kuksa.val
-RUN  rm -rf /kuksa.val/kuksa-val-server/build  && mkdir  /kuksa.val/kuksa-val-server/build 
+RUN  rm -rf /kuksa.val/kuksa-val-server/build  && mkdir  /kuksa.val/kuksa-val-server/build
 WORKDIR /kuksa.val/kuksa-val-server/build
 RUN cmake .. -DBUILD_UNIT_TEST=ON -DCMAKE_BUILD_TYPE=Coverage
 RUN make -j8
 
-CMD ./src/kuksa-val-server -c src/config.ini 
-
+CMD ./src/kuksa-val-server -c src/config.ini

--- a/kuksa-val-server/docker/Dockerfile.dev
+++ b/kuksa-val-server/docker/Dockerfile.dev
@@ -23,6 +23,6 @@ ADD . /kuksa.val
 RUN  rm -rf /kuksa.val/kuksa-val-server/build  && mkdir  /kuksa.val/kuksa-val-server/build
 WORKDIR /kuksa.val/kuksa-val-server/build
 RUN cmake .. -DBUILD_UNIT_TEST=ON -DCMAKE_BUILD_TYPE=Coverage
-RUN make -j8
+RUN make -j 4
 
 CMD ./src/kuksa-val-server -c src/config.ini


### PR DESCRIPTION
This aligns unit-tests with other triggers and now it works. It also removes explicit install of gRPC and Boost. That is included from cmake so not needed. The old warning that it might be needed for "older" versions of cmake shall likely not be relevant any longer, at least not if we assume that Ubuntu 20 or newer is used. 

Still the build takes time. A possible remedy for CI could be to join both builds to the same so we do not need to install boost and gRPC twice.

Now also using 4 threads (`-j 4` in all builds)
