### PR TITLE
[databroker] Fix permissions bug.

### DIFF
--- a/kuksa_databroker/databroker/src/broker.rs
+++ b/kuksa_databroker/databroker/src/broker.rs
@@ -39,7 +39,7 @@ pub enum UpdateError {
     PermissionExpired,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ReadError {
     NotFound,
     PermissionDenied,
@@ -850,16 +850,59 @@ pub struct DatabaseWriteAccess<'a, 'b> {
     permissions: &'b Permissions,
 }
 
-pub struct EntryIterator<'a> {
-    inner: std::collections::hash_map::Values<'a, i32, Entry>,
+pub enum EntryReadAccess<'a> {
+    Entry(&'a Entry),
+    Err(&'a Metadata, ReadError),
 }
 
-impl<'a> Iterator for EntryIterator<'a> {
-    type Item = &'a Entry;
+impl<'a> EntryReadAccess<'a> {
+    pub fn datapoint(&self) -> Result<&Datapoint, ReadError> {
+        match self {
+            Self::Entry(entry) => Ok(&entry.datapoint),
+            Self::Err(_, err) => Err(err.clone()),
+        }
+    }
+
+    pub fn actuator_target(&self) -> Result<&Option<Datapoint>, ReadError> {
+        match self {
+            Self::Entry(entry) => Ok(&entry.actuator_target),
+            Self::Err(_, err) => Err(err.clone()),
+        }
+    }
+
+    pub fn metadata(&self) -> &Metadata {
+        match self {
+            Self::Entry(entry) => &entry.metadata,
+            Self::Err(metadata, _) => metadata,
+        }
+    }
+}
+
+impl<'a> EntryReadAccess<'a> {
+    fn new(entry: &'a Entry, permissions: &Permissions) -> Self {
+        match permissions.can_read(&entry.metadata.path) {
+            Ok(()) => Self::Entry(entry),
+            Err(PermissionError::Denied) => Self::Err(&entry.metadata, ReadError::PermissionDenied),
+            Err(PermissionError::Expired) => {
+                Self::Err(&entry.metadata, ReadError::PermissionExpired)
+            }
+        }
+    }
+}
+
+pub struct EntryReadIterator<'a, 'b> {
+    inner: std::collections::hash_map::Values<'a, i32, Entry>,
+    permissions: &'b Permissions,
+}
+
+impl<'a, 'b> Iterator for EntryReadIterator<'a, 'b> {
+    type Item = EntryReadAccess<'a>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.inner.next()
+        self.inner
+            .next()
+            .map(|entry| EntryReadAccess::new(entry, self.permissions))
     }
 
     #[inline]
@@ -910,9 +953,10 @@ impl<'a, 'b> DatabaseReadAccess<'a, 'b> {
         self.get_metadata_by_id(*id)
     }
 
-    pub fn iter_entries(&self) -> EntryIterator {
-        EntryIterator {
+    pub fn iter_entries(&self) -> EntryReadIterator {
+        EntryReadIterator {
             inner: self.db.entries.values(),
+            permissions: self.permissions,
         }
     }
 }
@@ -1206,7 +1250,7 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             .cloned()
     }
 
-    pub async fn for_each_entry(&self, f: impl FnMut(&Entry)) {
+    pub async fn for_each_entry(&self, f: impl FnMut(EntryReadAccess)) {
         self.broker
             .database
             .read()
@@ -1216,7 +1260,7 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             .for_each(f)
     }
 
-    pub async fn map_entries<T>(&self, f: impl FnMut(&Entry) -> T) -> Vec<T> {
+    pub async fn map_entries<T>(&self, f: impl FnMut(EntryReadAccess) -> T) -> Vec<T> {
         self.broker
             .database
             .read()
@@ -1227,7 +1271,10 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             .collect()
     }
 
-    pub async fn filter_map_entries<T>(&self, f: impl FnMut(&Entry) -> Option<T>) -> Vec<T> {
+    pub async fn filter_map_entries<T>(
+        &self,
+        f: impl FnMut(EntryReadAccess) -> Option<T>,
+    ) -> Vec<T> {
         self.broker
             .database
             .read()
@@ -2880,7 +2927,7 @@ mod tests {
         // No permissions
         let permissions = Permissions::builder().build().unwrap();
         let broker = db.authorized_access(&permissions);
-        let metadata = broker.map_entries(|entry| entry.metadata.clone()).await;
+        let metadata = broker.map_entries(|entry| entry.metadata().clone()).await;
         for entry in metadata {
             match entry.path.as_str() {
                 "Vehicle.Test1" => assert_eq!(entry.id, id1),

--- a/kuksa_databroker/databroker/src/grpc/sdv_databroker_v1/broker.rs
+++ b/kuksa_databroker/databroker/src/grpc/sdv_databroker_v1/broker.rs
@@ -208,7 +208,7 @@ impl proto::broker_server::Broker for broker::DataBroker {
 
         let list = if request.names.is_empty() {
             broker
-                .map_entries(|entry| proto::Metadata::from(&entry.metadata))
+                .map_entries(|entry| proto::Metadata::from(entry.metadata()))
                 .await
         } else {
             broker

--- a/kuksa_databroker/databroker/src/main.rs
+++ b/kuksa_databroker/databroker/src/main.rs
@@ -269,7 +269,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Arg::new("dummy-metadata")
                 .display_order(10)
                 .long("dummy-metadata")
-                .action(ArgAction::Set)
+                .action(ArgAction::SetTrue)
                 .help("Populate data broker with dummy metadata")
                 .required(false),
         );


### PR DESCRIPTION
Fix permissions bug inadvertently introduced when adding `iter_entries()`.

Summary:

Access control in databroker is implemented by the need to have a `DatabaseReadAccess` in order to read anything from the db. It's only possible to get a `DatabaseReadAccess` if you supply a set of permissions, that will then be kept as a reference in this struct.

```rust
pub struct DatabaseReadAccess<'a, 'b> {
    db: &'a Database,
    permissions: &'b Permissions,
}
```

Once you have that, you have access to the database only available through the following interface.

```rust
impl DatabaseReadAccess {
    pub fn get_entry_by_id(&self, id: i32) -> Result<&Entry, ReadError>;
    pub fn get_entry_by_path(&self, path: impl AsRef<str>) -> Result<&Entry, ReadError>;
    pub fn get_entries_by_regex(&self, regex: regex::Regex) -> Result<Vec<Entry>, ReadError>;
    pub fn get_metadata_by_id(&self, id: i32) -> Option<&Metadata>;
    pub fn get_metadata_by_path(&self, path: &str) -> Option<&Metadata>;

    // Newly added
    pub fn iter_entries(&self) -> EntryIterator;
    pub fn get_entries_by_regex(&self, regex: regex::Regex) -> Result<Vec<Entry>, ReadError>;
}
```

Obviously, this only works if these functions (which internally have full access to the db) enforce the permissions.

This was not the case for the two newly added functions.
This PR fixes `iter_entries()` in this regard, and `get_entries_by_regex()` will be removed (in #654) as it is just a specialized case of `iter_entries()`.

### Implications
The `get` function of the `kuksa.val.v1` API is not enforcing permissions correctly when a wildcard pattern (which includes branches without any actual wildcard) is used.