### PR TITLE
Add (optional) VISSv2 interface

### DIFF
--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -43,6 +43,10 @@ jobs:
       - name: cargo clippy
         working-directory: ${{github.workspace}}
         run: cargo clippy --all-targets -- -W warnings -D warnings
+      - name: cargo clippy (feature viss)
+        working-directory: ${{github.workspace}}
+        run: cargo clippy --features viss --all-targets -- -W warnings -D warnings
+
 
   test:
     name: Test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,12 +196,13 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
+ "base64 0.21.2",
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
@@ -201,7 +217,13 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -275,6 +297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -307,6 +338,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +360,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "time 0.1.45",
+ "wasm-bindgen",
+ "winapi",
+]
 
 [[package]]
 name = "clap"
@@ -398,6 +450,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +480,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -477,13 +554,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+
+[[package]]
 name = "databroker"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "axum",
+ "chrono",
  "clap",
  "cucumber",
  "databroker-proto",
+ "futures",
  "jemallocator",
  "jsonwebtoken",
  "lazy_static",
@@ -499,6 +585,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "vergen",
 ]
 
@@ -551,6 +638,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -765,6 +862,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -992,7 +1099,7 @@ dependencies = [
  "bstr",
  "itoa",
  "thiserror",
- "time",
+ "time 0.3.23",
 ]
 
 [[package]]
@@ -1615,6 +1722,29 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2581,6 +2711,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2623,7 +2786,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time",
+ "time 0.3.23",
 ]
 
 [[package]]
@@ -2850,6 +3013,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
@@ -2955,6 +3129,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3099,6 +3286,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "tungstenite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e862a1c4128df0112ab625f55cd5c934bcb4312ba80b39ae4b4835a3fd58e649"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,6 +3314,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-bidi"
@@ -3172,10 +3384,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+dependencies = [
+ "getrandom 0.2.10",
+]
 
 [[package]]
 name = "vergen"
@@ -3186,7 +3413,7 @@ dependencies = [
  "anyhow",
  "gix",
  "rustversion",
- "time",
+ "time 0.3.23",
 ]
 
 [[package]]
@@ -3219,6 +3446,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/doc/protocol/support.md
+++ b/doc/protocol/support.md
@@ -1,60 +1,81 @@
-# What do the KUKSA.val Server and databroker support?
-This file contains an overview what the KUKSA.val Server and databroker each supports. It focuses on gRPC and VISS support and also what feeders are supported.
-
 ## Supported protocols
 
-
-| Protocol   |      KUKSA.val server      |  KUKSA.val databroker   |
-|------------|:-----------------:|----------:|
-| VISS V1    |      o           |     o     |
-| VISS V2    |     x/o          |     o     |
-| gRPC       |      x           |     x     |
-
-x = supported; x/o = partly supported; o = not supported
+This file contains an overview what the KUKSA.val Server and databroker each supports. It focuses on gRPC and VISS support and also what feeders are supported.
 
 
-### Server and VISS 
+| Protocol                  | KUKSA.val server | KUKSA.val databroker |
+|---------------------------|:----------------:|:--------------------:|
+| VISS V1                   |         -        |           -          |
+| VISS V2                   |        x/-       |          x/-         |
+| gRPC (kuksa)              |         x        |           -          |
+| gRPC (kuksa.val.v1)       |         -        |           x          |
+| gRPC (sdv.databroker.v1)  |         -        |           x          |
 
-KUKSA.val server supports the semantic of [VISS v1](https://www.w3.org/TR/vehicle-information-service/) using the new syntax of [VISS v2](https://www.w3.org/TR/viss2-core/).
+x = supported; x/- = partially supported; - = not supported
 
-KUKSA.val only supports the Websocket transport defined in VISS v2.
 
-Support of VISSv2:
+### VISSv2 support (websocket transport)
 
-### Security model
-KUKSA.val does not support the VISS V2 security model and currently we are not planning to support. KUKSA.val server does support authenticated access to VSS resources. For details check [here.](../KUKSA.val_server/jwt.md).
+| Feature                       | KUKSA.val server  | KUKSA.val databroker |
+|-------------------------------|:-----------------:|:--------------------:|
+| Read                          |                   |                      |
+|   - Authorized Read           | x<sup>1,2</sup>   |           x          |
+|   - Search Read               | -                 |           -          |
+|   - History Read              | -                 |           -          |
+|   - Static Metadata Read      | -                 |           x          |
+|   - Dynamic Metadata Read     | -                 |           -          |
+| Update                        |                   |                      |
+|   - Authorized Update         | x<sup>1,2</sup>   |           x          |
+| Subscribe                     |                   |                      |
+|   - Authorized Subscribe      | x<sup>1,2</sup>   |           x          |
+|   - Curve Logging Subscribe   | -                 |           -          |
+|   - Range Subscribe           | -                 |           -          |
+|   - Change Subscribe          | -                 |           -          |
+| Unsubscribe                   | x                 |           x          |
+| Subscription                  | x                 |           x          |
+| Error messages                | x                 |           x          |
+| Timestamps                    | x                 |           x          |
 
-### Supported VISS (v2) calls
+x = supported
 
-| method                        |   Support                     | Comment                                                                                                           |
-|-------------------------------|:-----------------------------:|-------------------------------------------------------------------------------------------------------------------|
-| Read                          |            x/o                ||
-|   - Authorized Read           |             x                 | Authorization must be performed as standalone call, do not support "in-lining" authorization in read call         |
-|   - Search Read               |             o                 ||
-|   - History Read              |             o                 ||
-|   - Signal Discovery Read     |             o                 ||
-|   - Dynamic Metadata Read     |             o                 ||
-| Update                        |             x                 ||
-|   - Authorized Update         |             x                 | Authorization must be performed as standalone call, do not support "in-lining" authorization in update call       |
-| Subscribe                     |             x                 ||
-|   - Authorized Subscribe      |             x                 | Authorization must be performed as standalone call, do not support "in-lining" authorization in subscribe call    |
-|   - Curve Logging Subscribe   |             o                 ||
-|   - Range Subscribe           |             o                 ||
-|   - Change Subscribe          |             o                 ||
-| Unsubscribe                   |             x                 ||
-| Subscription                  |             x                 ||
-| Error messages                |             x                 ||
-| Timestamps                    |             x                 ||
+x<sup>1</sup> Authorization is done using a non-standard standalone call which is incompatible with standards compliant clients.
 
-x = implemented; x/o = partly implemented; o = not implemented
+x<sup>2</sup> Relies on the non-standard `attribute` values which doesn't work with standards compliant clients.
 
 For a more detailed view of the supported JSON-schemas [click here](https://github.com/eclipse/kuksa.val/blob/master/kuksa-val-server/include/VSSRequestJsonSchema.hpp)
 
+### VISSv2 in KUKSA.val server
+KUKSA.val server supports the semantics of [VISS v1](https://www.w3.org/TR/vehicle-information-service/) using the new syntax of [VISS v2](https://www.w3.org/TR/viss2-core/). It implements a modified version of VISSv2 which introduces the concept of `attributes` which makes it incompatible with standards compliant VISSv2 clients.
+KUKSA.val server doesn't support the VISS V2 security model and there is currently no plan to support it. KUKSA.val server does support authenticated access to VSS resources. For details check [here.](../KUKSA.val_server/jwt.md).
+
+### VISSv2 in KUKSA.val databroker
+KUKSA.val databroker aims to provide a standards compliant implementation of VISSv2 (using the websocket transport).
+
+It supports authorization using the access token format specified in [authorization.md](../KUKSA.val_data_broker/authorization.md).
+
+VISSv2 support in databroker is included by building it with the `viss` feature flag.
+```shell
+$ cargo build --features viss
+```
+
+The `enable-viss` flag must be provided at startup in order to enable the VISSv2 websocket interface.
+
+```shell
+$ databroker --enable-viss
+```
+
+Using kuksa-client, the VISSv2 interface of databroker is available using the `ws` protocol in the uri, i.e.:
+
+```shell
+$ kuksa-client ws://127.0.0.1:8090
+```
+
+TLS is currently not supported.
 
 ### KUKSA.val databroker gRPC API
-The VISS Standard is not applicable for gRPC protocol. Here is an overview what the gRPC API in KUKSA.val databroker is capable of:
+The VISS Standard is not applicable for gRPC protocols. Here is an overview what the gRPC API in KUKSA.val databroker is capable of:
 
-  * Read: Reading VSS datapoints 
+  * Read: Reading VSS datapoints
     * Reading current or target value for actuators
     * Reading some metadata information from VSS datapoints
   * Write: Writing VSS datapoints
@@ -64,5 +85,3 @@ The VISS Standard is not applicable for gRPC protocol. Here is an overview what 
   * Subscription: Subscribing VSS datapoints
     * Subscribing sensor values
     * Subscribing current or target value for actuators
-
-

--- a/kuksa-client/kuksa_client/__main__.py
+++ b/kuksa-client/kuksa_client/__main__.py
@@ -97,7 +97,7 @@ class TestClient(Cmd):
             # Convert to dict with paths as key
             self.metadata = {entry["path"]: entry for entry in entries}
         else:
-            entries = json.loads(self.getMetaData("*"))
+            entries = json.loads(self.getMetaData(""))
             if 'metadata' in entries:
                 # Convert to dict with paths as key
                 self.metadata = metadata_tree_to_dict(entries['metadata'])

--- a/kuksa_databroker/databroker-cli/src/main.rs
+++ b/kuksa_databroker/databroker-cli/src/main.rs
@@ -341,7 +341,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     continue;
                                 }
 
-                                if metadata.entry_type != proto::v1::EntryType::Actuator.into() {
+                                if metadata.entry_type != proto::v1::EntryType::Actuator as i32 {
                                     print_error(
                                         cmd,
                                         format!("{} is not an actuator.", metadata.name),
@@ -1434,7 +1434,6 @@ fn try_into_data_value(
             )),
             Err(err) => Err(err),
         },
-        _ => Err(ParseError {}),
     }
 }
 

--- a/kuksa_databroker/databroker-proto/src/lib.rs
+++ b/kuksa_databroker/databroker-proto/src/lib.rs
@@ -78,8 +78,6 @@ pub mod kuksa {
                         "float[]" => Ok(DataType::FloatArray),
                         "double" => Ok(DataType::Double),
                         "double[]" => Ok(DataType::DoubleArray),
-                        "timestamp" => Ok(DataType::Timestamp),
-                        "timestamp[]" => Ok(DataType::TimestampArray),
                         _ => Err(ParsingError::new(format!("unsupported data type '{s}'"))),
                     }
                 }

--- a/kuksa_databroker/databroker/Cargo.toml
+++ b/kuksa_databroker/databroker/Cargo.toml
@@ -55,11 +55,17 @@ jemallocator = { version = "0.5.0", optional = true }
 lazy_static = "1.4.0"
 thiserror = "1.0.47"
 
+# VISS
+axum = { version = "0.6.20", optional = true, features = ["ws"] }
+futures = { version = "0.3.28", optional = true }
+chrono = { version = "0.4.26", optional = true, features = ["std", "time"] }
+uuid = { version = "1.4.1", optional = true, features = ["v4"] }
+
 [features]
 default = ["tls"]
 tls = ["tonic/tls"]
-# to enable jemalloc use --features jemalloc
 jemalloc = ["dep:jemallocator"]
+viss = ["dep:axum", "dep:chrono", "dep:futures", "dep:uuid"]
 libtest = []
 
 [build-dependencies]

--- a/kuksa_databroker/databroker/src/broker.rs
+++ b/kuksa_databroker/databroker/src/broker.rs
@@ -553,8 +553,6 @@ impl Entry {
                 DataValue::DoubleArray(_) => Ok(()),
                 _ => Err(UpdateError::WrongType),
             },
-            DataType::Timestamp => Err(UpdateError::UnsupportedType),
-            DataType::TimestampArray => Err(UpdateError::UnsupportedType),
         }
     }
 

--- a/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/conversions.rs
+++ b/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/conversions.rs
@@ -43,7 +43,6 @@ impl From<broker::DataType> for proto::DataType {
             broker::DataType::Uint64 => proto::DataType::Uint64,
             broker::DataType::Float => proto::DataType::Float,
             broker::DataType::Double => proto::DataType::Double,
-            broker::DataType::Timestamp => proto::DataType::Timestamp,
             broker::DataType::StringArray => proto::DataType::StringArray,
             broker::DataType::BoolArray => proto::DataType::BooleanArray,
             broker::DataType::Int8Array => proto::DataType::Int8Array,
@@ -56,7 +55,6 @@ impl From<broker::DataType> for proto::DataType {
             broker::DataType::Uint64Array => proto::DataType::Uint64Array,
             broker::DataType::FloatArray => proto::DataType::FloatArray,
             broker::DataType::DoubleArray => proto::DataType::DoubleArray,
-            broker::DataType::TimestampArray => proto::DataType::TimestampArray,
         }
     }
 }

--- a/kuksa_databroker/databroker/src/grpc/sdv_databroker_v1/conversions.rs
+++ b/kuksa_databroker/databroker/src/grpc/sdv_databroker_v1/conversions.rs
@@ -177,7 +177,6 @@ impl From<&proto::DataType> for broker::DataType {
             proto::DataType::Uint64 => broker::DataType::Uint64,
             proto::DataType::Float => broker::DataType::Float,
             proto::DataType::Double => broker::DataType::Double,
-            proto::DataType::Timestamp => broker::DataType::Timestamp,
             proto::DataType::StringArray => broker::DataType::StringArray,
             proto::DataType::BoolArray => broker::DataType::BoolArray,
             proto::DataType::Int8Array => broker::DataType::Int8Array,
@@ -190,7 +189,6 @@ impl From<&proto::DataType> for broker::DataType {
             proto::DataType::Uint64Array => broker::DataType::Uint64Array,
             proto::DataType::FloatArray => broker::DataType::FloatArray,
             proto::DataType::DoubleArray => broker::DataType::DoubleArray,
-            proto::DataType::TimestampArray => broker::DataType::TimestampArray,
         }
     }
 }
@@ -255,7 +253,6 @@ impl From<&broker::DataType> for proto::DataType {
             broker::DataType::Uint64 => proto::DataType::Uint64,
             broker::DataType::Float => proto::DataType::Float,
             broker::DataType::Double => proto::DataType::Double,
-            broker::DataType::Timestamp => proto::DataType::Timestamp,
             broker::DataType::StringArray => proto::DataType::StringArray,
             broker::DataType::BoolArray => proto::DataType::BoolArray,
             broker::DataType::Int8Array => proto::DataType::Int8Array,
@@ -268,7 +265,6 @@ impl From<&broker::DataType> for proto::DataType {
             broker::DataType::Uint64Array => proto::DataType::Uint64Array,
             broker::DataType::FloatArray => proto::DataType::FloatArray,
             broker::DataType::DoubleArray => proto::DataType::DoubleArray,
-            broker::DataType::TimestampArray => proto::DataType::TimestampArray,
         }
     }
 }

--- a/kuksa_databroker/databroker/src/lib.rs
+++ b/kuksa_databroker/databroker/src/lib.rs
@@ -20,6 +20,9 @@ pub mod query;
 pub mod types;
 pub mod vss;
 
+#[cfg(feature = "viss")]
+pub mod viss;
+
 use std::fmt::Write;
 
 use tracing::info;

--- a/kuksa_databroker/databroker/src/permissions.rs
+++ b/kuksa_databroker/databroker/src/permissions.rs
@@ -26,6 +26,13 @@ lazy_static! {
         provide: PathMatcher::Everything,
         create: PathMatcher::Everything,
     };
+    pub static ref ALLOW_NONE: Permissions = Permissions {
+        expires_at: None,
+        read: PathMatcher::Nothing,
+        actuate: PathMatcher::Nothing,
+        provide: PathMatcher::Nothing,
+        create: PathMatcher::Nothing,
+    };
 }
 
 #[derive(Debug, Clone)]

--- a/kuksa_databroker/databroker/src/types.rs
+++ b/kuksa_databroker/databroker/src/types.rs
@@ -27,7 +27,6 @@ pub enum DataType {
     Uint64,
     Float,
     Double,
-    Timestamp,
     StringArray,
     BoolArray,
     Int8Array,
@@ -40,7 +39,6 @@ pub enum DataType {
     Uint64Array,
     FloatArray,
     DoubleArray,
-    TimestampArray,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/kuksa_databroker/databroker/src/viss/mod.rs
+++ b/kuksa_databroker/databroker/src/viss/mod.rs
@@ -1,0 +1,15 @@
+/********************************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License 2.0 which is available at
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+pub mod server;
+pub mod v2;

--- a/kuksa_databroker/databroker/src/viss/server.rs
+++ b/kuksa_databroker/databroker/src/viss/server.rs
@@ -1,0 +1,276 @@
+/********************************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License 2.0 which is available at
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+use axum::{
+    extract::ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade},
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+use std::{borrow::Cow, net::SocketAddr};
+
+use tracing::{debug, error, info, trace};
+
+use futures::{channel::mpsc, Sink};
+use futures::{stream::StreamExt, Stream};
+
+use crate::authorization::Authorization;
+use crate::broker;
+
+use super::v2::{self, server::Viss};
+
+#[derive(Clone)]
+struct AppState {
+    broker: broker::DataBroker,
+    authorization: Authorization,
+}
+
+pub async fn serve(
+    addr: impl Into<std::net::SocketAddr>,
+    broker: broker::DataBroker,
+    // #[cfg(feature = "tls")] server_tls: ServerTLS,
+    authorization: Authorization,
+    // signal: F
+) -> Result<(), Box<dyn std::error::Error>> {
+    let app = Router::new()
+        .route("/", get(handle_upgrade))
+        .with_state(AppState {
+            broker,
+            authorization,
+        });
+
+    let addr = addr.into();
+    let builder = axum::Server::try_bind(&addr).map_err(|err| {
+        error!("Failed to bind address {addr}: {err}");
+        err
+    })?;
+
+    info!("VISSv2 (websocket) service listening on {}", addr);
+    builder
+        .serve(app.into_make_service_with_connect_info::<SocketAddr>())
+        .await
+        .map_err(|e| e.into())
+}
+
+// Handle upgrade request
+async fn handle_upgrade(
+    ws: WebSocketUpgrade,
+    axum::extract::ConnectInfo(addr): axum::extract::ConnectInfo<SocketAddr>,
+    axum::extract::State(state): axum::extract::State<AppState>,
+) -> impl IntoResponse {
+    debug!("Received websocket upgrade request");
+    ws.protocols(["VISSv2"])
+        .on_upgrade(move |socket| handle_websocket(socket, addr, state.broker, state.authorization))
+}
+
+// Handle websocket (one per connection)
+async fn handle_websocket(
+    socket: WebSocket,
+    addr: SocketAddr,
+    broker: broker::DataBroker,
+    authorization: Authorization,
+) {
+    let valid_subprotocol = match socket.protocol() {
+        Some(subprotocol) => match subprotocol.to_str() {
+            Ok("VISSv2") => {
+                debug!("VISSv2 requested");
+                true
+            }
+            Ok(_) | Err(_) => {
+                debug!("Unsupported websocket subprotocol");
+                false
+            }
+        },
+        None => {
+            debug!("Websocket subprotocol not specified, defaulting to VISSv2");
+            true
+        }
+    };
+    let mut socket = socket;
+    if !valid_subprotocol {
+        let _ = socket
+            .send(Message::Close(Some(CloseFrame {
+                code: axum::extract::ws::close_code::PROTOCOL,
+                reason: Cow::from("Unsupported websocket subprotocol"),
+            })))
+            .await;
+        return;
+    }
+
+    let (write, read) = socket.split();
+
+    handle_viss_v2(write, read, addr, broker, authorization).await;
+}
+
+async fn handle_viss_v2<W, R>(
+    write: W,
+    mut read: R,
+    client_addr: SocketAddr,
+    broker: broker::DataBroker,
+    authorization: Authorization,
+) where
+    W: Sink<Message> + Unpin + Send + 'static,
+    <W as Sink<Message>>::Error: Send,
+    R: Stream<Item = Result<Message, axum::Error>> + Unpin + Send + 'static,
+{
+    // Create a multi producer / single consumer channel, where the
+    // single consumer will write to the socket.
+    let (sender, receiver) = mpsc::channel::<Message>(10);
+
+    let server = v2::server::Server::new(broker, authorization);
+    let mut write_task = tokio::spawn(async move {
+        let _ = receiver.map(Ok).forward(write).await;
+    });
+
+    let mut read_task = tokio::spawn(async move {
+        while let Some(Ok(msg)) = read.next().await {
+            match msg {
+                Message::Text(msg) => {
+                    debug!("Received request: {msg}");
+
+                    // Handle it
+                    let sender = sender.clone();
+                    let serialized_response = match parse_v2_msg(&msg) {
+                        Ok(request) => {
+                            match request {
+                                v2::Request::Get(request) => match server.get(request).await {
+                                    Ok(response) => serialize(response),
+                                    Err(error_response) => serialize(error_response),
+                                },
+                                v2::Request::Set(request) => match server.set(request).await {
+                                    Ok(response) => serialize(response),
+                                    Err(error_response) => serialize(error_response),
+                                },
+                                v2::Request::Subscribe(request) => {
+                                    match server.subscribe(request).await {
+                                        Ok((response, stream)) => {
+                                            // Setup background stream
+                                            let mut background_sender = sender.clone();
+
+                                            tokio::spawn(async move {
+                                                let mut stream = stream;
+                                                while let Some(event) = stream.next().await {
+                                                    let serialized_event = match event {
+                                                        Ok(event) => serialize(event),
+                                                        Err(error_event) => serialize(error_event),
+                                                    };
+
+                                                    if let Ok(text) = serialized_event {
+                                                        debug!("Sending notification: {}", text);
+                                                        if let Err(err) = background_sender
+                                                            .try_send(Message::Text(text))
+                                                        {
+                                                            debug!("Failed to send notification: {err}");
+                                                            if err.is_disconnected() {
+                                                                break;
+                                                            }
+                                                        };
+                                                    }
+                                                }
+                                            });
+
+                                            // Return response
+                                            serialize(response)
+                                        }
+                                        Err(error_response) => serialize(error_response),
+                                    }
+                                }
+                                v2::Request::Unsubscribe(request) => {
+                                    match server.unsubscribe(request).await {
+                                        Ok(response) => serialize(response),
+                                        Err(error_response) => serialize(error_response),
+                                    }
+                                }
+                            }
+                        }
+                        Err(error_response) => serialize(error_response),
+                    };
+
+                    // Send it
+                    if let Ok(text) = serialized_response {
+                        debug!("Sending response: {}", text);
+                        let mut sender = sender;
+                        if let Err(err) = sender.try_send(Message::Text(text)) {
+                            debug!("Failed to send response: {err}")
+                        };
+                    }
+                }
+                Message::Binary(msg) => {
+                    debug!(
+                        "Received binary message from {} (ignoring it) len={}: {:?}",
+                        client_addr,
+                        msg.len(),
+                        msg
+                    );
+                }
+                Message::Close(msg) => {
+                    if let Some(close) = msg {
+                        debug!(
+                            "Received close connection request from {}: code = {}, reason: \"{}\"",
+                            client_addr, close.code, close.reason
+                        );
+                    } else {
+                        debug!(
+                            "Received close connection request from {}: (missing CloseFrame)",
+                            client_addr
+                        );
+                    }
+                    break;
+                }
+                Message::Pong(msg) => {
+                    trace!("Received pong message from {}: {:?}", client_addr, msg);
+                }
+                Message::Ping(msg) => {
+                    // Handled automatically
+                    trace!("Received ping message from {}: {:?}", client_addr, msg);
+                }
+            }
+        }
+    });
+
+    // If any one of the tasks exit, abort the other.
+    tokio::select! {
+        _ = (&mut read_task) => {
+            debug!("Read task completed, aborting write task.");
+            write_task.abort();
+        }
+        _ = (&mut write_task) => {
+            debug!("Write task completed, aborting read task.");
+            read_task.abort();
+        },
+    }
+    info!("Websocket connection closed ({})", client_addr);
+}
+
+fn parse_v2_msg(msg: &str) -> Result<v2::Request, v2::GenericErrorResponse> {
+    let request: v2::Request =
+        serde_json::from_str(msg).map_err(|_| {
+            match serde_json::from_str::<v2::GenericRequest>(msg) {
+                Ok(request) => v2::GenericErrorResponse {
+                    action: request.action,
+                    request_id: request.request_id,
+                    error: v2::Error::BadRequest { msg: None },
+                },
+                Err(_) => v2::GenericErrorResponse {
+                    action: None,
+                    request_id: None,
+                    error: v2::Error::BadRequest { msg: None },
+                },
+            }
+        })?;
+    Ok(request)
+}
+
+fn serialize(response: impl v2::Response) -> Result<String, serde_json::Error> {
+    serde_json::to_string(&response)
+}

--- a/kuksa_databroker/databroker/src/viss/v2/conversions.rs
+++ b/kuksa_databroker/databroker/src/viss/v2/conversions.rs
@@ -1,0 +1,432 @@
+/********************************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License 2.0 which is available at
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+use std::{convert::TryFrom, time::SystemTime};
+
+use crate::broker;
+
+use super::types::{
+    ActuatorEntry, AttributeEntry, DataPoint, DataType, MetadataEntry, SensorEntry, Value,
+};
+
+pub enum Error {
+    ParseError,
+}
+
+impl From<broker::Datapoint> for DataPoint {
+    fn from(dp: broker::Datapoint) -> Self {
+        DataPoint {
+            value: dp.value.into(),
+            ts: dp.ts.into(),
+        }
+    }
+}
+
+impl TryFrom<Value> for String {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Array(_) | Value::None => Err(Error::ParseError),
+            Value::Scalar(value) => Ok(value),
+        }
+    }
+}
+
+impl TryFrom<Value> for bool {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Array(_) | Value::None => Err(Error::ParseError),
+            Value::Scalar(value) => value.parse::<bool>().map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for i32 {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Array(_) | Value::None => Err(Error::ParseError),
+            Value::Scalar(value) => value.parse::<i32>().map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for i64 {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Array(_) | Value::None => Err(Error::ParseError),
+            Value::Scalar(value) => value.parse::<i64>().map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for u32 {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Array(_) | Value::None => Err(Error::ParseError),
+            Value::Scalar(value) => value.parse::<u32>().map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for u64 {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Array(_) | Value::None => Err(Error::ParseError),
+            Value::Scalar(value) => value.parse::<u64>().map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for f32 {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Array(_) | Value::None => Err(Error::ParseError),
+            Value::Scalar(value) => value.parse::<f32>().map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for f64 {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Array(_) | Value::None => Err(Error::ParseError),
+            Value::Scalar(value) => value.parse::<f64>().map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for Vec<String> {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Scalar(_) | Value::None => Err(Error::ParseError),
+            Value::Array(array) => Ok(array),
+        }
+    }
+}
+
+impl TryFrom<Value> for Vec<bool> {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Scalar(_) | Value::None => Err(Error::ParseError),
+            Value::Array(array) => array
+                .iter()
+                .map(|value| value.parse::<bool>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for Vec<i32> {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Scalar(_) | Value::None => Err(Error::ParseError),
+            Value::Array(array) => array
+                .iter()
+                .map(|value| value.parse::<i32>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for Vec<i64> {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Scalar(_) | Value::None => Err(Error::ParseError),
+            Value::Array(array) => array
+                .iter()
+                .map(|value| value.parse::<i64>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for Vec<u32> {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Scalar(_) | Value::None => Err(Error::ParseError),
+            Value::Array(array) => array
+                .iter()
+                .map(|value| value.parse::<u32>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for Vec<u64> {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Scalar(_) | Value::None => Err(Error::ParseError),
+            Value::Array(array) => array
+                .iter()
+                .map(|value| value.parse::<u64>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for Vec<f32> {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Scalar(_) | Value::None => Err(Error::ParseError),
+            Value::Array(array) => array
+                .iter()
+                .map(|value| value.parse::<f32>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl TryFrom<Value> for Vec<f64> {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Scalar(_) | Value::None => Err(Error::ParseError),
+            Value::Array(array) => array
+                .iter()
+                .map(|value| value.parse::<f64>())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl From<broker::DataValue> for Value {
+    fn from(value: broker::DataValue) -> Self {
+        match value {
+            broker::DataValue::NotAvailable => Value::None,
+            broker::DataValue::Bool(value) => Value::Scalar(value.to_string()),
+            broker::DataValue::String(value) => Value::Scalar(value),
+            broker::DataValue::Int32(value) => Value::Scalar(value.to_string()),
+            broker::DataValue::Int64(value) => Value::Scalar(value.to_string()),
+            broker::DataValue::Uint32(value) => Value::Scalar(value.to_string()),
+            broker::DataValue::Uint64(value) => Value::Scalar(value.to_string()),
+            broker::DataValue::Float(value) => Value::Scalar(value.to_string()),
+            broker::DataValue::Double(value) => Value::Scalar(value.to_string()),
+            broker::DataValue::BoolArray(array) => {
+                Value::Array(array.iter().map(|value| value.to_string()).collect())
+            }
+            broker::DataValue::StringArray(array) => Value::Array(array),
+            broker::DataValue::Int32Array(array) => {
+                Value::Array(array.iter().map(|value| value.to_string()).collect())
+            }
+            broker::DataValue::Int64Array(array) => {
+                Value::Array(array.iter().map(|value| value.to_string()).collect())
+            }
+            broker::DataValue::Uint32Array(array) => {
+                Value::Array(array.iter().map(|value| value.to_string()).collect())
+            }
+            broker::DataValue::Uint64Array(array) => {
+                Value::Array(array.iter().map(|value| value.to_string()).collect())
+            }
+            broker::DataValue::FloatArray(array) => {
+                Value::Array(array.iter().map(|value| value.to_string()).collect())
+            }
+            broker::DataValue::DoubleArray(array) => {
+                Value::Array(array.iter().map(|value| value.to_string()).collect())
+            }
+        }
+    }
+}
+
+impl TryFrom<Value> for SystemTime {
+    type Error = Error;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        match value {
+            Value::Array(_) | Value::None => Err(Error::ParseError),
+            Value::Scalar(value) => chrono::DateTime::parse_from_rfc3339(&value)
+                .map(|datetime| datetime.with_timezone(&chrono::Utc))
+                .map(SystemTime::from)
+                .map_err(|_| Error::ParseError),
+        }
+    }
+}
+
+impl From<broker::DataType> for DataType {
+    fn from(value: broker::DataType) -> Self {
+        match value {
+            broker::DataType::String => DataType::String,
+            broker::DataType::Bool => DataType::Boolean,
+            broker::DataType::Int8 => DataType::Int8,
+            broker::DataType::Int16 => DataType::Int16,
+            broker::DataType::Int32 => DataType::Int32,
+            broker::DataType::Int64 => DataType::Int64,
+            broker::DataType::Uint8 => DataType::Uint8,
+            broker::DataType::Uint16 => DataType::Uint16,
+            broker::DataType::Uint32 => DataType::Uint32,
+            broker::DataType::Uint64 => DataType::Uint64,
+            broker::DataType::Float => DataType::Float,
+            broker::DataType::Double => DataType::Double,
+            broker::DataType::StringArray => DataType::StringArray,
+            broker::DataType::BoolArray => DataType::BoolArray,
+            broker::DataType::Int8Array => DataType::Int8Array,
+            broker::DataType::Int16Array => DataType::Int16Array,
+            broker::DataType::Int32Array => DataType::Int32Array,
+            broker::DataType::Int64Array => DataType::Int64Array,
+            broker::DataType::Uint8Array => DataType::Uint8Array,
+            broker::DataType::Uint16Array => DataType::Uint16Array,
+            broker::DataType::Uint32Array => DataType::Uint32Array,
+            broker::DataType::Uint64Array => DataType::Uint64Array,
+            broker::DataType::FloatArray => DataType::FloatArray,
+            broker::DataType::DoubleArray => DataType::DoubleArray,
+        }
+    }
+}
+impl From<&broker::Metadata> for MetadataEntry {
+    fn from(metadata: &broker::Metadata) -> Self {
+        match metadata.entry_type {
+            broker::EntryType::Sensor => MetadataEntry::Sensor(SensorEntry {
+                datatype: metadata.data_type.clone().into(),
+                description: metadata.description.clone(),
+                comment: None,
+                unit: None,
+                allowed: metadata.allowed.clone().map(|allowed| allowed.into()),
+                min: None,
+                max: None,
+            }),
+            broker::EntryType::Attribute => MetadataEntry::Attribute(AttributeEntry {
+                datatype: metadata.data_type.clone().into(),
+                description: metadata.description.clone(),
+                unit: None,
+                allowed: metadata.allowed.clone().map(|allowed| allowed.into()),
+                default: None, // TODO: Add to metadata
+            }),
+            broker::EntryType::Actuator => MetadataEntry::Actuator(ActuatorEntry {
+                description: metadata.description.clone(),
+                comment: None,
+                datatype: metadata.data_type.clone().into(),
+                unit: None,
+                allowed: metadata.allowed.clone().map(|allowed| allowed.into()),
+                min: None,
+                max: None,
+            }),
+        }
+    }
+}
+
+impl Value {
+    pub fn try_into_type(self, data_type: &broker::DataType) -> Result<broker::DataValue, Error> {
+        match data_type {
+            broker::DataType::String => String::try_from(self).map(broker::DataValue::String),
+            broker::DataType::Bool => bool::try_from(self).map(broker::DataValue::Bool),
+            broker::DataType::Int8 | broker::DataType::Int16 | broker::DataType::Int32 => {
+                i32::try_from(self).map(broker::DataValue::Int32)
+            }
+            broker::DataType::Int64 => i64::try_from(self).map(broker::DataValue::Int64),
+            broker::DataType::Uint8 | broker::DataType::Uint16 | broker::DataType::Uint32 => {
+                u32::try_from(self).map(broker::DataValue::Uint32)
+            }
+            broker::DataType::Uint64 => u64::try_from(self).map(broker::DataValue::Uint64),
+            broker::DataType::Float => f32::try_from(self).map(broker::DataValue::Float),
+            broker::DataType::Double => f64::try_from(self).map(broker::DataValue::Double),
+            // broker::DataType::Timestamp => {
+            //     SystemTime::try_from(self).map(broker::DataValue::Timestamp)
+            // }
+            broker::DataType::StringArray => {
+                Vec::<String>::try_from(self).map(broker::DataValue::StringArray)
+            }
+            broker::DataType::BoolArray => {
+                Vec::<bool>::try_from(self).map(broker::DataValue::BoolArray)
+            }
+            broker::DataType::Int8Array
+            | broker::DataType::Int16Array
+            | broker::DataType::Int32Array => {
+                Vec::<i32>::try_from(self).map(broker::DataValue::Int32Array)
+            }
+            broker::DataType::Int64Array => {
+                Vec::<i64>::try_from(self).map(broker::DataValue::Int64Array)
+            }
+            broker::DataType::Uint8Array
+            | broker::DataType::Uint16Array
+            | broker::DataType::Uint32Array => {
+                Vec::<u32>::try_from(self).map(broker::DataValue::Uint32Array)
+            }
+            broker::DataType::Uint64Array => {
+                Vec::<u64>::try_from(self).map(broker::DataValue::Uint64Array)
+            }
+            broker::DataType::FloatArray => {
+                Vec::<f32>::try_from(self).map(broker::DataValue::FloatArray)
+            }
+            broker::DataType::DoubleArray => {
+                Vec::<f64>::try_from(self).map(broker::DataValue::DoubleArray)
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for DataType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.pad(match self {
+            DataType::String => "string",
+            DataType::Boolean => "bool",
+            DataType::Int8 => "int8",
+            DataType::Int16 => "int16",
+            DataType::Int32 => "int32",
+            DataType::Int64 => "int64",
+            DataType::Uint8 => "uint8",
+            DataType::Uint16 => "uint16",
+            DataType::Uint32 => "uint32",
+            DataType::Uint64 => "uint64",
+            DataType::Float => "float",
+            DataType::Double => "double",
+            DataType::StringArray => "string[]",
+            DataType::BoolArray => "bool[]",
+            DataType::Int8Array => "int8[]",
+            DataType::Int16Array => "int16[]",
+            DataType::Int32Array => "int32[]",
+            DataType::Int64Array => "int64[]",
+            DataType::Uint8Array => "uint8[]",
+            DataType::Uint16Array => "uint16[]",
+            DataType::Uint32Array => "uint32[]",
+            DataType::Uint64Array => "uint64[]",
+            DataType::FloatArray => "float[]",
+            DataType::DoubleArray => "double[]",
+        })
+    }
+}

--- a/kuksa_databroker/databroker/src/viss/v2/mod.rs
+++ b/kuksa_databroker/databroker/src/viss/v2/mod.rs
@@ -1,0 +1,19 @@
+/********************************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License 2.0 which is available at
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+mod conversions;
+
+pub(crate) mod server;
+pub(crate) mod types;
+
+pub use types::*;

--- a/kuksa_databroker/databroker/src/viss/v2/server.rs
+++ b/kuksa_databroker/databroker/src/viss/v2/server.rs
@@ -1,0 +1,428 @@
+/********************************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License 2.0 which is available at
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+use std::{
+    collections::{HashMap, HashSet},
+    convert::TryFrom,
+    pin::Pin,
+    sync::Arc,
+    time::SystemTime,
+};
+
+use futures::{
+    stream::{AbortHandle, Abortable},
+    Stream, StreamExt,
+};
+use tokio::sync::RwLock;
+use tracing::warn;
+
+use crate::{
+    authorization::Authorization,
+    broker::{self, AuthorizedAccess, UpdateError},
+    permissions::{self, Permissions},
+};
+
+use super::{conversions, types::*};
+
+#[tonic::async_trait]
+pub(crate) trait Viss: Send + Sync + 'static {
+    async fn get(&self, request: GetRequest) -> Result<GetSuccessResponse, GetErrorResponse>;
+    async fn set(&self, request: SetRequest) -> Result<SetSuccessResponse, SetErrorResponse>;
+
+    type SubscribeStream: Stream<Item = Result<SubscriptionEvent, SubscriptionErrorEvent>>
+        + Send
+        + 'static;
+
+    async fn subscribe(
+        &self,
+        request: SubscribeRequest,
+    ) -> Result<(SubscribeSuccessResponse, Self::SubscribeStream), SubscribeErrorResponse>;
+
+    async fn unsubscribe(
+        &self,
+        request: UnsubscribeRequest,
+    ) -> Result<UnsubscribeSuccessResponse, UnsubscribeErrorResponse>;
+}
+
+pub struct SubscriptionHandle {
+    abort_handle: AbortHandle,
+}
+
+impl From<AbortHandle> for SubscriptionHandle {
+    fn from(abort_handle: AbortHandle) -> Self {
+        Self { abort_handle }
+    }
+}
+
+impl Drop for SubscriptionHandle {
+    fn drop(&mut self) {
+        self.abort_handle.abort();
+    }
+}
+
+pub struct Server {
+    broker: broker::DataBroker,
+    authorization: Authorization,
+    subscriptions: Arc<RwLock<HashMap<SubscriptionId, SubscriptionHandle>>>,
+}
+
+impl Server {
+    pub fn new(broker: broker::DataBroker, authorization: Authorization) -> Self {
+        Self {
+            broker,
+            authorization,
+            subscriptions: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl Viss for Server {
+    async fn get(&self, request: GetRequest) -> Result<GetSuccessResponse, GetErrorResponse> {
+        let request_id = request.request_id;
+
+        if let Some(Filter::StaticMetadata(_)) = &request.filter {
+            // Authorization not required for metadata, don't bail if an
+            // access token is missing.
+            let broker = self.broker.authorized_access(&permissions::ALLOW_NONE);
+            let metadata = generate_metadata(&broker, request.path.as_ref()).await;
+            return Ok(GetSuccessResponse::Metadata(MetadataResponse {
+                request_id,
+                metadata,
+            }));
+        }
+        let permissions = resolve_permissions(&self.authorization, &request.authorization)
+            .map_err(|error| GetErrorResponse {
+                request_id: request_id.clone(),
+                error,
+                ts: SystemTime::now().into(),
+            })?;
+        let broker = self.broker.authorized_access(&permissions);
+
+        // Get datapoints
+        match broker.get_datapoint_by_path(request.path.as_ref()).await {
+            Ok(datapoint) => {
+                let dp = DataPoint::from(datapoint);
+                Ok(GetSuccessResponse::Data(DataResponse {
+                    request_id,
+                    data: Data::Object(DataObject {
+                        path: request.path,
+                        dp,
+                    }),
+                }))
+            }
+            Err(err) => Err(GetErrorResponse {
+                request_id,
+                ts: SystemTime::now().into(),
+                error: match err {
+                    broker::ReadError::NotFound => Error::NotFoundInvalidPath,
+                    broker::ReadError::PermissionDenied => Error::Forbidden,
+                    broker::ReadError::PermissionExpired => Error::UnauthorizedTokenExpired,
+                },
+            }),
+        }
+    }
+
+    async fn set(&self, request: SetRequest) -> Result<SetSuccessResponse, SetErrorResponse> {
+        let request_id = request.request_id;
+        let permissions = resolve_permissions(&self.authorization, &request.authorization)
+            .map_err(|error| SetErrorResponse {
+                request_id: request_id.clone(),
+                error,
+                ts: SystemTime::now().into(),
+            })?;
+        let broker = self.broker.authorized_access(&permissions);
+
+        match broker.get_metadata_by_path(request.path.as_ref()).await {
+            Some(metadata) => {
+                if metadata.entry_type != broker::EntryType::Actuator {
+                    return Err(SetErrorResponse {
+                        request_id,
+                        error: Error::UnauthorizedReadOnly,
+                        ts: SystemTime::now().into(),
+                    });
+                }
+
+                let value = request.value;
+
+                let update = value
+                    .try_into_type(&metadata.data_type)
+                    .map(|actuator_target| broker::EntryUpdate {
+                        path: None,
+                        datapoint: None,
+                        actuator_target: Some(Some(broker::Datapoint {
+                            value: actuator_target,
+                            ts: SystemTime::now(),
+                        })),
+                        entry_type: None,
+                        data_type: None,
+                        description: None,
+                        allowed: None,
+                    })
+                    .map_err(|err| SetErrorResponse {
+                        request_id: request_id.clone(),
+                        error: match err {
+                            conversions::Error::ParseError => Error::BadRequest {
+                                msg: Some(format!(
+                                    "Failed to parse the value as a {}",
+                                    DataType::from(metadata.data_type.clone())
+                                )),
+                            },
+                        },
+                        ts: SystemTime::now().into(),
+                    })?;
+
+                let updates = vec![(metadata.id, update)];
+                match broker.update_entries(updates).await {
+                    Ok(()) => Ok(SetSuccessResponse {
+                        request_id,
+                        ts: SystemTime::now().into(),
+                    }),
+                    Err(errors) => {
+                        let error = if let Some((_, error)) = errors.get(0) {
+                            match error {
+                                UpdateError::NotFound => Error::NotFoundInvalidPath,
+                                UpdateError::WrongType => Error::BadRequest {
+                                    msg: Some("Wrong data type.".into()),
+                                },
+                                UpdateError::OutOfBounds => Error::BadRequest {
+                                    msg: Some("Value out of bounds.".into()),
+                                },
+                                UpdateError::UnsupportedType => Error::BadRequest {
+                                    msg: Some("Unsupported data type.".into()),
+                                },
+                                UpdateError::PermissionDenied => Error::Forbidden,
+                                UpdateError::PermissionExpired => Error::UnauthorizedTokenExpired,
+                            }
+                        } else {
+                            Error::InternalServerError
+                        };
+
+                        Err(SetErrorResponse {
+                            request_id,
+                            error,
+                            ts: SystemTime::now().into(),
+                        })
+                    }
+                }
+            }
+            None => {
+                // Not found
+                Err(SetErrorResponse {
+                    request_id,
+                    error: Error::NotFoundInvalidPath,
+                    ts: SystemTime::now().into(),
+                })
+            }
+        }
+    }
+
+    type SubscribeStream = Pin<
+        Box<
+            dyn Stream<Item = Result<SubscriptionEvent, SubscriptionErrorEvent>>
+                + Send
+                + Sync
+                + 'static,
+        >,
+    >;
+
+    async fn subscribe(
+        &self,
+        request: SubscribeRequest,
+    ) -> Result<(SubscribeSuccessResponse, Self::SubscribeStream), SubscribeErrorResponse> {
+        let request_id = request.request_id;
+        let permissions = resolve_permissions(&self.authorization, &request.authorization)
+            .map_err(|error| SubscribeErrorResponse {
+                request_id: request_id.clone(),
+                error,
+                ts: SystemTime::now().into(),
+            })?;
+        let broker = self.broker.authorized_access(&permissions);
+
+        let entries = HashMap::from([(
+            Into::<String>::into(request.path),
+            HashSet::from([broker::Field::Datapoint]),
+        )]);
+        match broker.subscribe(entries).await {
+            Ok(stream) => {
+                let subscription_id = SubscriptionId::new();
+
+                let (abort_handle, abort_registration) = AbortHandle::new_pair();
+
+                // Make the stream abortable
+                let stream = Abortable::new(stream, abort_registration);
+
+                // Register abort handle
+                self.subscriptions.write().await.insert(
+                    subscription_id.clone(),
+                    SubscriptionHandle::from(abort_handle),
+                );
+
+                let stream = convert_to_viss_stream(subscription_id.clone(), stream);
+
+                Ok((
+                    SubscribeSuccessResponse {
+                        request_id,
+                        subscription_id,
+                        ts: SystemTime::now().into(),
+                    },
+                    Box::pin(stream),
+                ))
+            }
+            Err(err) => Err(SubscribeErrorResponse {
+                request_id,
+                error: match err {
+                    broker::SubscriptionError::NotFound => Error::NotFoundInvalidPath,
+                    broker::SubscriptionError::InvalidInput => Error::NotFoundInvalidPath,
+                    broker::SubscriptionError::InternalError => Error::InternalServerError,
+                },
+                ts: SystemTime::now().into(),
+            }),
+        }
+    }
+
+    async fn unsubscribe(
+        &self,
+        request: UnsubscribeRequest,
+    ) -> Result<UnsubscribeSuccessResponse, UnsubscribeErrorResponse> {
+        let subscription_id = request.subscription_id;
+        let request_id = request.request_id;
+        match self.subscriptions.write().await.remove(&subscription_id) {
+            Some(_) => {
+                // Stream is aborted when handle is dropped
+                Ok(UnsubscribeSuccessResponse {
+                    request_id,
+                    subscription_id,
+                    ts: SystemTime::now().into(),
+                })
+            }
+            None => Err(UnsubscribeErrorResponse {
+                request_id,
+                subscription_id,
+                error: Error::NotFoundInvalidSubscriptionId,
+                ts: SystemTime::now().into(),
+            }),
+        }
+    }
+}
+
+fn convert_to_viss_stream(
+    subscription_id: SubscriptionId,
+    stream: impl Stream<Item = broker::EntryUpdates>,
+) -> impl Stream<Item = Result<SubscriptionEvent, SubscriptionErrorEvent>> {
+    stream.map(move |mut item| {
+        let ts = SystemTime::now().into();
+        let subscription_id = subscription_id.clone();
+        match item.updates.pop() {
+            Some(item) => match (item.update.path, item.update.datapoint) {
+                (Some(path), Some(datapoint)) => Ok(SubscriptionEvent {
+                    subscription_id,
+                    data: Data::Object(DataObject {
+                        path: path.into(),
+                        dp: datapoint.into(),
+                    }),
+                    ts,
+                }),
+                (_, _) => Err(SubscriptionErrorEvent {
+                    subscription_id,
+                    error: Error::InternalServerError,
+                    ts,
+                }),
+            },
+            None => Err(SubscriptionErrorEvent {
+                subscription_id,
+                error: Error::InternalServerError,
+                ts,
+            }),
+        }
+    })
+}
+
+fn resolve_permissions(
+    authorization: &Authorization,
+    token: &Option<String>,
+) -> Result<Permissions, Error> {
+    match authorization {
+        Authorization::Disabled => Ok(permissions::ALLOW_ALL.clone()),
+        Authorization::Enabled { token_decoder } => match token {
+            Some(token) => match token_decoder.decode(token) {
+                Ok(claims) => match Permissions::try_from(claims) {
+                    Ok(permissions) => Ok(permissions),
+                    Err(_) => Err(Error::UnauthorizedTokenInvalid),
+                },
+                Err(_) => Err(Error::UnauthorizedTokenInvalid),
+            },
+            None => Err(Error::UnauthorizedTokenMissing),
+        },
+    }
+}
+
+async fn generate_metadata<'a>(
+    db: &'a AuthorizedAccess<'_, '_>,
+    path: &str,
+) -> HashMap<String, MetadataEntry> {
+    let mut metadata: HashMap<String, MetadataEntry> = HashMap::new();
+
+    // We want to remove all but the last "component" present in the path.
+    // For example, if requesting "Vehicle.Driver", we want to match
+    // everything starting with "Vehicle.Driver" but include "Driver"
+    // as the top level entry returned as metadata.
+    let prefix_to_strip = match path.rsplit_once('.') {
+        Some((prefix_excl_dot, _leaf)) => &path[..=prefix_excl_dot.len()],
+        None => "",
+    };
+
+    // Include everything that starts with the requested path.
+    // Insert into the metadata tree, with the top level being the last
+    // "component" of the branch as described above.
+    db.for_each_entry(|entry| {
+        let entry_metadata = entry.metadata();
+        let entry_path = &entry_metadata.path;
+        if entry_path.starts_with(path) {
+            if let Some(path) = entry_path.strip_prefix(prefix_to_strip) {
+                insert_entry(&mut metadata, path, entry_metadata.into());
+            }
+        }
+    })
+    .await;
+
+    metadata
+}
+
+fn insert_entry(entries: &mut HashMap<String, MetadataEntry>, path: &str, entry: MetadataEntry) {
+    // Get the leftmost path component by splitting at '.'.
+    // `split_once` will return None if there is only one component,
+    // which means it's the leaf.
+    match path.split_once('.') {
+        Some((key, path)) => match entries.get_mut(key) {
+            Some(MetadataEntry::Branch(branch_entry)) => {
+                insert_entry(&mut branch_entry.children, path, entry);
+            }
+            Some(_) => {
+                warn!("Should only be possible for branches to exist here");
+                // ignore
+            }
+            None => {
+                let mut branch = BranchEntry {
+                    description: "".into(),
+                    children: HashMap::default(),
+                };
+                insert_entry(&mut branch.children, path, entry);
+                entries.insert(key.to_owned(), MetadataEntry::Branch(branch));
+            }
+        },
+        None => {
+            entries.insert(path.to_owned(), entry);
+        }
+    }
+}

--- a/kuksa_databroker/databroker/src/viss/v2/types.rs
+++ b/kuksa_databroker/databroker/src/viss/v2/types.rs
@@ -1,0 +1,553 @@
+/********************************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License 2.0 which is available at
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* SPDX-License-Identifier: Apache-2.0
+********************************************************************************/
+
+use std::{collections::HashMap, time::SystemTime};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+#[serde(tag = "action")]
+pub enum Request {
+    #[serde(rename = "get")]
+    Get(GetRequest),
+    #[serde(rename = "set")]
+    Set(SetRequest),
+    #[serde(rename = "subscribe")]
+    Subscribe(SubscribeRequest),
+    #[serde(rename = "unsubscribe")]
+    Unsubscribe(UnsubscribeRequest),
+}
+
+// Identify responses using the `Response` trait to prevent
+// responding with other serializable things.
+pub trait Response: Serialize {}
+
+impl Response for GetSuccessResponse {}
+impl Response for GetErrorResponse {}
+
+impl Response for SetSuccessResponse {}
+impl Response for SetErrorResponse {}
+
+impl Response for SubscribeSuccessResponse {}
+impl Response for SubscribeErrorResponse {}
+
+impl Response for UnsubscribeSuccessResponse {}
+impl Response for UnsubscribeErrorResponse {}
+
+impl Response for SubscriptionEvent {}
+impl Response for SubscriptionErrorEvent {}
+
+impl Response for GenericErrorResponse {}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetRequest {
+    pub path: Path,
+    pub request_id: RequestId,
+    pub authorization: Option<String>,
+    pub filter: Option<Filter>,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum GetSuccessResponse {
+    Data(DataResponse),
+    Metadata(MetadataResponse),
+}
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename = "get", rename_all = "camelCase")]
+pub struct DataResponse {
+    pub request_id: RequestId,
+    pub data: Data,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename = "get", rename_all = "camelCase")]
+pub struct MetadataResponse {
+    pub request_id: RequestId,
+    pub metadata: HashMap<String, MetadataEntry>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename = "get", rename_all = "camelCase")]
+pub struct GetErrorResponse {
+    pub request_id: RequestId,
+    pub error: Error,
+    pub ts: Timestamp,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetRequest {
+    pub path: Path,
+    pub value: Value,
+    pub request_id: RequestId,
+    pub authorization: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename = "set", rename_all = "camelCase")]
+pub struct SetSuccessResponse {
+    pub request_id: RequestId,
+    pub ts: Timestamp,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename = "set", rename_all = "camelCase")]
+pub struct SetErrorResponse {
+    pub request_id: RequestId,
+    pub error: Error,
+    pub ts: Timestamp,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscribeRequest {
+    pub path: Path,
+    pub request_id: RequestId,
+    pub authorization: Option<String>,
+    // filter: Option<Filter>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename = "subscribe", rename_all = "camelCase")]
+pub struct SubscribeSuccessResponse {
+    pub request_id: RequestId,
+    pub subscription_id: SubscriptionId,
+    pub ts: Timestamp,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename = "subscribe", rename_all = "camelCase")]
+pub struct SubscribeErrorResponse {
+    pub request_id: RequestId,
+    pub error: Error,
+    pub ts: Timestamp,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename = "subscription", rename_all = "camelCase")]
+pub struct SubscriptionEvent {
+    pub subscription_id: SubscriptionId,
+    pub data: Data,
+    pub ts: Timestamp,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename = "subscription", rename_all = "camelCase")]
+pub struct SubscriptionErrorEvent {
+    pub subscription_id: SubscriptionId,
+    pub error: Error,
+    pub ts: Timestamp,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnsubscribeRequest {
+    pub request_id: RequestId,
+    pub subscription_id: SubscriptionId,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename = "unsubscribe", rename_all = "camelCase")]
+pub struct UnsubscribeSuccessResponse {
+    pub request_id: RequestId,
+    pub subscription_id: SubscriptionId,
+    pub ts: Timestamp,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "action", rename = "unsubscribe", rename_all = "camelCase")]
+pub struct UnsubscribeErrorResponse {
+    pub request_id: RequestId,
+    pub subscription_id: SubscriptionId,
+    pub error: Error,
+    pub ts: Timestamp,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenericRequest {
+    pub action: Option<String>,
+    pub request_id: Option<RequestId>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GenericErrorResponse {
+    pub action: Option<String>,
+    pub request_id: Option<RequestId>,
+    pub error: Error,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type")]
+pub enum Filter {
+    #[serde(rename = "static-metadata")]
+    StaticMetadata(StaticMetadataFilter),
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StaticMetadataFilter {
+    // pub parameters: Option<StaticMetadataParameters>,
+}
+
+// Unique id value specified by the client. Returned by the server in the
+// response and used by the client to link the request and response messages.
+// The value MAY be an integer or a Universally Unique Identifier (UUID).
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(transparent)]
+pub struct RequestId(String);
+
+// The path consists a sequence of VSS node names separated by a delimiter.
+// VSS specifies the dot (.) as delimiter, which therefore is the recommended
+// choice also in this specification. However, in HTTP URLs the conventional
+// delimiter is slash (/), therefore also this delimiter is supported.
+// To exemplify, the path expression from traversing the nodes
+// Vehicle, Car, Engine, RPM can be "Vehicle.Car.Engine.RPM", or
+// "Vehicle/Car/Engine/RPM". A mix of delimiters in the same path expression
+// SHOULD be avoided.
+// The path MUST not contain any wildcard characters ("*"), for such needs
+// see 7.1 Paths Filter Operation.
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(transparent)]
+pub struct Path(String);
+
+// A handle identifying a subscription session.
+#[derive(Serialize, Deserialize, Clone, Eq, Hash, PartialEq)]
+#[serde(transparent)]
+pub struct SubscriptionId(String);
+
+// Timestamps in transport payloads MUST conform to the [ISO8601] standard,
+// using the UTC format with a trailing Z. Time resolution SHALL at least be
+// seconds, with sub-second resolution as an optional degree of precision when
+// desired. The time and date format shall be as shown below, where the
+// sub-second data and delimiter is optional.
+//
+// YYYY-MM-DDTHH:MM:SS.ssssssZ
+//
+pub struct Timestamp {
+    ts: SystemTime,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum Data {
+    Object(DataObject),
+    #[allow(dead_code)]
+    Array(Vec<DataObject>),
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataObject {
+    pub path: Path,
+    pub dp: DataPoint,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataPoint {
+    pub value: Value,
+    pub ts: Timestamp,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(untagged)]
+pub enum Value {
+    None,
+    Scalar(String),
+    Array(Vec<String>),
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum MetadataEntry {
+    Branch(BranchEntry),
+    Sensor(SensorEntry),
+    Attribute(AttributeEntry),
+    Actuator(ActuatorEntry),
+}
+
+#[derive(Serialize)]
+pub struct BranchEntry {
+    pub description: String,
+    pub children: HashMap<String, MetadataEntry>,
+}
+
+#[derive(Serialize)]
+pub struct SensorEntry {
+    pub datatype: DataType,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max: Option<Value>,
+}
+
+#[derive(Serialize)]
+pub struct AttributeEntry {
+    pub datatype: DataType,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<Value>,
+}
+
+#[derive(Serialize)]
+pub struct ActuatorEntry {
+    pub datatype: DataType,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub comment: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max: Option<Value>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum DataType {
+    String,
+    Boolean,
+    Int8,
+    Int16,
+    Int32,
+    Int64,
+    Uint8,
+    Uint16,
+    Uint32,
+    Uint64,
+    Float,
+    Double,
+    #[serde(rename = "string[]")]
+    StringArray,
+    #[serde(rename = "boolean[]")]
+    BoolArray,
+    #[serde(rename = "int8[]")]
+    Int8Array,
+    #[serde(rename = "int16[]")]
+    Int16Array,
+    #[serde(rename = "int32[]")]
+    Int32Array,
+    #[serde(rename = "int64[]")]
+    Int64Array,
+    #[serde(rename = "uint8[]")]
+    Uint8Array,
+    #[serde(rename = "uint16[]")]
+    Uint16Array,
+    #[serde(rename = "uint32[]")]
+    Uint32Array,
+    #[serde(rename = "uint64[]")]
+    Uint64Array,
+    #[serde(rename = "float[]")]
+    FloatArray,
+    #[serde(rename = "double[]")]
+    DoubleArray,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ErrorSpec {
+    pub number: i32,
+    pub reason: String,
+    pub message: String,
+}
+
+#[derive(Serialize, Clone)]
+#[serde(into = "ErrorSpec")]
+#[allow(dead_code, clippy::enum_variant_names)]
+pub enum Error {
+    BadRequest { msg: Option<String> },
+    UnauthorizedTokenExpired,
+    UnauthorizedTokenInvalid,
+    UnauthorizedTokenMissing,
+    UnauthorizedReadOnly,
+    Forbidden,
+    NotFoundInvalidPath,
+    NotFoundUnavailableData,
+    NotFoundInvalidSubscriptionId,
+    InternalServerError,
+    NotImplemented,
+}
+
+impl From<Error> for ErrorSpec {
+    fn from(error: Error) -> Self {
+        match error {
+            // Error            Number  Reason                    Message
+            // NotModified         304  not_modified              No changes have been made by the server.
+            // BadRequest          400  bad_request               The server is unable to fulfil the client request because the request is malformed.
+            Error::BadRequest{ msg: custom_msg } => ErrorSpec {
+                number: 400,
+                reason: "bad_request".into(),
+                message: custom_msg.unwrap_or("The server is unable to fulfil the client request because the request is malformed.".into()),
+            },
+            // BadRequest          400  filter_invalid            Filter requested on non-primitive type.
+            // BadRequest          400  invalid_duration          Time duration is invalid.
+            // BadRequest          400  invalid_value             The requested set value is invalid.
+            // Unauthorized        401  token_expired             Access token has expired.
+            Error::UnauthorizedTokenExpired => ErrorSpec {
+                number: 401,
+                reason: "token_expired".into(),
+                message: "Access token has expired.".into(),
+            },
+            // Unauthorized        401  token_invalid             Access token is invalid.
+            Error::UnauthorizedTokenInvalid => ErrorSpec {
+                number: 401,
+                reason: "token_invalid".into(),
+                message: "Access token is invalid.".into(),
+            },
+            // Unauthorized        401  token_missing             Access token is missing.
+            Error::UnauthorizedTokenMissing => ErrorSpec {
+                number: 401,
+                reason: "token_missing".into(),
+                message: "Access token is missing.".into(),
+            },
+            // Unauthorized        401  too_many_attempts         The client has failed to authenticate too many times.
+            // Unauthorized        401  read_only                 The desired signal cannot be set since it is a read only signal.
+            Error::UnauthorizedReadOnly => ErrorSpec {
+                number: 401,
+                reason: "read_only".into(),
+                message: "The desired signal cannot be set since it is a read only signal.".into(),
+            },
+            // Forbidden           403  user_forbidden            The user is not permitted to access the requested resource. Retrying does not help.
+            Error::Forbidden => ErrorSpec {
+                number: 403,
+                reason: "user_forbidden".into(),
+                message: "The user is not permitted to access the requested resource. Retrying does not help.".into(),
+            },
+            // Forbidden           403  user_unknown              The user is unknown. Retrying does not help.
+            // Forbidden           403  device_forbidden          The device is not permitted to access the requested resource. Retrying does not help.
+            // Forbidden           403  device_unknown            The device is unknown. Retrying does not help.
+            // NotFound            404  invalid_path              The specified data path does not exist.
+            Error::NotFoundInvalidPath => ErrorSpec {
+                number: 404,
+                reason: "invalid_path".into(),
+                message: "The specified data path does not exist.".into(),
+            },
+            // NotFound            404  private_path              The specified data path is private and the request is not authorized to access signals on this path.
+            // NotFound            404  unavailable_data          The requested data was not found.
+            Error::NotFoundUnavailableData => ErrorSpec {
+                number: 404,
+                reason: "unavailable_data".into(),
+                message: "The requested data was not found.".into(),
+            },
+            // NotFound            404  invalid_subscription_id   The specified subscription was not found.
+            Error::NotFoundInvalidSubscriptionId => ErrorSpec {
+                number: 404,
+                reason: "invalid_subscription_id".into(),
+                message: "The specified subscription was not found.".into(),
+            },
+            // NotAcceptable       406  insufficient_privileges   The privileges represented by the access token are not sufficient.
+            // NotAcceptable       406  not_acceptable            The server is unable to generate content that is acceptable to the client
+            // TooManyRequests     429  too_many_requests         The client has sent the server too many requests in a given amount of time.
+            // InternalServerError 500  internal_server_error     The server encountered an unexpected condition which prevented it from fulfilling the request.
+            Error::InternalServerError => ErrorSpec {
+                number: 500,
+                reason: "internal_server_error".into(),
+                message: "The server encountered an unexpected condition which prevented it from fulfilling the request.".into(),
+            },
+            // NotImplemented      501  not_implemented           The server does not support the functionality required to fulfill the request.
+            Error::NotImplemented => ErrorSpec {
+                number: 501,
+                reason: "not_implemented".into(),
+                message: "The server does not support the functionality required to fulfill the request.".into(),
+            },
+            // BadGateway          502  bad_gateway               The server was acting as a gateway or proxy and received an invalid response from an upstream server.
+            // ServiceUnavailable  503  service_unavailable       The server is currently unable to handle the request due to a temporary overload or scheduled maintenance (which may be alleviated after some delay).
+            // GatewayTimeout      504  gateway_timeout           The server did not receive a timely response from an upstream server it needed to access in order to complete the request.
+        }
+    }
+}
+
+impl AsRef<str> for Path {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<Path> for String {
+    fn from(value: Path) -> Self {
+        value.0
+    }
+}
+
+impl From<String> for Path {
+    fn from(value: String) -> Self {
+        Path(value)
+    }
+}
+
+impl From<String> for SubscriptionId {
+    fn from(value: String) -> Self {
+        SubscriptionId(value)
+    }
+}
+
+impl From<SubscriptionId> for String {
+    fn from(value: SubscriptionId) -> Self {
+        value.0
+    }
+}
+
+impl AsRef<str> for RequestId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<SystemTime> for Timestamp {
+    fn from(ts: SystemTime) -> Self {
+        Timestamp { ts }
+    }
+}
+
+impl Serialize for Timestamp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let utc_time: chrono::DateTime<chrono::Utc> = self.ts.into();
+        let use_z = true;
+        let serialized = utc_time.to_rfc3339_opts(chrono::SecondsFormat::Millis, use_z);
+        serializer.serialize_str(&serialized)
+    }
+}
+
+impl SubscriptionId {
+    pub fn new() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+}
+
+impl Default for SubscriptionId {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/kuksa_databroker/databroker/src/vss.rs
+++ b/kuksa_databroker/databroker/src/vss.rs
@@ -220,9 +220,6 @@ fn try_from_json_array(
                 types::DataType::Double => {
                     try_from_json_value(value, &types::DataType::DoubleArray)
                 }
-                types::DataType::Timestamp => {
-                    try_from_json_value(value, &types::DataType::TimestampArray)
-                }
                 types::DataType::StringArray
                 | types::DataType::BoolArray
                 | types::DataType::Int8Array
@@ -234,8 +231,7 @@ fn try_from_json_array(
                 | types::DataType::Uint32Array
                 | types::DataType::Uint64Array
                 | types::DataType::FloatArray
-                | types::DataType::DoubleArray
-                | types::DataType::TimestampArray => try_from_json_value(value, data_type),
+                | types::DataType::DoubleArray => try_from_json_value(value, data_type),
             }
         }
         None => Ok(None),
@@ -284,9 +280,6 @@ fn try_from_json_value(
             types::DataType::Double => serde_json::from_value::<f64>(value)
                 .map(|value| Some(types::DataValue::Double(value)))
                 .map_err(|err| err.into()),
-            types::DataType::Timestamp => {
-                Err(Error::ParseError("timestamp is not supported".to_owned()))
-            }
             types::DataType::StringArray => serde_json::from_value::<Vec<String>>(value)
                 .map(|array| Some(types::DataValue::StringArray(array)))
                 .map_err(|err| err.into()),
@@ -339,9 +332,6 @@ fn try_from_json_value(
             types::DataType::DoubleArray => serde_json::from_value::<Vec<f64>>(value)
                 .map(|array| Some(types::DataValue::DoubleArray(array)))
                 .map_err(|err| err.into()),
-            types::DataType::TimestampArray => Err(Error::ParseError(
-                "timestamp array is not supported".to_owned(),
-            )),
         },
         None => Ok(None),
     }

--- a/kuksa_databroker/proto/sdv/databroker/v1/types.proto
+++ b/kuksa_databroker/proto/sdv/databroker/v1/types.proto
@@ -23,32 +23,30 @@ package sdv.databroker.v1;
 // These are mapped to sint32 and uint32 respectively.
 //
 enum DataType {
-  STRING          = 0;
-  BOOL            = 1;
-  INT8            = 2;
-  INT16           = 3;
-  INT32           = 4;
-  INT64           = 5;
-  UINT8           = 6;
-  UINT16          = 7;
-  UINT32          = 8;
-  UINT64          = 9;
-  FLOAT           = 10;
-  DOUBLE          = 11;
-  TIMESTAMP       = 12;
-  STRING_ARRAY    = 20;
-  BOOL_ARRAY      = 21;
-  INT8_ARRAY      = 22;
-  INT16_ARRAY     = 23;
-  INT32_ARRAY     = 24;
-  INT64_ARRAY     = 25;
-  UINT8_ARRAY     = 26;
-  UINT16_ARRAY    = 27;
-  UINT32_ARRAY    = 28;
-  UINT64_ARRAY    = 29;
-  FLOAT_ARRAY     = 30;
-  DOUBLE_ARRAY    = 31;
-  TIMESTAMP_ARRAY = 32;
+  STRING       = 0;
+  BOOL         = 1;
+  INT8         = 2;
+  INT16        = 3;
+  INT32        = 4;
+  INT64        = 5;
+  UINT8        = 6;
+  UINT16       = 7;
+  UINT32       = 8;
+  UINT64       = 9;
+  FLOAT        = 10;
+  DOUBLE       = 11;
+  STRING_ARRAY = 20;
+  BOOL_ARRAY   = 21;
+  INT8_ARRAY   = 22;
+  INT16_ARRAY  = 23;
+  INT32_ARRAY  = 24;
+  INT64_ARRAY  = 25;
+  UINT8_ARRAY  = 26;
+  UINT16_ARRAY = 27;
+  UINT32_ARRAY = 28;
+  UINT64_ARRAY = 29;
+  FLOAT_ARRAY  = 30;
+  DOUBLE_ARRAY = 31;
 }
 
 enum DatapointError {


### PR DESCRIPTION
Add VISSv2 interface to databroker.
Gated by feature flag `viss` (not built by default).

Supports:
- `get`, `set`, `subscribe` and `unsubscribe`
- Authorization (using same jwt scope format as the other interfaces)

Not implemented:
- Filters
- TLS
