### PR TITLE
Remove `optional` from kuksa.val.v1 proto

### DIFF
--- a/kuksa-client/kuksa_client/grpc/__init__.py
+++ b/kuksa-client/kuksa_client/grpc/__init__.py
@@ -161,7 +161,7 @@ class Metadata:
         metadata = cls(data_type=DataType(message.data_type),
                        entry_type=EntryType(message.entry_type))
         for field in ('description', 'comment', 'deprecation', 'unit'):
-            if message.HasField(field):
+            if getattr(message, field):
                 setattr(metadata, field, getattr(message, field))
         if message.HasField('value_restriction'):
             value_restriction = getattr(

--- a/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -488,7 +488,7 @@ fn proto_entry_from_entry_and_fields(
         }
         if all || fields.contains(&proto::Field::MetadataDescription) {
             metadata_is_set = true;
-            metadata.description = Some(entry.metadata().description.clone());
+            metadata.description = entry.metadata().description.clone();
         }
         if all || fields.contains(&proto::Field::MetadataEntryType) {
             metadata_is_set = true;
@@ -497,17 +497,14 @@ fn proto_entry_from_entry_and_fields(
         if all || fields.contains(&proto::Field::MetadataComment) {
             metadata_is_set = true;
             // TODO: Add to Metadata
-            metadata.comment = None;
         }
         if all || fields.contains(&proto::Field::MetadataDeprecation) {
             metadata_is_set = true;
             // TODO: Add to Metadata
-            metadata.deprecation = None;
         }
         if all || fields.contains(&proto::Field::MetadataUnit) {
             metadata_is_set = true;
             // TODO: Add to Metadata
-            metadata.unit = None;
         }
         if all || fields.contains(&proto::Field::MetadataValueRestriction) {
             metadata_is_set = true;

--- a/proto/kuksa/val/v1/types.proto
+++ b/proto/kuksa/val/v1/types.proto
@@ -72,21 +72,21 @@ message Metadata {
 
   // Description
   // Describes the meaning and content of the entry.
-  optional string description = 13;  // [field: FIELD_METADATA_DESCRIPTION]
+  string description = 13;  // [field: FIELD_METADATA_DESCRIPTION]
 
   // Comment [optional]
   // A comment can be used to provide additional informal information
   // on a entry.
-  optional string comment = 14;  // [field: FIELD_METADATA_COMMENT]
+  string comment = 14;  // [field: FIELD_METADATA_COMMENT]
 
   // Deprecation [optional]
   // Whether this entry is deprecated. Can contain recommendations of what
   // to use instead.
-  optional string deprecation = 15;  // [field: FIELD_METADATA_DEPRECATION]
+  string deprecation = 15;  // [field: FIELD_METADATA_DEPRECATION]
 
   // Unit [optional]
   // The unit of measurement
-  optional string unit = 16;  // [field: FIELD_METADATA_UNIT]
+  string unit = 16;  // [field: FIELD_METADATA_UNIT]
 
   // Value restrictions [optional]
   // Restrict which values are allowed.
@@ -137,20 +137,32 @@ message ValueRestriction {
 }
 
 message ValueRestrictionInt {
-  optional sint64 min            = 1;
-  optional sint64 max            = 2;
+  oneof optional_min {
+    sint64 min = 1;
+  }
+  oneof optional_max {
+    sint64 max = 2;
+  }
   repeated sint64 allowed_values = 3;
 }
 
 message ValueRestrictionUint {
-  optional uint64 min            = 1;
-  optional uint64 max            = 2;
+  oneof optional_min {
+    uint64 min = 1;
+  }
+  oneof optional_max {
+    uint64 max = 2;
+  }
   repeated uint64 allowed_values = 3;
 }
 
 message ValueRestrictionFloat {
-  optional double min = 1;
-  optional double max = 2;
+  oneof optional_min {
+    double min = 1;
+  }
+  oneof optional_max {
+    double max = 2;
+  }
 
   // allowed for doubles/floats not recommended
   repeated double allowed_values = 3;


### PR DESCRIPTION
Remove `optional` from `kuksa.val.v1` as it's causing unnecessary issues building it on various platforms depending on which version of protoc is available.

It should have minimal effects downstream, as the python library API remains backwards compatible and the few clients using their own generated files can be updated with minimal effort.