### PR TITLE
Raise exception if not connected

### DIFF
--- a/kuksa-client/docs/examples/async-grpc.md
+++ b/kuksa-client/docs/examples/async-grpc.md
@@ -37,7 +37,9 @@ async def main():
 asyncio.run(main())
 ```
 
-Besides this there is a solution where you are not using the client as context-manager
+Besides this there is a solution where you are not using the client as context-manager.
+Then you must explicitly call `connect()`.
+
 ```python
 import asyncio
 
@@ -85,7 +87,7 @@ async def main():
         async for updates in client.subscribe_current_values([
             'Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition',
         ]):
-             if current_values['Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition'] is not None:
+             if updates['Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition'] is not None:
                 current_position = updates['Vehicle.Body.Windshield.Front.Wiping.System.TargetPosition'].value
                 print(f"Current wiper position is: {current_position}")
 
@@ -108,7 +110,7 @@ async def main():
         current_values = await client.get_current_values([
             'Vehicle.Speed',
         ])
-        
+
         if current_values['Vehicle.Speed'] is not None:
             print(current_values['Vehicle.Speed'].value)
 

--- a/kuksa-client/docs/examples/sync-grpc.md
+++ b/kuksa-client/docs/examples/sync-grpc.md
@@ -33,7 +33,9 @@ with VSSClient('127.0.0.1', 55555) as client:
         print(current_values['Vehicle.Speed'].value)
 ```
 
-Besides this there is a solution where you are not using the client as context-manager
+Besides this there is a solution where you are not using the client as context-manager.
+Then you must explicitly call `connect()`.
+
 ```python
 from kuksa_client.grpc import VSSClient
 

--- a/kuksa-client/tests/test_grpc.py
+++ b/kuksa-client/tests/test_grpc.py
@@ -354,6 +354,8 @@ class TestVSSClient:
 
     async def test_get_current_values(self, mocker, unused_tcp_port):
         client = VSSClient('127.0.0.1', unused_tcp_port)
+        client.connected = True  # To bypass connection test
+
         mocker.patch.object(client, 'get', return_value=[
             DataEntry('Vehicle.Speed', value=Datapoint(
                 42.0, datetime.datetime(
@@ -382,6 +384,7 @@ class TestVSSClient:
 
     async def test_get_target_values(self, mocker, unused_tcp_port):
         client = VSSClient('127.0.0.1', unused_tcp_port)
+        client.connected = True  # To bypass connection check
         mocker.patch.object(client, 'get', return_value=[
             DataEntry('Vehicle.ADAS.ABS.IsActive', actuator_target=Datapoint(
                 True, datetime.datetime(
@@ -405,6 +408,7 @@ class TestVSSClient:
 
     async def test_get_metadata(self, mocker, unused_tcp_port):
         client = VSSClient('127.0.0.1', unused_tcp_port)
+        client.connected = True  # To bypass connection check
         mocker.patch.object(client, 'get', return_value=[
             DataEntry('Vehicle.Speed', metadata=Metadata(
                 entry_type=EntryType.SENSOR)),
@@ -433,6 +437,7 @@ class TestVSSClient:
 
     async def test_set_current_values(self, mocker, unused_tcp_port):
         client = VSSClient('127.0.0.1', unused_tcp_port)
+        client.connected = True  # To bypass connection check
         mocker.patch.object(client, 'set')
         await client.set_current_values({
             'Vehicle.Speed': Datapoint(42.0,
@@ -454,6 +459,7 @@ class TestVSSClient:
 
     async def test_set_target_values(self, mocker, unused_tcp_port):
         client = VSSClient('127.0.0.1', unused_tcp_port)
+        client.connected = True  # To bypass connection check
         mocker.patch.object(client, 'set')
         await client.set_target_values({
             'Vehicle.ADAS.ABS.IsActive': Datapoint(True, datetime.datetime(2022, 11, 7, tzinfo=datetime.timezone.utc)),
@@ -470,6 +476,7 @@ class TestVSSClient:
 
     async def test_set_metadata(self, mocker, unused_tcp_port):
         client = VSSClient('127.0.0.1', unused_tcp_port)
+        client.connected = True  # To bypass connection check
         mocker.patch.object(client, 'set')
         await client.set_metadata({
             'Vehicle.Speed': Metadata(entry_type=EntryType.SENSOR),
@@ -490,6 +497,7 @@ class TestVSSClient:
 
     async def test_subscribe_current_values(self, mocker, unused_tcp_port):
         client = VSSClient('127.0.0.1', unused_tcp_port)
+        client.connected = True  # To bypass connection check
 
         async def subscribe_response_stream(**kwargs):
             yield [
@@ -529,6 +537,7 @@ class TestVSSClient:
 
     async def test_subscribe_target_values(self, mocker, unused_tcp_port):
         client = VSSClient('127.0.0.1', unused_tcp_port)
+        client.connected = True  # To bypass connection check
 
         async def subscribe_response_stream(**kwargs):
             yield [
@@ -561,6 +570,7 @@ class TestVSSClient:
 
     async def test_subscribe_metadata(self, mocker, unused_tcp_port):
         client = VSSClient('127.0.0.1', unused_tcp_port)
+        client.connected = True  # To bypass connection check
 
         async def subscribe_response_stream(**kwargs):
             yield [


### PR DESCRIPTION
Fixes #667

With this change, if calling `authorize` before `connect` you get:
```

erik@debian3:~/kuksa.val/kuksa-client$ ./hej.py 
Traceback (most recent call last):
  File "/home/erik/kuksa.val/kuksa-client/./hej.py", line 105, in <module>
    client.authorize(token)
  File "/home/erik/kuksa.val/kuksa-client/kuksa_client/grpc/__init__.py", line 678, in wrapper
    raise Exception("Server not connected! Call connect() before using this command!")
Exception: Server not connected! Call connect() before using this command!
erik@debian3:~/kuksa.val/kuksa-client$ 
```

PR consist of two types of changes:
* Exception instead of info for both sync and async
* Alignment of connection check, previously connection was checked just for subset
