### PR TITLE
Fix protoc install vulnerability

### DIFF
--- a/kuksa_go_client/protocInstall/protocInstall.go
+++ b/kuksa_go_client/protocInstall/protocInstall.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 const (
@@ -50,8 +51,11 @@ func UnzipSource(source, destination string) error {
 	}
 
 	for _, f := range reader.File {
+		if strings.Contains(f.Name, "..") {
+			fmt.Println("Ignoring path traversal elements (CWE-22): ", f.Name)
+			continue
+		}
 		filePath := filepath.Join(destination, f.Name)
-
 		if f.FileInfo().IsDir() {
 			err := os.MkdirAll(filePath, os.ModePerm)
 			if err != nil {


### PR DESCRIPTION
See https://cwe.mitre.org/data/definitions/22.html

Theoretical risk in short:
- We download a malicious zip archive
- The zip archive contains items like "../../usr/bin/something"
- We might end up with installing unwanted files at wrong places

Tested that it does not affect normal install
This was detected when running Github code scanning in my own fork