### PR TITLE
Add iterator access for entries

### DIFF
--- a/kuksa_databroker/databroker/src/broker.rs
+++ b/kuksa_databroker/databroker/src/broker.rs
@@ -845,16 +845,16 @@ pub struct DatabaseWriteAccess<'a, 'b> {
     permissions: &'b Permissions,
 }
 
-pub struct MetadataIterator<'a> {
-    inner: std::collections::hash_map::Iter<'a, i32, Entry>,
+pub struct EntryIterator<'a> {
+    inner: std::collections::hash_map::Values<'a, i32, Entry>,
 }
 
-impl<'a> Iterator for MetadataIterator<'a> {
-    type Item = &'a Metadata;
+impl<'a> Iterator for EntryIterator<'a> {
+    type Item = &'a Entry;
 
     #[inline]
-    fn next(&mut self) -> Option<&'a Metadata> {
-        self.inner.next().map(|(_, entry)| &entry.metadata)
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
     }
 
     #[inline]
@@ -891,9 +891,9 @@ impl<'a, 'b> DatabaseReadAccess<'a, 'b> {
         self.get_metadata_by_id(*id)
     }
 
-    pub fn iter_metadata(&self) -> MetadataIterator {
-        MetadataIterator {
-            inner: self.db.entries.iter(),
+    pub fn iter_entries(&self) -> EntryIterator {
+        EntryIterator {
+            inner: self.db.entries.values(),
         }
     }
 }
@@ -1099,6 +1099,15 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             )
     }
 
+    pub async fn with_read_lock<T>(&self, f: impl FnOnce(&DatabaseReadAccess) -> T) -> T {
+        f(&self
+            .broker
+            .database
+            .read()
+            .await
+            .authorized_read_access(self.permissions))
+    }
+
     pub async fn get_id_by_path(&self, name: &str) -> Option<i32> {
         self.broker
             .database
@@ -1169,24 +1178,35 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             .cloned()
     }
 
-    pub async fn for_each_metadata(&self, f: impl FnMut(&Metadata)) {
+    pub async fn for_each_entry(&self, f: impl FnMut(&Entry)) {
         self.broker
             .database
             .read()
             .await
             .authorized_read_access(self.permissions)
-            .iter_metadata()
+            .iter_entries()
             .for_each(f)
     }
 
-    pub async fn map_metadata<T>(&self, f: impl FnMut(&Metadata) -> T) -> Vec<T> {
+    pub async fn map_entries<T>(&self, f: impl FnMut(&Entry) -> T) -> Vec<T> {
         self.broker
             .database
             .read()
             .await
             .authorized_read_access(self.permissions)
-            .iter_metadata()
+            .iter_entries()
             .map(f)
+            .collect()
+    }
+
+    pub async fn filter_map_entries<T>(&self, f: impl FnMut(&Entry) -> Option<T>) -> Vec<T> {
+        self.broker
+            .database
+            .read()
+            .await
+            .authorized_read_access(self.permissions)
+            .iter_entries()
+            .filter_map(f)
             .collect()
     }
 
@@ -2832,7 +2852,7 @@ mod tests {
         // No permissions
         let permissions = Permissions::builder().build().unwrap();
         let broker = db.authorized_access(&permissions);
-        let metadata = broker.map_metadata(|metadata| metadata.clone()).await;
+        let metadata = broker.map_entries(|entry| entry.metadata.clone()).await;
         for entry in metadata {
             match entry.path.as_str() {
                 "Vehicle.Test1" => assert_eq!(entry.id, id1),


### PR DESCRIPTION
A wrapper function that made it easy to iterate through metadata was already available in the broker interface:
```rust
broker
    .map_metadata(|metadata| proto::Metadata::from(metadata))
    .await
```

This has been generalized to iterate over entries instead (i.e. not only metadata) as that will be useful when in the `kuksa.val.v1` interface for example:
```rust
broker
    .map_entries(|entry| {
        // Extract stuff from all entries (including metadata)
    }).await

broker
    .filter_map_entries(|entry| {
        // Extract stuff from some entries (including metadata)
    }).await
```