### PR TITLE
Configure change-type from VSS JSON

### DIFF
--- a/kuksa_databroker/databroker/src/main.rs
+++ b/kuksa_databroker/databroker/src/main.rs
@@ -117,7 +117,7 @@ async fn read_metadata_file<'a, 'b>(
             .add_entry(
                 path.clone(),
                 entry.data_type,
-                databroker::broker::ChangeType::OnChange,
+                entry.change_type,
                 entry.entry_type,
                 entry.description,
                 entry.allowed,

--- a/kuksa_databroker/doc/user_guide.md
+++ b/kuksa_databroker/doc/user_guide.md
@@ -15,6 +15,7 @@ The following sections provide information for running and configuring Databroke
     <li><a href="#query-syntax">Query Syntax</a></li>
     <li><a href="#using-custom-vss-data-entries">Using Custom VSS Data Entries</a></li>
     <li><a href="#configuration-reference">Configuration Reference</a></li>
+    <li><a href="#signal-change-types">Signal Change Types</a></li>
     <li><a href="#api">API</a></li>
     <li><a href="#known-limitations">Known Limitations</a></li>
   </ol>
@@ -167,6 +168,50 @@ The Databroker can be configured to load the resulting `vss.json` file at startu
 docker run --rm -it -p 55555:55555 ghcr.io/eclipse/kuksa.val/databroker:master --insecure --vss vss.json
 ```
 <p align="right">(<a href="#top">back to top</a>)</p>
+
+## Signal Change Types
+
+Internally, databroker knows different change types for VSS signals. There are three change-types
+
+ - **Continuos**: This are usually sensor values that are continuos, such as vehicle speed. Whenever a continuos signal is updated by a provider, all subscribers are notified.
+ - **OnChange**: This are usually signals that indicate a state, for example whether a door is open or closed. Even if this data is updated regularly by a provider, subscribers are only notified if the the value actually changed.
+ - **Static**: This are signals that you would not expect to change during one ignition cycle, i.e. if an application reads it once, it could expect this signal to remain static during the runtime of the application. The VIN might be an example for a static signal. Currently, in the implementation subscribing `static` signals behaves exactly the same as `onchange` signals.
+
+Currently the way signals are classified depends on databroker version.
+
+Up until version 0.4.1 (including)
+ - All signals where registered as **OnChange**
+
+Starting from version 0.4.2, if nothing else is specified
+ - All signals that are of VSS type `sensor` or `actuator` are registered as change type `continuos`
+ - All attributes are registered as change type `static`
+
+VSS itself has no concept of change types, but you can explicitly configure this behavior on vss level with the custom extended attribute `x-kuksa-changetype`, where valid values are `continuos`, `onchange`, `static`.
+
+Check these `.vspec` snippets as example
+
+```yaml
+VehicleIdentification.VIN:
+  datatype: string
+  type: attribute
+  x-kuksa-changetype: static
+  description: 17-character Vehicle Identification Number (VIN) as defined by ISO 3779.
+
+Vehicle.Speed:
+  datatype: float
+  type: sensor
+  unit: km/h
+  x-kuksa-changetype: continuos
+  description: Vehicle speed.
+
+Vehicle.Cabin.Door.Row1.Left.IsOpen:
+  datatype: boolean
+  type: actuator
+  x-kuksa-changetype: onchange
+  description: Is door open or closed
+```
+
+The change types currently apply on *current* values, when subscribing to a *target value*, as an actuation provider would do, any set on the target value is propagated just like in `continuos` mode, even if a datapoint (and thus its current value behavior) is set to `onchange` or `static`. The idea here is, that a "set" by an application is the intent to actuate something (maybe a retry even), and should thus always be forwarded to the provider.
 
 
 ## Configuration Reference

--- a/kuksa_databroker/doc/user_guide.md
+++ b/kuksa_databroker/doc/user_guide.md
@@ -173,7 +173,7 @@ docker run --rm -it -p 55555:55555 ghcr.io/eclipse/kuksa.val/databroker:master -
 
 Internally, databroker knows different change types for VSS signals. There are three change-types
 
- - **Continuos**: This are usually sensor values that are continuos, such as vehicle speed. Whenever a continuos signal is updated by a provider, all subscribers are notified.
+ - **Continuous**: This are usually sensor values that are continuous, such as vehicle speed. Whenever a continuous signal is updated by a provider, all subscribers are notified.
  - **OnChange**: This are usually signals that indicate a state, for example whether a door is open or closed. Even if this data is updated regularly by a provider, subscribers are only notified if the the value actually changed.
  - **Static**: This are signals that you would not expect to change during one ignition cycle, i.e. if an application reads it once, it could expect this signal to remain static during the runtime of the application. The VIN might be an example for a static signal. Currently, in the implementation subscribing `static` signals behaves exactly the same as `onchange` signals.
 
@@ -183,10 +183,10 @@ Up until version 0.4.1 (including)
  - All signals where registered as **OnChange**
 
 Starting from version 0.4.2, if nothing else is specified
- - All signals that are of VSS type `sensor` or `actuator` are registered as change type `continuos`
+ - All signals that are of VSS type `sensor` or `actuator` are registered as change type `continuous`
  - All attributes are registered as change type `static`
 
-VSS itself has no concept of change types, but you can explicitly configure this behavior on vss level with the custom extended attribute `x-kuksa-changetype`, where valid values are `continuos`, `onchange`, `static`.
+VSS itself has no concept of change types, but you can explicitly configure this behavior on vss level with the custom extended attribute `x-kuksa-changetype`, where valid values are `continuous`, `onchange`, `static`.
 
 Check these `.vspec` snippets as example
 
@@ -201,7 +201,7 @@ Vehicle.Speed:
   datatype: float
   type: sensor
   unit: km/h
-  x-kuksa-changetype: continuos
+  x-kuksa-changetype: continuous
   description: Vehicle speed.
 
 Vehicle.Cabin.Door.Row1.Left.IsOpen:
@@ -211,7 +211,7 @@ Vehicle.Cabin.Door.Row1.Left.IsOpen:
   description: Is door open or closed
 ```
 
-The change types currently apply on *current* values, when subscribing to a *target value*, as an actuation provider would do, any set on the target value is propagated just like in `continuos` mode, even if a datapoint (and thus its current value behavior) is set to `onchange` or `static`. The idea here is, that a "set" by an application is the intent to actuate something (maybe a retry even), and should thus always be forwarded to the provider.
+The change types currently apply on *current* values, when subscribing to a *target value*, as an actuation provider would do, any set on the target value is propagated just like in `continuous` mode, even if a datapoint (and thus its current value behavior) is set to `onchange` or `static`. The idea here is, that a "set" by an application is the intent to actuate something (maybe a retry even), and should thus always be forwarded to the provider.
 
 
 ## Configuration Reference


### PR DESCRIPTION
Work in progress.

Tries to let user determine change_type (continous/on_change) via VSS model as suggested in #652 

The behavior is as follows:

With a standard VSS all sensor and actuator signals are registered with ChangeType `continuous` (I feel, as VSS itself does not specify this, continuous is a more "safe" choice in terms of expectations. Everything that comes in via provider is forwarded to subscribers. But this is just a default.) 

Attributes are set to ChangeType `static` - if have no idea what implications that has in databroker, is this correct?


If a signal defines the extra proper x-kuksa-changetype being either `onchange`, `continuous` or `static` the ChangeType is set respectively. 


To test: Start databroker, start to kuksa-clients, subscribe e.g. `Vehicle.Speed` in one of them, and do a `setValue` for the same in another client. You will see all updates on the subscriber side, even when you repeatedly send the same value. This is different from the behavior in master.

You can change this behavior for any sensor by setting `x-kuksa-changetype`in the metadata.json (this also works through vss-tools, using e.g. an overlay), as an example consider this snippet

```json
"Speed": {"datatype": "float", "description": "Vehicle speed.", "x-kuksa-changetype": "onchange" , "type": "sensor", "unit": "km/h", "uuid": "efe50798638d55fab18ab7d43cc490e9"}
```

If the experiment is repeated, as above, if you send the same value the subscriber is only informed once.



Should this potentially also be returned in metadata? If so, where would be the place to put it into databroker, and would doing so break API compatibility?