### PR TITLE
Remove `optional` from kuksa.val.v1 proto

### DIFF
--- a/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -488,7 +488,10 @@ fn proto_entry_from_entry_and_fields(
         }
         if all || fields.contains(&proto::Field::MetadataDescription) {
             metadata_is_set = true;
-            metadata.description = Some(entry.metadata().description.clone());
+            metadata.optional_description =
+                Some(proto::metadata::OptionalDescription::Description(
+                    entry.metadata().description.clone(),
+                ));
         }
         if all || fields.contains(&proto::Field::MetadataEntryType) {
             metadata_is_set = true;
@@ -497,17 +500,14 @@ fn proto_entry_from_entry_and_fields(
         if all || fields.contains(&proto::Field::MetadataComment) {
             metadata_is_set = true;
             // TODO: Add to Metadata
-            metadata.comment = None;
         }
         if all || fields.contains(&proto::Field::MetadataDeprecation) {
             metadata_is_set = true;
             // TODO: Add to Metadata
-            metadata.deprecation = None;
         }
         if all || fields.contains(&proto::Field::MetadataUnit) {
             metadata_is_set = true;
             // TODO: Add to Metadata
-            metadata.unit = None;
         }
         if all || fields.contains(&proto::Field::MetadataValueRestriction) {
             metadata_is_set = true;

--- a/proto/kuksa/val/v1/types.proto
+++ b/proto/kuksa/val/v1/types.proto
@@ -72,21 +72,28 @@ message Metadata {
 
   // Description
   // Describes the meaning and content of the entry.
-  optional string description = 13;  // [field: FIELD_METADATA_DESCRIPTION]
-
+  oneof optional_description {
+    string description = 13;  // [field: FIELD_METADATA_DESCRIPTION]
+  }
   // Comment [optional]
   // A comment can be used to provide additional informal information
   // on a entry.
-  optional string comment = 14;  // [field: FIELD_METADATA_COMMENT]
+  oneof optional_comment {
+    string comment = 14;  // [field: FIELD_METADATA_COMMENT]
+  }
 
   // Deprecation [optional]
   // Whether this entry is deprecated. Can contain recommendations of what
   // to use instead.
-  optional string deprecation = 15;  // [field: FIELD_METADATA_DEPRECATION]
+  oneof optional_deprecation {
+    string deprecation = 15;  // [field: FIELD_METADATA_DEPRECATION]
+  }
 
   // Unit [optional]
   // The unit of measurement
-  optional string unit = 16;  // [field: FIELD_METADATA_UNIT]
+  oneof optional_unit {
+    string unit = 16;  // [field: FIELD_METADATA_UNIT]
+  }
 
   // Value restrictions [optional]
   // Restrict which values are allowed.
@@ -137,20 +144,32 @@ message ValueRestriction {
 }
 
 message ValueRestrictionInt {
-  optional sint64 min            = 1;
-  optional sint64 max            = 2;
+  oneof optional_min {
+    sint64 min = 1;
+  }
+  oneof optional_max {
+    sint64 max = 2;
+  }
   repeated sint64 allowed_values = 3;
 }
 
 message ValueRestrictionUint {
-  optional uint64 min            = 1;
-  optional uint64 max            = 2;
+  oneof optional_min {
+    uint64 min = 1;
+  }
+  oneof optional_max {
+    uint64 max = 2;
+  }
   repeated uint64 allowed_values = 3;
 }
 
 message ValueRestrictionFloat {
-  optional double min = 1;
-  optional double max = 2;
+  oneof optional_min {
+    double min = 1;
+  }
+  oneof optional_max {
+    double max = 2;
+  }
 
   // allowed for doubles/floats not recommended
   repeated double allowed_values = 3;


### PR DESCRIPTION
Alternative implementation that remains wire-protocol compatible.
Turns out it's actually _source compatible_ when using python, which is good.

Example of the "clunkyness" of using it in Rust (and probably C++).

```diff
-    metadata.description = Some(description);

+    metadata.optional_description = Some(
+        proto::metadata::OptionalDescription::Description(description)
+    );
```

```diff
-    if let Some(description) = metadata.description {
-        // Do things
-    }

+    if let Some(OptionalDescription::Description(description)) =
+        metadata.optional_description
+    {
+        // Do things
+    }
```

Not great, not terrible.

And technically, those who want use `optional` can just use an alternative `.proto`, as it's all compatible on the wire anyway.