### PR TITLE
RISCV builds for databroker-cli

### DIFF
--- a/.github/workflows/kuksa_databroker-cli_build.yml
+++ b/.github/workflows/kuksa_databroker-cli_build.yml
@@ -32,11 +32,12 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint
+    name: Linting
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3
+
       - name: cargo fmt
         working-directory: ${{github.workspace}}
         run: cargo fmt -- --check
@@ -50,13 +51,19 @@ jobs:
 # Run on selfhosted, because our runner has native ARM build in a remote
 # builder (no need for qemu)
   build-container:
-    runs-on: [ self-hosted ]
+    runs-on: ubuntu-latest
     needs: check_ghcr_push
 
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: recursive
+
+    - name: Building
+      working-directory: ${{github.workspace}}/kuksa_databroker/
+      run: |
+          cargo install cargo-license cross
+          ./build-all-targets-cli.sh
 
     - name: Docker meta
       id: meta
@@ -73,13 +80,12 @@ jobs:
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
 
-    # only needed for runners without buildx setup, will be slow
-    #- name: Set up QEMU
-    #  uses: docker/setup-qemu-action@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
 
-    # - name: Set up Docker Buildx
-    #  id: buildx
-    #  uses: docker/setup-buildx-action@v2
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
 
     - name: Log in to the Container registry
       if: needs.check_ghcr_push.outputs.push == 'true'
@@ -97,6 +103,7 @@ jobs:
         platforms: |
           linux/amd64
           linux/arm64
+          linux/riscv64
         file: ./kuksa_databroker/Dockerfile-cli
         context: .
         push: true
@@ -113,6 +120,7 @@ jobs:
         platforms: |
           linux/amd64
           linux/arm64
+          linux/riscv64
         file: ./kuksa_databroker/Dockerfile-cli
         context: .
         push: true
@@ -125,25 +133,24 @@ jobs:
       with:
         image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}
 
-    - name: Extracting ARM64 binaries
-      uses: ./.github/actions/copy-from-oci
+    - name: "Archiving AMD64 artifacts"
+      uses: actions/upload-artifact@v3
       with:
-        platform: linux/arm64
-        id: databroker-cli-arm64
-        image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}
-        src: /app/
-        export: true
-        transform: s/app/databroker-cli/
+        name: databroker-cli-amd64
+        path: ${{github.workspace}}/dist/amd64
 
-    - name: Extracting AMD64 binaries
-      uses: ./.github/actions/copy-from-oci
+    - name: "Archiving ARM64 artifacts"
+      uses: actions/upload-artifact@v3
       with:
-        platform: linux/amd64
-        id: databroker-cli-amd64
-        image: ttl.sh/kuksa.val/kuksa-databroker-cli-${{github.sha}}
-        src: /app/
-        export: true
-        transform: s/app/databroker-cli/
+        name: databroker-cli-arm64
+        path: ${{github.workspace}}/dist/arm64
+
+    - name: "Archiving RISCV64 artifacts"
+      uses: actions/upload-artifact@v3
+      with:
+        name: databroker--cli-riscv64
+        path: ${{github.workspace}}/dist/riscv64
+
 
   bom:
     name: Bill of Material Check

--- a/kuksa_databroker/Dockerfile
+++ b/kuksa_databroker/Dockerfile
@@ -31,8 +31,10 @@ COPY ./target/aarch64-unknown-linux-musl/release/databroker /app/databroker
 
 
 # RISCV is a glibc build. Rust toolchain not supported for MUSL
-# Distroless has not RISCV support yet, using debian for now
-#FROM gcr.io/distroless/base-debian12:debug as target-riscv64
+# Normally we prefer "distroless" base images, i.e.:
+# FROM gcr.io/distroless/base-debian12:debug as target-riscv64
+# However, distorless has no RISCV support yet,
+# (Nov 2023). Using debian unstable for now
 FROM riscv64/debian:sid-slim as target-riscv64
 
 ENV BUILDTARGET="riscv64gc-unknown-linux-gnu"

--- a/kuksa_databroker/Dockerfile-cli
+++ b/kuksa_databroker/Dockerfile-cli
@@ -12,51 +12,45 @@
 # ********************************************************************************/
 
 # This is expected to be executed in the kuksa.val top-level directory
+# You need to run build-all-targets-cli.sh first, as this docker file jsut
+# collects the artifacts
 
-# This builds the databroker-cli
-
-FROM ghcr.io/rust-cross/rust-musl-cross:x86_64-musl AS builder-amd64
+# AMD is a statically linked MUSL build
+FROM scratch AS target-amd64
 ENV BUILDTARGET="x86_64-unknown-linux-musl"
+COPY ./target/x86_64-unknown-linux-musl/release/databroker-cli /app/databroker-cli
 
 
-FROM ghcr.io/rust-cross/rust-musl-cross:aarch64-musl AS builder-arm64
+# ARM64 is a statically linked GRPC build
+FROM scratch AS target-arm64
 ENV BUILDTARGET="aarch64-unknown-linux-musl"
+COPY ./target/aarch64-unknown-linux-musl/release/databroker-cli /app/databroker-cli
 
-FROM builder-$TARGETARCH as builder
+
+# RISCV is a glibc build. Rust toolchain not supported for MUSL
+# Distroless has not RISCV support yet, using debian for now
+#FROM gcr.io/distroless/base-debian12:debug as target-riscv64
+FROM riscv64/debian:sid-slim as target-riscv64
+ENV BUILDTARGET="riscv64gc-unknown-linux-gnu"
+COPY ./target/riscv64gc-unknown-linux-gnu/release/databroker-cli /app/databroker-cli
+
+# Databroker-cli is an interactive cli, thus it can only work correctly
+# if we have some terminfo configurations available. We will transplant
+# them from a donor
+# While writing this, the latest versuion 3.18 does not support riscv yet,
+# but edge does. As we are only getting some config files, this will
+# likely not break
+FROM alpine:edge as terminfo-donor
+RUN apk update && apk add ncurses-terminfo-base
+
+
+# Now adding generic parts
+FROM target-$TARGETARCH as target
 ARG TARGETARCH
 
-RUN apt-get update && apt-get install -y protobuf-compiler \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY ./dist/$TARGETARCH/thirdparty/ /app/thirdparty
 
-# This will speed up fetching the crate.io index in the future, see
-# https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html
-ENV CARGO_UNSTABLE_SPARSE_REGISTRY=true
-
-RUN echo "Building for $TARGETARCH"
-ENV SRC="/home/rust/src"
-WORKDIR ${SRC}
-
-ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
-
-ADD kuksa_databroker kuksa_databroker
-ADD proto proto
-ADD Cargo.toml Cargo.toml
-
-# Creating BOM
-RUN cargo install cargo-license
-WORKDIR ${SRC}/kuksa_databroker/createbom
-RUN rm -rf ../thirdparty
-RUN python3 createbom.py ../databroker-cli
-
-WORKDIR ${SRC}/kuksa_databroker/databroker-cli
-
-RUN cargo build --bin databroker-cli --release --target $BUILDTARGET
-RUN mv ${SRC}/target/$BUILDTARGET/release/databroker-cli ${SRC}/
-
-FROM  scratch
-
-COPY --from=builder /home/rust/src/databroker-cli /app/databroker-cli
-COPY --from=builder /home/rust/src/kuksa_databroker/databroker-cli/thirdparty /app/thirdparty
-COPY --from=builder /lib/terminfo /etc/terminfo
+# Copy terminfo database
+COPY --from=terminfo-donor /etc/terminfo /etc/terminfo
 
 ENTRYPOINT [ "/app/databroker-cli" ]

--- a/kuksa_databroker/Dockerfile-cli
+++ b/kuksa_databroker/Dockerfile-cli
@@ -28,8 +28,10 @@ COPY ./target/aarch64-unknown-linux-musl/release/databroker-cli /app/databroker-
 
 
 # RISCV is a glibc build. Rust toolchain not supported for MUSL
-# Distroless has not RISCV support yet, using debian for now
-#FROM gcr.io/distroless/base-debian12:debug as target-riscv64
+# Normally we prefer "distroless" base images, i.e.:
+# FROM gcr.io/distroless/base-debian12:debug as target-riscv64
+# However, distorless has no RISCV support yet,
+# (Nov 2023). Using debian unstable for now
 FROM riscv64/debian:sid-slim as target-riscv64
 ENV BUILDTARGET="riscv64gc-unknown-linux-gnu"
 COPY ./target/riscv64gc-unknown-linux-gnu/release/databroker-cli /app/databroker-cli

--- a/kuksa_databroker/build-all-targets-cli.sh
+++ b/kuksa_databroker/build-all-targets-cli.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Building all currently supported targets for databroker-cli.
+# Uses cross for cross-compiling. Needs to be executed
+# before docker build, as docker collects the artifacts
+# created by this script
+# this needs the have cross, cargo-license and createbom dependencies installed
+
+# exit on error, to not waste any time
+set -e
+
+CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
+
+# Create thirdparty bom
+cd createbom/
+rm -rf ../databroker/thirdparty || true
+python3 createbom.py ../databroker-cli
+cd ..
+
+# Starting a fresh build
+echo "Cargo clean, to start fresh..."
+cargo clean
+rm -rf ../dist || true
+mkdir ../dist
+
+# Buidling AMD46
+echo "Building AMD64"
+cross build --target x86_64-unknown-linux-musl --bin databroker-cli --release
+# We need to clean this folder in target, otherwise we get weird side
+# effects building the aarch image, complaining libc crate can not find
+# GLIBC, i.e
+#   Compiling libc v0.2.149
+#error: failed to run custom build command for `libc v0.2.149`
+#
+#Caused by:
+#  process didn't exit successfully: `/target/release/build/libc-2dd22ab6b5fb9fd2/#build-script-build` (exit status: 1)
+#  --- stderr
+#  /target/release/build/libc-2dd22ab6b5fb9fd2/build-script-build: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found (required by /target/release/build/libc-2dd22ab6b5fb9fd2/build-script-build)
+#
+# It seems cross/cargo is reusing something from previous builds it shouldn't.
+# the finished artifact resides in ../target/x86_64-unknown-linux-musl/release
+# so deleting the temporary files in trget/releae is no problem
+echo "Cleaning up...."
+rm -rf ../target/release
+
+
+# Buidling ARM64
+echo "Building ARM64"
+cross build --target aarch64-unknown-linux-musl --bin databroker-cli --release
+echo "Cleaning up...."
+rm -rf ../target/release
+
+
+# Build RISCV64, this is a glibc based build, as musl is not
+# yet supported
+echo "Building RISCV64"
+cross build --target riscv64gc-unknown-linux-gnu --bin databroker-cli --release
+echo "Cleaning up...."
+rm -rf ../target/release
+
+# Prepare dist folders
+echo "Prepare amd64 dist folder"
+mkdir ../dist/amd64
+cp ../target/x86_64-unknown-linux-musl/release/databroker-cli ../dist/amd64
+cp -r ./databroker-cli/thirdparty ../dist/amd64
+
+echo "Prepare arm64 dist folder"
+mkdir ../dist/arm64
+cp ../target/aarch64-unknown-linux-musl/release/databroker-cli ../dist/arm64
+cp -r ./databroker-cli/thirdparty ../dist/arm64
+
+echo "Prepare riscv64 dist folder"
+mkdir ../dist/riscv64
+cp ../target/riscv64gc-unknown-linux-gnu/release/databroker-cli ../dist/riscv64
+cp -r ./databroker-cli/thirdparty ../dist/riscv64

--- a/kuksa_databroker/build-all-targets-cli.sh
+++ b/kuksa_databroker/build-all-targets-cli.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 #
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
 # Building all currently supported targets for databroker-cli.
 # Uses cross for cross-compiling. Needs to be executed
 # before docker build, as docker collects the artifacts
 # created by this script
 # this needs the have cross, cargo-license and createbom dependencies installed
+#
+# SPDX-License-Identifier: Apache-2.0
+
 
 # exit on error, to not waste any time
 set -e

--- a/kuksa_databroker/build-all-targets.sh
+++ b/kuksa_databroker/build-all-targets.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 #
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
 # Building all currently supported targets.
 # Uses cross for cross-compiling. Needs to be executed
 # before docker build, as docker collects the artifacts
 # created by this script
 # this needs the have cross, cargo-license and createbom dependencies installed
+#
+# SPDX-License-Identifier: Apache-2.0
 
 # exit on error, to not waste any time
 set -e


### PR DESCRIPTION
uses the same pattern as datbaroker to build CLI. As a result it als emits RISCV binaries (glibc ones due to limitations in the ecosystem currently)

Hint: On a linux system with qemu-user-static (or similar) package installed the system can run/test any of the ocntainers, e.g. 

 docker run --rm -it --net=host --platform linux/riscv64 ttl.sh/kuksa.val/kuksa-databroker-cli-1924d6d3a814e19efd84ec1cd210dabc6fc6a387

Currently supported platforms are `linux/amd64` , `linux/arm64`, `linux/riscv64`
