### PR TITLE
createToken.py: Fix typo output_filename => input_filename

### DIFF
--- a/kuksa_certificates/jwt/createToken.py
+++ b/kuksa_certificates/jwt/createToken.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python3
 
-# All rights reserved. This configuration file is provided to you under the
-# terms and conditions of the Eclipse Distribution License v1.0 which
-# accompanies this distribution, and is available at
-# http://www.eclipse.org/org/documents/edl-v10.php
+########################################################################
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+########################################################################
 
 import argparse
 import json
@@ -19,10 +30,8 @@ def createJWTToken(input_filename, priv_key):
 
     encoded = jwt.encode(payload, priv_key, algorithm="RS256")
 
-    if input_filename.endswith(".json"):
-        output_filename = input_filename[:-5] + ".token"
-    else:
-        output_filename = output_filename + ".token"
+    output_filename = input_filename[:-5] if input_filename.endswith(".json") else input_filename
+    output_filename += ".token"
 
     print("Writing signed access token to {}".format(output_filename))
     with open(output_filename, "w") as output:


### PR DESCRIPTION
output_filename is not defined in else branch. Most likely author wanted to use input_filename instead