### PR TITLE
Use entries iterator that handles permissions correctly

### DIFF
--- a/kuksa-client/kuksa_client/cli_backend/grpc.py
+++ b/kuksa-client/kuksa_client/cli_backend/grpc.py
@@ -28,7 +28,6 @@ from typing import Iterable
 from typing import Optional
 import uuid
 import os
-import re
 
 from kuksa_client import cli_backend
 import kuksa_client.grpc
@@ -36,14 +35,17 @@ import kuksa_client.grpc.aio
 from kuksa_client.grpc import EntryUpdate
 from kuksa.val.v1 import types_pb2
 
+
 def callback_wrapper(callback: Callable[[str], None]) -> Callable[[Iterable[EntryUpdate]], None]:
     def wrapper(updates: Iterable[EntryUpdate]) -> None:
         callback(json.dumps([update.to_dict() for update in updates]))
     return wrapper
 
+
 class DatabrokerEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, (types_pb2.StringArray, types_pb2.BoolArray, types_pb2.Uint32Array, types_pb2.Uint64Array, types_pb2.FloatArray, types_pb2.Int32Array, types_pb2.Int64Array, types_pb2.DoubleArray)):
+        if isinstance(obj, (types_pb2.StringArray, types_pb2.BoolArray, types_pb2.Uint32Array, types_pb2.Uint64Array,
+                            types_pb2.FloatArray, types_pb2.Int32Array, types_pb2.Int64Array, types_pb2.DoubleArray)):
             string_values = []
             for value in obj.values:
                 value = str(value)
@@ -145,7 +147,7 @@ class Backend(cli_backend.Backend):
         return json.dumps({"error": "Invalid Attribute"})
 
     # Function for authorization
-    def authorize(self, token_or_tokenfile:Optional[str] =None, timeout=5):
+    def authorize(self, token_or_tokenfile: Optional[str] = None, timeout=5):
         if token_or_tokenfile is None:
             token_or_tokenfile = self.token_or_tokenfile
         if os.path.isfile(token_or_tokenfile):
@@ -251,7 +253,7 @@ class Backend(cli_backend.Backend):
                 responseQueue.put((resp, None))
             except kuksa_client.grpc.VSSClientError as exc:
                 responseQueue.put((None, exc.to_dict()))
-            except ValueError as exc:
+            except ValueError:
                 responseQueue.put(
                     (None, {"error": "ValueError in casting the value."}))
 

--- a/kuksa-client/kuksa_client/grpc/__init__.py
+++ b/kuksa-client/kuksa_client/grpc/__init__.py
@@ -315,7 +315,6 @@ class Datapoint:
             ) if message.HasField('timestamp') else None,
         )
 
-
     def cast_array_values(cast, array):
         """
         Parses array input and cast individual values to wanted type.
@@ -339,7 +338,7 @@ class Datapoint:
             # My Way
             # ... without quotes
             if item.strip() == '':
-                #skip
+                # skip
                 pass
             else:
                 yield cast(item)
@@ -365,7 +364,7 @@ class Datapoint:
         new_val = new_val.replace('\\\"', '\"')
         new_val = new_val.replace("\\\'", "\'")
         return new_val
-            
+
     def to_message(self, value_type: DataType) -> types_pb2.Datapoint:
         message = types_pb2.Datapoint()
 
@@ -373,7 +372,6 @@ class Datapoint:
             array = getattr(obj, attr)
             array.Clear()
             array.values.extend(values)
-
 
         field, set_field, cast_field = {
             DataType.INT8: ('int32', setattr, int),
@@ -388,29 +386,29 @@ class Datapoint:
             DataType.DOUBLE: ('double', setattr, float),
             DataType.BOOLEAN: ('bool', setattr, Datapoint.cast_bool),
             DataType.STRING: ('string', setattr, Datapoint.cast_str),
-            DataType.INT8_ARRAY: ('int32_array', set_array_attr, 
+            DataType.INT8_ARRAY: ('int32_array', set_array_attr,
                                   lambda array: Datapoint.cast_array_values(int, array)),
-            DataType.INT16_ARRAY: ('int32_array', set_array_attr, 
+            DataType.INT16_ARRAY: ('int32_array', set_array_attr,
                                    lambda array: Datapoint.cast_array_values(int, array)),
-            DataType.INT32_ARRAY: ('int32_array', set_array_attr, 
+            DataType.INT32_ARRAY: ('int32_array', set_array_attr,
                                    lambda array: Datapoint.cast_array_values(int, array)),
-            DataType.UINT8_ARRAY: ('uint32_array', set_array_attr, 
+            DataType.UINT8_ARRAY: ('uint32_array', set_array_attr,
                                    lambda array: Datapoint.cast_array_values(int, array)),
-            DataType.UINT16_ARRAY: ('uint32_array', set_array_attr, 
+            DataType.UINT16_ARRAY: ('uint32_array', set_array_attr,
                                     lambda array: Datapoint.cast_array_values(int, array)),
-            DataType.UINT32_ARRAY: ('uint32_array', set_array_attr, 
+            DataType.UINT32_ARRAY: ('uint32_array', set_array_attr,
                                     lambda array: Datapoint.cast_array_values(int, array)),
-            DataType.UINT64_ARRAY: ('uint64_array', set_array_attr, 
+            DataType.UINT64_ARRAY: ('uint64_array', set_array_attr,
                                     lambda array: Datapoint.cast_array_values(int, array)),
-            DataType.INT64_ARRAY: ('int64_array', set_array_attr, 
+            DataType.INT64_ARRAY: ('int64_array', set_array_attr,
                                    lambda array: Datapoint.cast_array_values(int, array)),
-            DataType.FLOAT_ARRAY: ('float_array', set_array_attr, 
+            DataType.FLOAT_ARRAY: ('float_array', set_array_attr,
                                    lambda array: Datapoint.cast_array_values(float, array)),
-            DataType.DOUBLE_ARRAY: ('double_array', set_array_attr, 
+            DataType.DOUBLE_ARRAY: ('double_array', set_array_attr,
                                     lambda array: Datapoint.cast_array_values(float, array)),
-            DataType.BOOLEAN_ARRAY: ('bool_array', set_array_attr, 
+            DataType.BOOLEAN_ARRAY: ('bool_array', set_array_attr,
                                      lambda array: Datapoint.cast_array_values(Datapoint.cast_bool, array)),
-            DataType.STRING_ARRAY: ('string_array', set_array_attr, 
+            DataType.STRING_ARRAY: ('string_array', set_array_attr,
                                     lambda array: Datapoint.cast_array_values(Datapoint.cast_str, array)),
         }.get(value_type, (None, None, None))
         if self.value is not None:
@@ -523,6 +521,7 @@ class ServerInfo:
     def from_message(cls, message: val_pb2.GetServerInfoResponse):
         return cls(name=message.name, version=message.version)
 
+
 class BaseVSSClient:
     def __init__(
         self,
@@ -536,7 +535,6 @@ class BaseVSSClient:
         connected: bool = False,
         tls_server_name: Optional[str] = None
     ):
-    
 
         self.authorization_header = self.get_authorization_header(token)
         self.target_host = f'{host}:{port}'
@@ -559,11 +557,10 @@ class BaseVSSClient:
                 logger.info("Using client private key and certificates, mutual TLS supported if supported by server")
                 return grpc.ssl_channel_credentials(root_certificates, private_key, certificate_chain)
             else:
-                logger.info(f"No client certificates provided, mutual TLS not supported!")
+                logger.info("No client certificates provided, mutual TLS not supported!")
                 return grpc.ssl_channel_credentials(root_certificates)
-        logger.info(f"No Root CA present, it will not be posible to use a secure connection!")
+        logger.info("No Root CA present, it will not be posible to use a secure connection!")
         return None
-        
 
     def _prepare_get_request(self, entries: Iterable[EntryRequest]) -> val_pb2.GetRequest:
         req = val_pb2.GetRequest(entries=[])
@@ -649,7 +646,7 @@ class BaseVSSClient:
         return "Bearer " + token
 
     def generate_metadata_header(self, metadata: list, header=None) -> list:
-        if header == None:
+        if header is None:
             header = self.authorization_header
         if metadata:
             metadata = dict(metadata)
@@ -686,7 +683,7 @@ class VSSClient(BaseVSSClient):
         creds = self._load_creds()
         if target_host is None:
             target_host = self.target_host
-            
+
         if creds is not None:
             logger.info("Establishing secure channel")
             if self.tls_server_name:
@@ -694,12 +691,12 @@ class VSSClient(BaseVSSClient):
                 options = [('grpc.ssl_target_name_override', self.tls_server_name)]
                 channel = grpc.secure_channel(target_host, creds, options)
             else:
-                logger.debug(f"Not providing explicit TLS server name")
+                logger.debug("Not providing explicit TLS server name")
                 channel = grpc.secure_channel(target_host, creds)
         else:
             logger.info("Establishing insecure channel")
             channel = grpc.insecure_channel(target_host)
-            
+
         self.channel = self.exit_stack.enter_context(channel)
         self.client_stub = val_pb2_grpc.VALStub(self.channel)
         self.connected = True
@@ -973,7 +970,6 @@ class VSSClient(BaseVSSClient):
             else:
                 raise VSSClientError.from_grpc_error(exc) from exc
         return None
-        
 
     def get_value_types(self, paths: Collection[str], **rpc_kwargs) -> Dict[str, DataType]:
         """

--- a/kuksa-client/kuksa_client/grpc/aio.py
+++ b/kuksa-client/kuksa_client/grpc/aio.py
@@ -75,7 +75,7 @@ class VSSClient(BaseVSSClient):
                 options = [('grpc.ssl_target_name_override', self.tls_server_name)]
                 channel = grpc.aio.secure_channel(target_host, creds, options)
             else:
-                logger.debug(f"Not providing explicit TLS server name")
+                logger.debug("Not providing explicit TLS server name")
                 channel = grpc.aio.secure_channel(target_host, creds)
         else:
             logger.info("Establishing insecure channel")
@@ -363,7 +363,7 @@ class VSSClient(BaseVSSClient):
         except AioRpcError as exc:
             if exc.code() == grpc.StatusCode.UNAUTHENTICATED:
                 logger.info("Unauthenticated channel started")
-            else: 
+            else:
                 raise VSSClientError.from_grpc_error(exc) from exc
         return None
 

--- a/kuksa-client/tests/test_grpc.py
+++ b/kuksa-client/tests/test_grpc.py
@@ -435,7 +435,9 @@ class TestVSSClient:
         client = VSSClient('127.0.0.1', unused_tcp_port)
         mocker.patch.object(client, 'set')
         await client.set_current_values({
-            'Vehicle.Speed': Datapoint(42.0, datetime.datetime(2022, 11, 7, 16, 18, 35, 247307, tzinfo=datetime.timezone.utc)),
+            'Vehicle.Speed': Datapoint(42.0,
+                                       datetime.datetime(2022, 11, 7, 16, 18, 35, 247307,
+                                                         tzinfo=datetime.timezone.utc)),
             'Vehicle.ADAS.ABS.IsActive': Datapoint(True),
             'Vehicle.Chassis.Height': Datapoint(666),
         })
@@ -518,7 +520,9 @@ class TestVSSClient:
                            View.CURRENT_VALUE, (Field.VALUE,)),
         ]
         assert received_updates == {
-            'Vehicle.Speed': Datapoint(42.0, datetime.datetime(2022, 11, 7, 16, 18, 35, 247307, tzinfo=datetime.timezone.utc)),
+            'Vehicle.Speed': Datapoint(42.0,
+                                       datetime.datetime(2022, 11, 7, 16, 18, 35, 247307,
+                                                         tzinfo=datetime.timezone.utc)),
             'Vehicle.ADAS.ABS.IsActive': Datapoint(True),
             'Vehicle.Chassis.Height': Datapoint(666),
         }
@@ -652,7 +656,8 @@ class TestVSSClient:
             ),
         ])
         async with VSSClient('127.0.0.1', unused_tcp_port, ensure_startup_connection=False) as client:
-            entries = await client.get(entries=(entry for entry in (  # generator is intentional as get accepts Iterable
+            entries = await client.get(entries=(entry for entry in (
+                # generator is intentional as get accepts Iterable
                 EntryRequest('Vehicle.Speed',
                              View.CURRENT_VALUE, (Field.VALUE,)),
                 EntryRequest('Vehicle.ADAS.ABS.IsActive',
@@ -795,7 +800,6 @@ class TestVSSClient:
                 EntryRequest('Vehicle.ADAS.ABS.IsActive',
                              View.TARGET_VALUE, (Field.ACTUATOR_TARGET,)),
             ))
-
         assert entries == [DataEntry('Vehicle.Speed'), DataEntry(
             'Vehicle.ADAS.ABS.IsActive')]
 
@@ -991,8 +995,32 @@ class TestVSSClient:
             name='test_server', version='1.2.3')
         async with VSSClient('127.0.0.1', unused_tcp_port, ensure_startup_connection=False) as client:
             # token from kuksa.val directory under jwt/provide-vehicle-speed.token
-            success = await client.authorize(token='eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJsb2NhbCBkZXYiLCJpc3MiOiJjcmVhdGVUb2tlbi5weSIsImF1ZCI6WyJrdWtzYS52YWwiXSwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3NjcyMjU1OTksInNjb3BlIjoicmVhZDpWZWhpY2xlLldpZHRoIHByb3ZpZGU6VmVoaWNsZS5TcGVlZCJ9.w2c8xrYwBVgMav3f0Se6E8H8E36Nd03rJiSS2A8s-CL3GtlwB7wVanjXHhppNsCdWym3tK4JwgslQdMQF-UL4hd7vzdtt-Mx6VjH_jO9mDxz4Z0Uzw7aJtbtQSpi2h6kwceTVTllkbLRF7WRHWIpwzXFF9yZolX6lH-BE9xf1AB62d6icd9SKxFnVvYs3MVK5D1xNmDNOmm-Fr0d2K604MmIIXGW5kPZJYIvBKO4NYRLklhJe47It_lGo3gnh1ppmzTOIo1kB4sDe55hplUCbTCJVricpyQSgTYsf7aFRPK51XMRwwwJ8kShWeaTggMLKpv1W-9dhVWDk4isC8BxsOjaVloArausMmjLmTz6KwAsfARgfXtaCrMsESUBNXi5KIdAyHVXZpmERvc9yeYPcaWlknVFrFsHbV6bw4nwqBX-0Ubuga0NGNQDFKmyTKQrbuZmQ3L9iipxY8_BOSCkdiYtWbE3lpplxpS_PaZl10KAaMmUfbcF9aYZunDEzEtoJgJe2EeGu3XDBtbyXVUKruImdSEdjaImfUGQIWl5bMbVH4N4zK5jE45wT5FJiRUcA5pMN5wNmDYJJzgbxWNpYW40KZYPFc_7XUH8EZ2Cs69wDHam3ArkOs1qMgMIoEPWVzHakjlVJfrPR9zQKxfirBtNNENIoHsBjJ_P4FEJCN4')
-            assert client.authorization_header == 'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJsb2NhbCBkZXYiLCJpc3MiOiJjcmVhdGVUb2tlbi5weSIsImF1ZCI6WyJrdWtzYS52YWwiXSwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3NjcyMjU1OTksInNjb3BlIjoicmVhZDpWZWhpY2xlLldpZHRoIHByb3ZpZGU6VmVoaWNsZS5TcGVlZCJ9.w2c8xrYwBVgMav3f0Se6E8H8E36Nd03rJiSS2A8s-CL3GtlwB7wVanjXHhppNsCdWym3tK4JwgslQdMQF-UL4hd7vzdtt-Mx6VjH_jO9mDxz4Z0Uzw7aJtbtQSpi2h6kwceTVTllkbLRF7WRHWIpwzXFF9yZolX6lH-BE9xf1AB62d6icd9SKxFnVvYs3MVK5D1xNmDNOmm-Fr0d2K604MmIIXGW5kPZJYIvBKO4NYRLklhJe47It_lGo3gnh1ppmzTOIo1kB4sDe55hplUCbTCJVricpyQSgTYsf7aFRPK51XMRwwwJ8kShWeaTggMLKpv1W-9dhVWDk4isC8BxsOjaVloArausMmjLmTz6KwAsfARgfXtaCrMsESUBNXi5KIdAyHVXZpmERvc9yeYPcaWlknVFrFsHbV6bw4nwqBX-0Ubuga0NGNQDFKmyTKQrbuZmQ3L9iipxY8_BOSCkdiYtWbE3lpplxpS_PaZl10KAaMmUfbcF9aYZunDEzEtoJgJe2EeGu3XDBtbyXVUKruImdSEdjaImfUGQIWl5bMbVH4N4zK5jE45wT5FJiRUcA5pMN5wNmDYJJzgbxWNpYW40KZYPFc_7XUH8EZ2Cs69wDHam3ArkOs1qMgMIoEPWVzHakjlVJfrPR9zQKxfirBtNNENIoHsBjJ_P4FEJCN4'
+            token = ('eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJsb2NhbCBkZXYiLCJpc3MiOiJjcmVhdGVUb2'
+                     'tlbi5weSIsImF1ZCI6WyJrdWtzYS52YWwiXSwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3NjcyMjU1OTksIn'
+                     'Njb3BlIjoicmVhZDpWZWhpY2xlLldpZHRoIHByb3ZpZGU6VmVoaWNsZS5TcGVlZCJ9.w2c8xrYwBVgMav3f0S'
+                     'e6E8H8E36Nd03rJiSS2A8s-CL3GtlwB7wVanjXHhppNsCdWym3tK4JwgslQdMQF-UL4hd7vzdtt-Mx6VjH_jO9'
+                     'mDxz4Z0Uzw7aJtbtQSpi2h6kwceTVTllkbLRF7WRHWIpwzXFF9yZolX6lH-BE9xf1AB62d6icd9SKxFnVvYs3M'
+                     'VK5D1xNmDNOmm-Fr0d2K604MmIIXGW5kPZJYIvBKO4NYRLklhJe47It_lGo3gnh1ppmzTOIo1kB4sDe55hplUCb'
+                     'TCJVricpyQSgTYsf7aFRPK51XMRwwwJ8kShWeaTggMLKpv1W-9dhVWDk4isC8BxsOjaVloArausMmjLmTz6KwAsf'
+                     'ARgfXtaCrMsESUBNXi5KIdAyHVXZpmERvc9yeYPcaWlknVFrFsHbV6bw4nwqBX-0Ubuga0NGNQDFKmyTKQrbuZmQ'
+                     '3L9iipxY8_BOSCkdiYtWbE3lpplxpS_PaZl10KAaMmUfbcF9aYZunDEzEtoJgJe2EeGu3XDBtbyXVUKruImdSEdja'
+                     'ImfUGQIWl5bMbVH4N4zK5jE45wT5FJiRUcA5pMN5wNmDYJJzgbxWNpYW40KZYPFc_7XUH8EZ2Cs69wDHam3ArkOs1'
+                     'qMgMIoEPWVzHakjlVJfrPR9zQKxfirBtNNENIoHsBjJ_P4FEJCN4'
+                     )
+            bearer = ('Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJsb2NhbCBkZXYiLCJpc3MiOiJjcmVhdG'
+                      'VUb2tlbi5weSIsImF1ZCI6WyJrdWtzYS52YWwiXSwiaWF0IjoxNTE2MjM5MDIyLCJleHAiOjE3NjcyMjU1OTks'
+                      'InNjb3BlIjoicmVhZDpWZWhpY2xlLldpZHRoIHByb3ZpZGU6VmVoaWNsZS5TcGVlZCJ9.w2c8xrYwBVgMav3f0'
+                      'Se6E8H8E36Nd03rJiSS2A8s-CL3GtlwB7wVanjXHhppNsCdWym3tK4JwgslQdMQF-UL4hd7vzdtt-Mx6VjH_jO'
+                      '9mDxz4Z0Uzw7aJtbtQSpi2h6kwceTVTllkbLRF7WRHWIpwzXFF9yZolX6lH-BE9xf1AB62d6icd9SKxFnVvYs3M'
+                      'VK5D1xNmDNOmm-Fr0d2K604MmIIXGW5kPZJYIvBKO4NYRLklhJe47It_lGo3gnh1ppmzTOIo1kB4sDe55hplUCbT'
+                      'CJVricpyQSgTYsf7aFRPK51XMRwwwJ8kShWeaTggMLKpv1W-9dhVWDk4isC8BxsOjaVloArausMmjLmTz6KwAsf'
+                      'ARgfXtaCrMsESUBNXi5KIdAyHVXZpmERvc9yeYPcaWlknVFrFsHbV6bw4nwqBX-0Ubuga0NGNQDFKmyTKQrbuZmQ'
+                      '3L9iipxY8_BOSCkdiYtWbE3lpplxpS_PaZl10KAaMmUfbcF9aYZunDEzEtoJgJe2EeGu3XDBtbyXVUKruImdSEdj'
+                      'aImfUGQIWl5bMbVH4N4zK5jE45wT5FJiRUcA5pMN5wNmDYJJzgbxWNpYW40KZYPFc_7XUH8EZ2Cs69wDHam3ArkO'
+                      's1qMgMIoEPWVzHakjlVJfrPR9zQKxfirBtNNENIoHsBjJ_P4FEJCN4'
+                      )
+            success = await client.authorize(token)
+            assert client.authorization_header == bearer
             assert success == "Authenticated"
 
     @pytest.mark.usefixtures('val_server')
@@ -1002,7 +1030,7 @@ class TestVSSClient:
         async with VSSClient('127.0.0.1', unused_tcp_port, ensure_startup_connection=False) as client:
             with pytest.raises(VSSClientError):
                 await client.authorize(token='')
-            assert client.authorization_header == None
+            assert client.authorization_header is None
 
     @pytest.mark.usefixtures('val_server')
     async def test_subscribe_some_entries(self, mocker, unused_tcp_port, val_servicer):

--- a/kuksa_databroker/databroker/src/broker.rs
+++ b/kuksa_databroker/databroker/src/broker.rs
@@ -930,20 +930,6 @@ impl<'a, 'b> DatabaseReadAccess<'a, 'b> {
         }
     }
 
-    pub fn get_entries_by_regex(&self, regex: regex::Regex) -> Result<Vec<Entry>, ReadError> {
-        let mut entries: Vec<Entry> = Vec::new();
-        for (_, value) in self.db.entries.iter() {
-            if regex.is_match(&value.metadata.path) {
-                entries.push(value.clone());
-            }
-        }
-        if entries.is_empty() {
-            return Err(ReadError::NotFound);
-        }
-
-        Ok(entries)
-    }
-
     pub fn get_metadata_by_id(&self, id: i32) -> Option<&Metadata> {
         self.db.entries.get(&id).map(|entry| &entry.metadata)
     }
@@ -1229,15 +1215,6 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             .authorized_read_access(self.permissions)
             .get_entry_by_path(path)
             .cloned()
-    }
-
-    pub async fn get_entries_by_regex(&self, regex: regex::Regex) -> Result<Vec<Entry>, ReadError> {
-        self.broker
-            .database
-            .read()
-            .await
-            .authorized_read_access(self.permissions)
-            .get_entries_by_regex(regex)
     }
 
     pub async fn get_entry_by_id(&self, id: i32) -> Result<Entry, ReadError> {


### PR DESCRIPTION
**New expected behaviour**

1. Client remains as it was, just pre-commit style was updated.
2. Databroker responses works as follow:
      - ```getValue(path)```: return value or error if there is any.
      - ```getValues(path1, path2, ... , n)``` return all path values if there are no errors, if there is/are any error/errors it would return no **partial values** and just its corresponding error for each error path.

      - ```getValue(wildcard)```: return value or error if there is any but **no partial values**
      - ```getValues(wildcard1, wildcard2, ... , n)``` return all wildcard values if there are no errors, if there is/are any error/errors it would return no **partial values of any wildcard** and just its corresponding error for each error wildcard.
      
      - ```getValues(wildcard1, path2, ... , n)``` return all path/wildcard values if there are no errors, if there is/are any error/errors it would return no **partial values** and just its corresponding error for each error path/wildcard.
      
      - ```getMetaData(wildcard or path)``` return values without permission errors.


**(Outdated)**
**How wildards and request errors are handled?**

- When a wildcard pattern is requested and there are permission errors for some items, the response will include entries for which permission was granted, along with just one permission error indicating that "access was denied for some entries" -> Lazy developers should find out which those entries are
- If a wildcard pattern is requested, but it doesn't match any items, the response will consist of a single error, "No entries found for the provided path."
- When a request is made for an entry that doesn't exist, the response will also contain a single error, "No entries found for the provided path."
- In cases where a request is made for a value for which the requester lacks permission, the response will include one error indicating "Permission Denied" for the access attempt.