### PR TITLE
Simplify kuksa-client docker build and reducing resulting image size

### DIFF
--- a/.github/workflows/kuksa-client.yml
+++ b/.github/workflows/kuksa-client.yml
@@ -100,10 +100,14 @@ jobs:
           linux/arm64
         context: .
         file: kuksa-client/Dockerfile
-        push: false
+        push: true
         tags: "ttl.sh/kuksa.val/kuksa-client-${{github.sha}}"
         labels: ${{ steps.meta.outputs.labels }}
 
+    - name: Posting temporary container location
+      uses: ./.github/actions/post-container-location
+      with:
+        image: ttl.sh/kuksa.val/kuksa-client-${{github.sha}}
 
   kuksa-client-test:
     runs-on: ubuntu-latest

--- a/kuksa-client/Dockerfile
+++ b/kuksa-client/Dockerfile
@@ -8,23 +8,41 @@
 
 # Note: This dockerfile needs to be executed one level above in the root folder
 
-FROM python:3.10-alpine as build
-RUN apk update && apk add git alpine-sdk linux-headers
-RUN pip install --upgrade pip build
+
+FROM python:3.10-slim-bookworm as build
+# binutils is required by pyinstaller to strip any .so libs that are collected
+# git is used to determine & embed version information during build time
+RUN apt update && apt -yy install binutils git
+RUN pip install --upgrade pip build pyinstaller
+
 # We must copy the whole repository otherwise version lookup by tag would not work
 COPY . /kuksa.val/
 WORKDIR /kuksa.val/kuksa-client
-RUN rm -rf dist
+
 RUN python3 -m build
-RUN mkdir /kuksa-client
-RUN pip install --target /kuksa-client --no-cache-dir dist/*.whl
+# We install globally on build container, so pyinstaller can easily gather all files
+RUN pip install --no-cache-dir dist/*.whl
 
-FROM python:3.10-alpine
+WORKDIR /
+RUN rm -rf dist
+# Letting pyinstaller collect everything that is required
+RUN pyinstaller --collect-data kuksa_certificates  --collect-data kuksa_client --clean  -s  /usr/local/bin/kuksa-client
 
-RUN apk add --no-cache libstdc++
-COPY --from=build /kuksa-client /kuksa-client
+
+# Debian 12 is bookworm, so the glibc version matches. Distroless is a lot smaller than
+# Debian slim versions
+# For development add :debug like this
+# FROM gcr.io/distroless/base-debian12:debug  to get a busybox shell as well
+FROM gcr.io/distroless/base-debian12
+
+COPY --from=build /dist/kuksa-client /kuksa-client
+
+# pyinstaller doesn't pick up transient libz dependency, so copying it manually
+COPY --from=build /usr/lib/*-linux-gnu/libz.so.1 /lib/
+# stty is required by cmd2
+COPY --from=build /usr/bin/stty /bin/
+
 ENV PYTHONUNBUFFERED=yes
-ENV GRPC_ENABLE_FORK_SUPPORT=false
-ENV PYTHONPATH=/kuksa-client
+
 WORKDIR /kuksa-client
-ENTRYPOINT ["bin/kuksa-client"]
+ENTRYPOINT ["/kuksa-client/kuksa-client"]


### PR DESCRIPTION
This fixes #682 

On  a high level

 - switch to a glibc build
 - this reduced build times as grpc wheels exist
 - as a side effect the existing glibc wheels are already small
 - using pyinstaller only ship the parts of python necessary to run the client, thus reducing size over using a python base image

This fixes the huge size of the arm image, while at the same time even reducing the amd64 image compared to master

Arm64 size now

```
ttl.sh/kuksa.val/kuksa-client-ff43b39d56fff605c6330c078dea4b383cade50f        latest                 e2dce0b872fd   About a minute ago   73.1MB
```