### PR TITLE
Build and test RISCV

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 kuksa-val-server/build
 artifacts
-target
 .venv

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -89,16 +89,21 @@ jobs:
     uses: eclipse-kuksa/kuksa-actions/.github/workflows/check_ghcr_push.yml@2
     secrets: inherit
 
-# Run on selfhosted, because our runner has native ARM build in a remote
-# builder (no need for qemu)
   build-container:
-    runs-on: [ self-hosted ]
+    runs-on: ubuntu-latest
+
     needs: check_ghcr_push
 
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+
+    - name: Building
+      working-directory: ${{github.workspace}}/kuksa_databroker/
+      run: |
+        cargo install cargo-license cross
+        ./build-all-targets.sh
 
     - name: Docker meta
       id: meta
@@ -116,12 +121,12 @@ jobs:
           type=semver,pattern={{major}}
 
     # only needed for runners without buildx setup, will be slow
-    #- name: Set up QEMU
-    #  uses: docker/setup-qemu-action@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
 
-    #- name: Set up Docker Buildx
-    #  id: buildx
-    #  uses: docker/setup-buildx-action@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
 
     - name: Log in to the Container registry
       if: needs.check_ghcr_push.outputs.push == 'true'
@@ -139,6 +144,7 @@ jobs:
         platforms: |
           linux/amd64
           linux/arm64
+          linux/riscv64
         file: ./kuksa_databroker/Dockerfile
         context: .
         push: true
@@ -155,6 +161,7 @@ jobs:
         platforms: |
           linux/amd64
           linux/arm64
+          linux/riscv64
         file: ./kuksa_databroker/Dockerfile
         context: .
         push: true
@@ -166,26 +173,24 @@ jobs:
       with:
         image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}
 
-    - name:  Extracting ARM64 binaries
-      uses: ./.github/actions/copy-from-oci
+    - name: "Archiving AMD64 artifacts"
+      uses: actions/upload-artifact@v3
       with:
-        platform: linux/arm64
-        id: databroker-arm64
-        image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}
-        src: /app/
-        export: true
-        transform: s/app/databroker/
+          name: databroker-amd64
+          path: ${{github.workspace}}/dist/amd64
 
-
-    - name:  Extracting AMD64 binaries
-      uses: ./.github/actions/copy-from-oci
+    - name: "Archiving ARM64 artifacts"
+      uses: actions/upload-artifact@v3
       with:
-        platform: linux/amd64
-        id: databroker-amd64
-        image: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}
-        src: /app/
-        export: true
-        transform: s/app/databroker/
+          name: databroker-arm64
+          path: ${{github.workspace}}/dist/arm64
+
+    - name: "Archiving RISCV64 artifacts"
+      uses: actions/upload-artifact@v3
+      with:
+        name: databroker-riscv64
+        path: ${{github.workspace}}/dist/riscv64
+
 
   integration-test:
     name: Run integration test
@@ -194,11 +199,29 @@ jobs:
 
     steps:
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - uses: actions/checkout@v3
 
-      - name: Run integration test
+      - name: Run integration test on AMD64 container
         env:
           DATABROKER_IMAGE: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}
+          CONTAINER_PLATFORM: linux/amd64
+        run: |
+          ${{github.workspace}}/kuksa_databroker/integration_test/run.sh
+
+      - name: Run integration test on ARM64 container
+        env:
+          DATABROKER_IMAGE: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}
+          CONTAINER_PLATFORM: linux/arm64
+        run: |
+          ${{github.workspace}}/kuksa_databroker/integration_test/run.sh
+
+      - name: Run integration test on RISCV64 container
+        env:
+          DATABROKER_IMAGE: ttl.sh/kuksa.val/kuksa-databroker-${{github.sha}}
+          CONTAINER_PLATFORM: linux/riscv64
         run: |
           ${{github.workspace}}/kuksa_databroker/integration_test/run.sh
 

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -31,12 +31,25 @@ concurrency:
       cancel-in-progress: true
 
 jobs:
-  lint:
-    name: Lint
+  lint-and-test:
+    name: Linting and Testing
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
+
+      # Seems not neccessary on ubuntu-latest runner
+      #- uses: dtolnay/rust-toolchain@stable
+
+      - name: "Install cargo modules"
+        run: cargo install cargo-tarpaulin
+
+      - name: Show toolchain information
+        working-directory: ${{github.workspace}}
+        run: |
+          rustup toolchain list
+          cargo --version
+
       - name: cargo fmt
         working-directory: ${{github.workspace}}
         run: cargo fmt -- --check
@@ -46,23 +59,6 @@ jobs:
       - name: cargo clippy (feature viss)
         working-directory: ${{github.workspace}}
         run: cargo clippy --features viss --all-targets -- -W warnings -D warnings
-
-
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-      - name: Install dependencies
-        run: |
-          cargo install cargo-tarpaulin
-      - name: Show toolchain information
-        working-directory: ${{github.workspace}}
-        run: |
-          rustup toolchain list
-          cargo --version
 
       - name: Run tests and report code coverage
         run: |
@@ -83,6 +79,7 @@ jobs:
       #     path: cobertura.xml
       #     repo_token: ${{ secrets.GITHUB_TOKEN }}
       #     minimum_coverage: 40
+
 
 
   check_ghcr_push:

--- a/kuksa_databroker/Dockerfile
+++ b/kuksa_databroker/Dockerfile
@@ -12,57 +12,40 @@
 # ********************************************************************************/
 
 # This is expected to be executed in the kuksa.val top-level directory
+# You need to run build-all-targets.sh first, as this docker file jsut
+# collects the artifacts
 
-# This builds KUKSA databroker
 
-FROM ghcr.io/rust-cross/rust-musl-cross:x86_64-musl AS builder-amd64
+# Different targets need different base images, so prepare aliases here
+
+# AMD is a statically linked MUSL build
+FROM scratch AS target-amd64
 ENV BUILDTARGET="x86_64-unknown-linux-musl"
+COPY ./target/x86_64-unknown-linux-musl/release/databroker /app/databroker
 
 
-FROM ghcr.io/rust-cross/rust-musl-cross:aarch64-musl AS builder-arm64
+# ARM64 is a statically linked GRPC build
+FROM scratch AS target-arm64
 ENV BUILDTARGET="aarch64-unknown-linux-musl"
+COPY ./target/aarch64-unknown-linux-musl/release/databroker /app/databroker
 
-FROM builder-$TARGETARCH as builder
+
+# RISCV is a glibc build. Rust toolchain not supported for MUSL
+# Distroless has not RISCV support yet, using debian for now
+#FROM gcr.io/distroless/base-debian12:debug as target-riscv64
+FROM riscv64/debian:sid-slim as target-riscv64
+
+ENV BUILDTARGET="riscv64gc-unknown-linux-gnu"
+COPY ./target/riscv64gc-unknown-linux-gnu/release/databroker /app/databroker
+
+# Now adding generic parts
+FROM target-$TARGETARCH as target
 ARG TARGETARCH
 
-RUN apt-get update && apt-get install -y protobuf-compiler \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY ./dist/$TARGETARCH/thirdparty/ /app/thirdparty
 
-# This will speed up fetching the crate.io index in the future, see
-# https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html
-ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
-
-RUN echo "Building for $TARGETARCH"
-ENV SRC="/home/rust/src"
-WORKDIR ${SRC}
-
-ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-
-RUN cargo install cargo-license
-
-# We need to add all files, because .git directory is needed to
-# extract verson information during build, and we can not leave
-# files out, if we do not want -dirty tags on every build
-# Does not influence final image size due to multistage build
-COPY . .
-
-# Creating BOM
-WORKDIR ${SRC}/kuksa_databroker/createbom
-RUN rm -rf ../thirdparty
-RUN python3 createbom.py ../databroker
-
-WORKDIR ${SRC}/kuksa_databroker/databroker 
-
-RUN cargo build --bin databroker --release --target $BUILDTARGET
-RUN mv ${SRC}/target/$BUILDTARGET/release/databroker ${SRC}/
-
-FROM scratch
-
-COPY --from=builder /home/rust/src/databroker /app/databroker
-COPY --from=builder /home/rust/src/kuksa_databroker/databroker/thirdparty /app/thirdparty
-
-ADD ./data/vss-core/vss_release_3.1.1.json vss_release_3.1.1.json
-ADD ./data/vss-core/vss_release_4.0.json vss_release_4.0.json
+COPY ./data/vss-core/vss_release_3.1.1.json vss_release_3.1.1.json
+COPY ./data/vss-core/vss_release_4.0.json vss_release_4.0.json
 
 ENV KUKSA_DATA_BROKER_ADDR=0.0.0.0
 ENV KUKSA_DATA_BROKER_PORT=55555

--- a/kuksa_databroker/build-all-targets.sh
+++ b/kuksa_databroker/build-all-targets.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Building all currently supported targets.
+# Uses cross for cross-compiling. Needs to be executed
+# before docker build, as docker collects the artifacts
+# created by this script
+# this needs the have cross, cargo-license and createbom dependencies installed
+
+# exit on error, to not waste any time
+set -e
+
+CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
+# Create thirdparty bom
+cd createbom/
+rm -rf ../databroker/thirdparty || true
+python3 createbom.py ../databroker
+cd ..
+
+# Starting a fresh build
+echo "Cargo clean, to start fresh..."
+cargo clean
+rm -rf ../dist || true
+mkdir ../dist
+
+# Buidling AMD46
+echo "Building AMD64"
+cross build --target x86_64-unknown-linux-musl --bin databroker --release
+# We need to clean this folder in target, otherwise we get weird side
+# effects building the aarch image, complaining libc crate can not find
+# GLIBC, i.e
+#   Compiling libc v0.2.149
+#error: failed to run custom build command for `libc v0.2.149`
+#
+#Caused by:
+#  process didn't exit successfully: `/target/release/build/libc-2dd22ab6b5fb9fd2/#build-script-build` (exit status: 1)
+#  --- stderr
+#  /target/release/build/libc-2dd22ab6b5fb9fd2/build-script-build: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found (required by /target/release/build/libc-2dd22ab6b5fb9fd2/build-script-build)
+#
+# It seems cross/cargo is reusing something from previous builds it shouldn't.
+# the finished artifact resides in ../target/x86_64-unknown-linux-musl/release
+# so deleting the temporary files in trget/releae is no problem
+echo "Cleaning up...."
+rm -rf ../target/release
+
+
+# Buidling ARM64
+echo "Building ARM64"
+cross build --target aarch64-unknown-linux-musl --bin databroker --release
+echo "Cleaning up...."
+rm -rf ../target/release
+
+
+# Build RISCV64, this is a glibc based build, as musl is not
+# yet supported
+echo "Building RISCV64"
+cross build --target riscv64gc-unknown-linux-gnu --bin databroker --release
+echo "Cleaning up...."
+rm -rf ../target/release
+
+# Prepare dist folders
+echo "Prepare amd64 dist folder"
+mkdir ../dist/amd64
+cp ../target/x86_64-unknown-linux-musl/release/databroker ../dist/amd64
+cp -r ./databroker/thirdparty ../dist/amd64
+
+echo "Prepare arm64 dist folder"
+mkdir ../dist/arm64
+cp ../target/aarch64-unknown-linux-musl/release/databroker ../dist/arm64
+cp -r ./databroker/thirdparty ../dist/arm64
+
+echo "Prepare riscv64 dist folder"
+mkdir ../dist/riscv64
+cp ../target/riscv64gc-unknown-linux-gnu/release/databroker ../dist/riscv64
+cp -r ./databroker/thirdparty ../dist/riscv64

--- a/kuksa_databroker/databroker/Cross.toml
+++ b/kuksa_databroker/databroker/Cross.toml
@@ -1,0 +1,4 @@
+[build.env]
+passthrough = [
+    "CARGO_REGISTRIES_CRATES_IO_PROTOCOL",
+]

--- a/kuksa_databroker/integration_test/run.sh
+++ b/kuksa_databroker/integration_test/run.sh
@@ -17,17 +17,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Setup
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r "${SCRIPT_DIR}"/requirements.txt 
+pip install -r "${SCRIPT_DIR}"/requirements.txt
 
 
-DATABROKER_IMAGE=${DATABROKER_IMAGE:-"ghcr.io/eclipse/kuksa.val/databroker:v0.17.0"}
+DATABROKER_IMAGE=${DATABROKER_IMAGE:-"ghcr.io/eclipse/kuksa.val/databroker:0.4.0"}
 DATABROKER_ADDRESS=${DATABROKER_ADDRESS:-"127.0.0.1:55555"}
+CONTAINER_PLATFORM=${CONTAINER_PLATFORM:-"linux/amd64"}
 
 VSS_DATA_DIR="$SCRIPT_DIR/../../data"
 
-echo "Starting databroker container (\"${DATABROKER_IMAGE}\") in insecure mode"
+echo "Starting databroker container (\"${DATABROKER_IMAGE}\") in insecure mode, requesting platform (\"${CONTAINER_PLATFORM}\")"
 RUNNING_IMAGE=$(
-    docker run -d -v ${VSS_DATA_DIR}:/data -p 55555:55555 --rm ${DATABROKER_IMAGE} --metadata data/vss-core/vss_release_4.0.json --insecure
+    docker run -d -v ${VSS_DATA_DIR}:/data -p 55555:55555 --rm  --platform ${CONTAINER_PLATFORM} ${DATABROKER_IMAGE} --metadata data/vss-core/vss_release_4.0.json --insecure
 )
 
 python3 -m pytest -v "${SCRIPT_DIR}/test_databroker.py"


### PR DESCRIPTION
This builds and pushes RISCV containers as well. One step further towards full #666 

I extended the integration test, so that all containers are tested (before only the one similar to the runner architecture)

As the riscv builds need to based on glibc for the moment, there was no easy way to adapt the general docker file, so I switched to building with cross and having the docker just "package" the binaries. On the plus side
 - this enables to run on standard Github runners as well
 - Does not need the hacky (ingenious?) copy-from-oci action anymore

Once this is in, I'd give the rust-cli the same treatment