### PR TITLE
LAG functionality, Subqueries, Comparing with NotAvailable values

### DIFF
--- a/kuksa_apps/node-red/README.md
+++ b/kuksa_apps/node-red/README.md
@@ -41,7 +41,7 @@ By default, the mqtt flows will be configured in node-red. You can also use the 
 
 Now you can view the example under [http://localhost:1880](http://localhost:1880/).
 
-<!-- markdown-link-check-enable --> 
+<!-- markdown-link-check-enable -->
 
 To test the example, you can use [Kuksa Client](../../kuksa-client) or use the [gps feeder](https://github.com/eclipse/kuksa.val.feeders/tree/main/gps2val).
 In [`feeders.yml`](./feeders.yml), you can find the experimental [config](kuksa_config/gpsd_feeder.ini) for gps feeder container. You use the following command to also start containers of feeders:
@@ -61,3 +61,7 @@ docker-compose -f docker-compose.yml  -f feeders.yml up
 - [websocket-advanced.json](./websocket-advanced.json) implements a test client and uses secure connection with server
 
 ![screenshot](./node-red-screenshot.png)
+
+*Note*: Websocket node-red configs are using url **wss://127.0.0.1:8090** if docker-compose used for running demo **127.0.0.1** is not
+available by docker container and in the flow dashboard state will be "disconnected". Compose is creating network between containers so check ip address of
+kuksa-val container and change websocket node accordingly.

--- a/kuksa_databroker/databroker/src/broker.rs
+++ b/kuksa_databroker/databroker/src/broker.rs
@@ -26,8 +26,10 @@ use std::convert::TryFrom;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use std::time::SystemTime;
+use crate::query::{CompiledQuery, ExecutionInput};
 
 use tracing::{debug, info, warn};
+use crate::types::ExecutionInputImplData;
 
 use crate::glob;
 
@@ -75,6 +77,7 @@ pub struct Datapoint {
 #[derive(Debug, Clone)]
 pub struct Entry {
     pub datapoint: Datapoint,
+    pub lag_datapoint: Datapoint,
     pub actuator_target: Option<Datapoint>,
     pub metadata: Metadata,
 }
@@ -556,9 +559,14 @@ impl Entry {
         }
     }
 
+    pub fn apply_lag_after_execute(&mut self) {
+        self.lag_datapoint = self.datapoint.clone();
+    }
+
     pub fn apply(&mut self, update: EntryUpdate) -> HashSet<Field> {
         let mut changed = HashSet::new();
         if let Some(datapoint) = update.datapoint {
+            self.lag_datapoint = self.datapoint.clone();
             self.datapoint = datapoint;
             changed.insert(Field::Datapoint);
         }
@@ -598,11 +606,21 @@ impl Subscriptions {
         &self,
         changed: Option<&HashMap<i32, HashSet<Field>>>,
         db: &Database,
-    ) -> Result<(), NotificationError> {
+    ) -> Result<Option<HashMap<String, ()>>, NotificationError> {
         let mut error = None;
+        let mut lag_updates: HashMap<String, ()> = HashMap::new();
         for sub in &self.query_subscriptions {
             match sub.notify(changed, db).await {
-                Ok(_) => {}
+                Ok(None) => {},
+                Ok(Some(input)) => {
+                    for x in input.get_fields() {
+                        if x.1.lag_value != x.1.value {
+                            if ! lag_updates.contains_key(x.0) {
+                                lag_updates.insert(x.0.clone(), ());
+                            }
+                        }
+                    }
+                }
                 Err(err) => error = Some(err),
             }
         }
@@ -616,7 +634,13 @@ impl Subscriptions {
 
         match error {
             Some(err) => Err(err),
-            None => Ok(()),
+            None => {
+                if lag_updates.len() > 0 {
+                    Ok(Some(lag_updates))
+                } else {
+                    Ok(None)
+                }
+            },
         }
     }
 
@@ -757,45 +781,85 @@ impl ChangeSubscription {
 }
 
 impl QuerySubscription {
-    fn generate_input(
+    fn find_in_db_and_add(
         &self,
-        changed: Option<&HashMap<i32, HashSet<Field>>>,
+        name: &String,
         db: &DatabaseReadAccess,
-    ) -> Option<impl query::ExecutionInput> {
-        let id_used_in_query = {
-            let mut query_uses_id = false;
-            match changed {
-                Some(changed) => {
-                    for (id, fields) in changed {
-                        if let Some(metadata) = db.get_metadata_by_id(*id) {
-                            if self.query.input_spec.contains(&metadata.path)
-                                && fields.contains(&Field::Datapoint)
-                            {
-                                query_uses_id = true;
-                                break;
+        input: &mut query::ExecutionInputImpl) {
+        match db.get_entry_by_path(name) {
+            Ok(entry) => {
+                input.add(name.to_owned(), ExecutionInputImplData{
+                    value: entry.datapoint.value.to_owned(),
+                    lag_value: entry.lag_datapoint.value.to_owned()
+                });
+
+            },
+            Err(_) => {
+                // TODO: This should probably generate an error
+                input.add(name.to_owned(), ExecutionInputImplData {
+                    value: DataValue::NotAvailable,
+                    lag_value: DataValue::NotAvailable
+                })
+            }
+        }
+    }
+    fn check_if_changes_match(
+        &self,
+        query: &CompiledQuery,
+        changed_origin: Option<&HashMap<i32, HashSet<Field>>>,
+        db: &DatabaseReadAccess,
+    ) -> bool {
+        match changed_origin {
+            Some(changed) => {
+                for (id, fields) in changed {
+                    if let Some(metadata) = db.get_metadata_by_id(*id) {
+                        if query.input_spec.contains(&metadata.path)
+                            && fields.contains(&Field::Datapoint)
+                        {
+                            return true;
+                        }
+                        if query.subquery.len() > 0 {
+                            for sub in query.subquery.iter() {
+                                if self.check_if_changes_match(sub, changed_origin, db) {
+                                    return true;
+                                }
                             }
                         }
                     }
                 }
-                None => {
-                    // Always generate input if `changed` is None
-                    query_uses_id = true;
-                }
             }
-            query_uses_id
-        };
+            None => {
+                // Always generate input if `changed` is None
+                return true
+            }
+        }
+        false
+    }
+    fn generate_input_list(
+        &self,
+        query: &CompiledQuery,
+        db: &DatabaseReadAccess,
+        input: &mut query::ExecutionInputImpl
+    ) {
+        for name in query.input_spec.iter() {
+            self.find_in_db_and_add(name, db, input);
+        }
+        if query.subquery.len() > 0 {
+            for sub in query.subquery.iter() {
+                self.generate_input_list(sub, db, input)
+            }
+        }
+    }
+    fn generate_input(
+        &self,
+        changed: Option<&HashMap<i32, HashSet<Field>>>,
+        db: &DatabaseReadAccess,
+    ) -> Option<impl ExecutionInput> {
+        let id_used_in_query = self.check_if_changes_match(&self.query, changed, db);
 
         if id_used_in_query {
             let mut input = query::ExecutionInputImpl::new();
-            for name in self.query.input_spec.iter() {
-                match db.get_entry_by_path(name) {
-                    Ok(entry) => input.add(name.to_owned(), entry.datapoint.value.to_owned()),
-                    Err(_) => {
-                        // TODO: This should probably generate an error
-                        input.add(name.to_owned(), DataValue::NotAvailable)
-                    }
-                }
-            }
+            self.generate_input_list(&self.query, db, &mut input);
             Some(input)
         } else {
             None
@@ -806,8 +870,9 @@ impl QuerySubscription {
         &self,
         changed: Option<&HashMap<i32, HashSet<Field>>>,
         db: &Database,
-    ) -> Result<(), NotificationError> {
+    ) -> Result<Option<impl query::ExecutionInput>, NotificationError> {
         let db_read = db.authorized_read_access(&self.permissions);
+
         match self.generate_input(changed, &db_read) {
             Some(input) =>
             // Execute query (if anything queued)
@@ -827,19 +892,19 @@ impl QuerySubscription {
                             })
                             .await
                         {
-                            Ok(()) => Ok(()),
+                            Ok(()) => Ok(Some(input)),
                             Err(_) => Err(NotificationError {}),
                         },
-                        None => Ok(()),
+                        None => Ok(None),
                     },
                     Err(e) => {
                         // TODO: send error to subscriber
                         debug!("{:?}", e);
-                        Ok(()) // no cleanup needed
+                        Ok(None) // no cleanup needed
                     }
                 }
             }
-            None => Ok(()),
+            None => Ok(None),
         }
     }
 }
@@ -963,6 +1028,21 @@ impl<'a, 'b> DatabaseWriteAccess<'a, 'b> {
         }
     }
 
+    pub fn update_entry_lag_to_be_equal(&mut self, path: &str) -> Result<(), UpdateError> {
+        match self.db.path_to_id.get(path) {
+            Some(id) => {
+                match self.db.entries.get_mut(&id) {
+                    Some(entry) => {
+                        entry.apply_lag_after_execute();
+                        Ok(())
+                    }
+                    None => Err(UpdateError::NotFound),
+                }
+            },
+            None => Err(UpdateError::NotFound),
+        }
+    }
+
     pub fn update(&mut self, id: i32, update: EntryUpdate) -> Result<HashSet<Field>, UpdateError> {
         match self.db.entries.get_mut(&id) {
             Some(entry) => {
@@ -1056,7 +1136,14 @@ impl<'a, 'b> DatabaseWriteAccess<'a, 'b> {
                 description,
                 allowed,
             },
-            datapoint: match datapoint {
+            datapoint: match datapoint.clone() {
+                Some(datapoint) => datapoint,
+                None => Datapoint {
+                    ts: SystemTime::now(),
+                    value: DataValue::NotAvailable,
+                },
+            },
+            lag_datapoint: match datapoint {
                 Some(datapoint) => datapoint,
                 None => Datapoint {
                     ts: SystemTime::now(),
@@ -1277,6 +1364,7 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
         let mut errors = Vec::new();
         let mut db = self.broker.database.write().await;
         let mut db_write = db.authorized_write_access(self.permissions);
+        let mut lag_updates: HashMap<String, ()> = HashMap::new();
 
         let cleanup_needed = {
             let changed = {
@@ -1301,6 +1389,7 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             // notifying subscribers (no writes in between)
             let db = db.downgrade();
 
+
             // Notify
             match self
                 .broker
@@ -1310,10 +1399,25 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
                 .notify(Some(&changed), &db)
                 .await
             {
-                Ok(()) => false,
+                Ok(None) => false,
+                Ok(Some(lag_updates_)) => {
+                    lag_updates = lag_updates_.clone();
+                    false
+                },
                 Err(_) => true, // Cleanup needed
             }
         };
+
+        if lag_updates.len() > 0 {
+            let mut db = self.broker.database.write().await;
+            let mut db_write = db.authorized_write_access(self.permissions);
+            for x in lag_updates {
+                match db_write.update_entry_lag_to_be_equal(x.0.as_str()) {
+                    Ok(_) => {},
+                    Err(_) => {},
+                };
+            }
+        }
 
         // Cleanup closed subscriptions
         if cleanup_needed {
@@ -1367,6 +1471,7 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
     ) -> Result<impl Stream<Item = QueryResponse>, QueryError> {
         let db_read = self.broker.database.read().await;
         let db_read_access = db_read.authorized_read_access(self.permissions);
+
         let compiled_query = query::compile(query, &db_read_access);
 
         match compiled_query {

--- a/kuksa_databroker/databroker/src/broker.rs
+++ b/kuksa_databroker/databroker/src/broker.rs
@@ -26,10 +26,10 @@ use std::convert::TryFrom;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use std::time::SystemTime;
-use crate::query::{CompiledQuery, ExecutionInput};
 
-use tracing::{debug, info, warn};
+use crate::query::{CompiledQuery, ExecutionInput};
 use crate::types::ExecutionInputImplData;
+use tracing::{debug, info, warn};
 
 use crate::glob;
 
@@ -611,11 +611,11 @@ impl Subscriptions {
         let mut lag_updates: HashMap<String, ()> = HashMap::new();
         for sub in &self.query_subscriptions {
             match sub.notify(changed, db).await {
-                Ok(None) => {},
+                Ok(None) => {}
                 Ok(Some(input)) => {
                     for x in input.get_fields() {
                         if x.1.lag_value != x.1.value {
-                            if ! lag_updates.contains_key(x.0) {
+                            if !lag_updates.contains_key(x.0) {
                                 lag_updates.insert(x.0.clone(), ());
                             }
                         }
@@ -640,7 +640,7 @@ impl Subscriptions {
                 } else {
                     Ok(None)
                 }
-            },
+            }
         }
     }
 
@@ -785,21 +785,27 @@ impl QuerySubscription {
         &self,
         name: &String,
         db: &DatabaseReadAccess,
-        input: &mut query::ExecutionInputImpl) {
+        input: &mut query::ExecutionInputImpl,
+    ) {
         match db.get_entry_by_path(name) {
             Ok(entry) => {
-                input.add(name.to_owned(), ExecutionInputImplData{
-                    value: entry.datapoint.value.to_owned(),
-                    lag_value: entry.lag_datapoint.value.to_owned()
-                });
-
-            },
+                input.add(
+                    name.to_owned(),
+                    ExecutionInputImplData {
+                        value: entry.datapoint.value.to_owned(),
+                        lag_value: entry.lag_datapoint.value.to_owned(),
+                    },
+                );
+            }
             Err(_) => {
                 // TODO: This should probably generate an error
-                input.add(name.to_owned(), ExecutionInputImplData {
-                    value: DataValue::NotAvailable,
-                    lag_value: DataValue::NotAvailable
-                })
+                input.add(
+                    name.to_owned(),
+                    ExecutionInputImplData {
+                        value: DataValue::NotAvailable,
+                        lag_value: DataValue::NotAvailable,
+                    },
+                )
             }
         }
     }
@@ -830,7 +836,7 @@ impl QuerySubscription {
             }
             None => {
                 // Always generate input if `changed` is None
-                return true
+                return true;
             }
         }
         false
@@ -839,7 +845,7 @@ impl QuerySubscription {
         &self,
         query: &CompiledQuery,
         db: &DatabaseReadAccess,
-        input: &mut query::ExecutionInputImpl
+        input: &mut query::ExecutionInputImpl,
     ) {
         for name in query.input_spec.iter() {
             self.find_in_db_and_add(name, db, input);
@@ -1030,14 +1036,12 @@ impl<'a, 'b> DatabaseWriteAccess<'a, 'b> {
 
     pub fn update_entry_lag_to_be_equal(&mut self, path: &str) -> Result<(), UpdateError> {
         match self.db.path_to_id.get(path) {
-            Some(id) => {
-                match self.db.entries.get_mut(&id) {
-                    Some(entry) => {
-                        entry.apply_lag_after_execute();
-                        Ok(())
-                    }
-                    None => Err(UpdateError::NotFound),
+            Some(id) => match self.db.entries.get_mut(&id) {
+                Some(entry) => {
+                    entry.apply_lag_after_execute();
+                    Ok(())
                 }
+                None => Err(UpdateError::NotFound),
             },
             None => Err(UpdateError::NotFound),
         }
@@ -1389,7 +1393,6 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             // notifying subscribers (no writes in between)
             let db = db.downgrade();
 
-
             // Notify
             match self
                 .broker
@@ -1403,7 +1406,7 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
                 Ok(Some(lag_updates_)) => {
                     lag_updates = lag_updates_.clone();
                     false
-                },
+                }
                 Err(_) => true, // Cleanup needed
             }
         };
@@ -1413,8 +1416,8 @@ impl<'a, 'b> AuthorizedAccess<'a, 'b> {
             let mut db_write = db.authorized_write_access(self.permissions);
             for x in lag_updates {
                 match db_write.update_entry_lag_to_be_equal(x.0.as_str()) {
-                    Ok(_) => {},
-                    Err(_) => {},
+                    Ok(_) => {}
+                    Err(_) => {}
                 };
             }
         }

--- a/kuksa_databroker/databroker/src/query/compiler.rs
+++ b/kuksa_databroker/databroker/src/query/compiler.rs
@@ -156,40 +156,38 @@ pub fn compile_expr(
         }
         ast::Expr::Function(f) => {
             let name = &f.name.to_string();
-            return if name == "LAG" {
+            if name == "LAG" {
                 let args = &f.args[0];
                 match args {
-                    ast::FunctionArg::Unnamed(e) => {
-                        return match e {
-                            ast::FunctionArgExpr::Expr(e) => {
-                                let function_expr = compile_expr(e, input, output)?;
-                                return match function_expr {
-                                    Expr::Datapoint {
-                                        name, data_type, ..
-                                    } => Ok(Expr::Datapoint {
-                                        name,
-                                        data_type,
-                                        lag: true,
-                                    }),
-                                    _ => Err(CompilationError::ParseError(format!(
-                                        "Unable to create lag datapoint"
-                                    ))),
-                                };
+                    ast::FunctionArg::Unnamed(e) => match e {
+                        ast::FunctionArgExpr::Expr(e) => {
+                            let function_expr = compile_expr(e, input, output)?;
+                            match function_expr {
+                                Expr::Datapoint {
+                                    name, data_type, ..
+                                } => Ok(Expr::Datapoint {
+                                    name,
+                                    data_type,
+                                    lag: true,
+                                }),
+                                _ => Err(CompilationError::ParseError(
+                                    "Unable to create lag datapoint".to_string(),
+                                )),
                             }
-                            _ => Err(CompilationError::UnsupportedOperator(format!(
-                                "Unsupported function argument expression"
-                            ))),
                         }
-                    }
-                    _ => Err(CompilationError::UnsupportedOperator(format!(
-                        "Unsupported function argument"
-                    ))),
+                        _ => Err(CompilationError::UnsupportedOperator(
+                            "Unsupported function argument expression".to_string(),
+                        )),
+                    },
+                    _ => Err(CompilationError::UnsupportedOperator(
+                        "Unsupported function argument".to_string(),
+                    )),
                 }
             } else {
                 Err(CompilationError::UnsupportedOperator(format!(
                     "Unsupported operator \"{name}\""
                 )))
-            };
+            }
         }
 
         ast::Expr::BinaryOp {
@@ -358,9 +356,9 @@ pub fn compile_expr(
                         })
                     }
 
-                    _ => Err(CompilationError::UnsupportedOperator(format!(
-                        "Subquery failed to compile query"
-                    ))),
+                    _ => Err(CompilationError::UnsupportedOperator(
+                        "Subquery failed to compile query".to_string(),
+                    )),
                 }
             } else {
                 Err(CompilationError::UnsupportedOperation(
@@ -539,7 +537,7 @@ pub fn compile(
                 _ => None,
             };
             if let Some(select) = select_statement {
-                return compile_select_statement(&select, input);
+                compile_select_statement(&select, input)
             } else {
                 Err(CompilationError::UnsupportedOperation(
                     "unrecognized SELECT statement".to_string(),

--- a/kuksa_databroker/databroker/src/query/compiler.rs
+++ b/kuksa_databroker/databroker/src/query/compiler.rs
@@ -153,7 +153,7 @@ pub fn compile_expr(
                 data_type,
                 lag: false,
             })
-        },
+        }
         ast::Expr::Function(f) => {
             let name = &f.name.to_string();
             return if name == "LAG" {
@@ -164,31 +164,33 @@ pub fn compile_expr(
                             ast::FunctionArgExpr::Expr(e) => {
                                 let function_expr = compile_expr(e, input, output)?;
                                 return match function_expr {
-                                    Expr::Datapoint { name, data_type, .. } => Ok(Expr::Datapoint {
+                                    Expr::Datapoint {
+                                        name, data_type, ..
+                                    } => Ok(Expr::Datapoint {
                                         name,
                                         data_type,
-                                        lag: true
+                                        lag: true,
                                     }),
                                     _ => Err(CompilationError::ParseError(format!(
                                         "Unable to create lag datapoint"
-                                    )))
+                                    ))),
                                 };
                             }
                             _ => Err(CompilationError::UnsupportedOperator(format!(
                                 "Unsupported function argument expression"
-                            )))
+                            ))),
                         }
-                    },
+                    }
                     _ => Err(CompilationError::UnsupportedOperator(format!(
                         "Unsupported function argument"
-                    )))
+                    ))),
                 }
             } else {
                 Err(CompilationError::UnsupportedOperator(format!(
                     "Unsupported operator \"{name}\""
                 )))
             };
-        },
+        }
 
         ast::Expr::BinaryOp {
             ref left,
@@ -352,20 +354,20 @@ pub fn compile_expr(
                     Ok(compiled_query) => {
                         output.subquery.push(compiled_query);
                         Ok(Expr::Subquery {
-                            index: (output.subquery.len() - 1) as u32
+                            index: (output.subquery.len() - 1) as u32,
                         })
-                    },
+                    }
 
                     _ => Err(CompilationError::UnsupportedOperator(format!(
                         "Subquery failed to compile query"
-                    )))
+                    ))),
                 }
             } else {
                 Err(CompilationError::UnsupportedOperation(
                     "Subquery to parse".to_string(),
                 ))
             }
-        },
+        }
 
         ast::Expr::UnaryOp { ref op, ref expr } => match op {
             ast::UnaryOperator::Not => Ok(Expr::UnaryOperation {
@@ -475,7 +477,7 @@ fn resolve_literal(
 
 fn compile_select_statement(
     select: &ast::Select,
-    input: &impl CompilationInput
+    input: &impl CompilationInput,
 ) -> Result<CompiledQuery, CompilationError> {
     let mut query = CompiledQuery::new();
 
@@ -486,8 +488,7 @@ fn compile_select_statement(
             if let Ok(data_type) = condition.get_type() {
                 if data_type != DataType::Bool {
                     return Err(CompilationError::TypeError(
-                        "WHERE statement doesn't evaluate to a boolean expression"
-                            .to_string(),
+                        "WHERE statement doesn't evaluate to a boolean expression".to_string(),
                     ));
                 }
             }

--- a/kuksa_databroker/databroker/src/query/compiler.rs
+++ b/kuksa_databroker/databroker/src/query/compiler.rs
@@ -347,7 +347,6 @@ pub fn compile_expr(
             };
             if let Some(select) = select_statement {
                 let compiled_query = compile_select_statement(&select, input);
-                println!("{:?}", compiled_query);
                 match compiled_query {
                     Ok(compiled_query) => {
                         output.subquery.push(compiled_query);

--- a/kuksa_databroker/databroker/src/query/compiler.rs
+++ b/kuksa_databroker/databroker/src/query/compiler.rs
@@ -65,6 +65,7 @@ impl CompilationInput for CompilationInputImpl {
     }
 }
 
+#[derive(Debug)]
 pub struct CompiledQuery {
     /// A single expression (tree) evaluating to either
     /// true or false.
@@ -79,8 +80,11 @@ pub struct CompiledQuery {
     /// or as part of a condition.
     ///
     /// These needs to be provided in the `input` when
-    /// executing the query.  
+    /// executing the query.
     pub input_spec: HashSet<String>, // Needed datapoints (values) for execution
+
+    /// Vector of subquery in SELECT query
+    pub subquery: Vec<CompiledQuery>,
 }
 
 impl CompiledQuery {
@@ -89,6 +93,7 @@ impl CompiledQuery {
             selection: None,
             projection: Vec::new(),
             input_spec: HashSet::new(),
+            subquery: Vec::new(),
         }
     }
 }
@@ -132,6 +137,7 @@ pub fn compile_expr(
             Ok(Expr::Datapoint {
                 name: name.clone(),
                 data_type,
+                lag: false,
             })
         }
 
@@ -145,8 +151,44 @@ pub fn compile_expr(
             Ok(Expr::Datapoint {
                 name: field,
                 data_type,
+                lag: false,
             })
-        }
+        },
+        ast::Expr::Function(f) => {
+            let name = &f.name.to_string();
+            return if name == "LAG" {
+                let args = &f.args[0];
+                match args {
+                    ast::FunctionArg::Unnamed(e) => {
+                        return match e {
+                            ast::FunctionArgExpr::Expr(e) => {
+                                let function_expr = compile_expr(e, input, output)?;
+                                return match function_expr {
+                                    Expr::Datapoint { name, data_type, .. } => Ok(Expr::Datapoint {
+                                        name,
+                                        data_type,
+                                        lag: true
+                                    }),
+                                    _ => Err(CompilationError::ParseError(format!(
+                                        "Unable to create lag datapoint"
+                                    )))
+                                };
+                            }
+                            _ => Err(CompilationError::UnsupportedOperator(format!(
+                                "Unsupported function argument expression"
+                            )))
+                        }
+                    },
+                    _ => Err(CompilationError::UnsupportedOperator(format!(
+                        "Unsupported function argument"
+                    )))
+                }
+            } else {
+                Err(CompilationError::UnsupportedOperator(format!(
+                    "Unsupported operator \"{name}\""
+                )))
+            };
+        },
 
         ast::Expr::BinaryOp {
             ref left,
@@ -298,6 +340,33 @@ pub fn compile_expr(
         }
         ast::Expr::Nested(e) => compile_expr(e, input, output),
 
+        ast::Expr::Subquery(q) => {
+            let select_statement = match &q.body {
+                sqlparser::ast::SetExpr::Select(query) => Some(query.clone()),
+                _ => None,
+            };
+            if let Some(select) = select_statement {
+                let compiled_query = compile_select_statement(&select, input);
+                println!("{:?}", compiled_query);
+                match compiled_query {
+                    Ok(compiled_query) => {
+                        output.subquery.push(compiled_query);
+                        Ok(Expr::Subquery {
+                            index: (output.subquery.len() - 1) as u32
+                        })
+                    },
+
+                    _ => Err(CompilationError::UnsupportedOperator(format!(
+                        "Subquery failed to compile query"
+                    )))
+                }
+            } else {
+                Err(CompilationError::UnsupportedOperation(
+                    "Subquery to parse".to_string(),
+                ))
+            }
+        },
+
         ast::Expr::UnaryOp { ref op, ref expr } => match op {
             ast::UnaryOperator::Not => Ok(Expr::UnaryOperation {
                 expr: Box::new(compile_expr(expr, input, output)?),
@@ -404,6 +473,55 @@ fn resolve_literal(
     }
 }
 
+fn compile_select_statement(
+    select: &ast::Select,
+    input: &impl CompilationInput
+) -> Result<CompiledQuery, CompilationError> {
+    let mut query = CompiledQuery::new();
+
+    match &select.selection {
+        None => {}
+        Some(expr) => {
+            let condition = compile_expr(expr, input, &mut query)?;
+            if let Ok(data_type) = condition.get_type() {
+                if data_type != DataType::Bool {
+                    return Err(CompilationError::TypeError(
+                        "WHERE statement doesn't evaluate to a boolean expression"
+                            .to_string(),
+                    ));
+                }
+            }
+
+            query.selection = Some(condition);
+        }
+    };
+
+    for c in &select.projection {
+        match c {
+            ast::SelectItem::UnnamedExpr(expr) => {
+                let expr = compile_expr(expr, input, &mut query)?;
+                query.projection.push(expr);
+            }
+            ast::SelectItem::ExprWithAlias { expr, alias } => {
+                let expr = compile_expr(expr, input, &mut query)?;
+
+                let name = alias.value.clone();
+                query.projection.push(Expr::Alias {
+                    expr: Box::new(expr),
+                    alias: name,
+                });
+            }
+            _ => {
+                return Err(CompilationError::UnsupportedOperation(
+                    "unrecognized entry in SELECT statement".to_string(),
+                ))
+            }
+        }
+    }
+
+    Ok(query)
+}
+
 pub fn compile(
     sql: &str,
     input: &impl CompilationInput,
@@ -419,50 +537,8 @@ pub fn compile(
                 },
                 _ => None,
             };
-
             if let Some(select) = select_statement {
-                let mut query = CompiledQuery::new();
-
-                match &select.selection {
-                    None => {}
-                    Some(expr) => {
-                        let condition = compile_expr(expr, input, &mut query)?;
-                        if let Ok(data_type) = condition.get_type() {
-                            if data_type != DataType::Bool {
-                                return Err(CompilationError::TypeError(
-                                    "WHERE statement doesn't evaluate to a boolean expression"
-                                        .to_string(),
-                                ));
-                            }
-                        }
-
-                        query.selection = Some(condition);
-                    }
-                };
-
-                for c in &select.projection {
-                    match c {
-                        ast::SelectItem::UnnamedExpr(expr) => {
-                            let expr = compile_expr(expr, input, &mut query)?;
-                            query.projection.push(expr);
-                        }
-                        ast::SelectItem::ExprWithAlias { expr, alias } => {
-                            let expr = compile_expr(expr, input, &mut query)?;
-                            let name = alias.value.clone();
-                            query.projection.push(Expr::Alias {
-                                expr: Box::new(expr),
-                                alias: name,
-                            });
-                        }
-                        _ => {
-                            return Err(CompilationError::UnsupportedOperation(
-                                "unrecognized entry in SELECT statement".to_string(),
-                            ))
-                        }
-                    }
-                }
-
-                Ok(query)
+                return compile_select_statement(&select, input);
             } else {
                 Err(CompilationError::UnsupportedOperation(
                     "unrecognized SELECT statement".to_string(),

--- a/kuksa_databroker/databroker/src/query/executor.rs
+++ b/kuksa_databroker/databroker/src/query/executor.rs
@@ -427,7 +427,7 @@ impl CompilationInput for TestCompilationInput {
 
 #[cfg(test)]
 fn assert_expected(res: Option<Vec<(String, DataValue)>>, expected: &Vec<(String, DataValue)>) {
-    assert!(matches!(res, Some(_)));
+    assert!(res.is_some());
     if let Some(fields) = &res {
         assert_eq!(fields.len(), expected.len());
         for (i, (name, value)) in fields.iter().enumerate() {
@@ -525,7 +525,7 @@ fn executor_test() {
     );
     let res = compiled_query.execute(&execution_input1).unwrap();
 
-    assert!(matches!(res, None));
+    assert!(res.is_none());
 }
 
 #[test]
@@ -555,7 +555,7 @@ fn executor_lag_test() {
         },
     );
     let res = compiled_query.execute(&execution_input1).unwrap();
-    assert!(matches!(res, Some(_)));
+    assert!(res.is_some());
     let expected = vec![
         (
             "Vehicle.Cabin.Seat.Row1.Pos1.Position".to_owned(),
@@ -593,7 +593,7 @@ fn executor_lag_subquery_test() {
         },
     );
     let res = compiled_query.execute(&execution_input1).unwrap();
-    assert!(matches!(res, Some(_)));
+    assert!(res.is_some());
     let expected = vec![
         (
             "Vehicle.Cabin.Seat.Row1.Pos1.Position".to_owned(),
@@ -627,7 +627,7 @@ fn executor_where_lag_subquery_test() {
         },
     );
     let res = compiled_query.execute(&execution_input1).unwrap();
-    assert!(matches!(res, Some(_)));
+    assert!(res.is_some());
     let expected = vec![(
         "Vehicle.Cabin.Seat.Row1.Pos1.Position".to_owned(),
         DataValue::Int32(230),
@@ -643,5 +643,5 @@ fn executor_where_lag_subquery_test() {
         },
     );
     let res = compiled_query.execute(&execution_input1).unwrap();
-    assert!(matches!(res, None));
+    assert!(res.is_none());
 }

--- a/kuksa_databroker/databroker/src/query/expr.rs
+++ b/kuksa_databroker/databroker/src/query/expr.rs
@@ -18,6 +18,7 @@ pub enum Expr {
     Datapoint {
         name: String,
         data_type: DataType,
+        lag: bool
     },
     Alias {
         expr: Box<Expr>,
@@ -42,6 +43,9 @@ pub enum Expr {
     UnaryOperation {
         expr: Box<Expr>,
         operator: UnaryOperator,
+    },
+    Subquery {
+        index: u32
     },
     Between {
         expr: Box<Expr>,
@@ -76,10 +80,11 @@ pub enum UnresolvedLiteral {
 impl Expr {
     pub fn get_type(&self) -> Result<DataType, UnresolvedLiteral> {
         match self {
-            Expr::Datapoint { name: _, data_type } => Ok(data_type.clone()),
+            Expr::Datapoint { name: _, data_type, .. } => Ok(data_type.clone()),
             Expr::Alias { expr, alias: _ } => expr.get_type(),
             Expr::Cast { expr: _, data_type } => Ok(data_type.clone()),
             Expr::UnresolvedLiteral { raw } => Err(UnresolvedLiteral::Number(raw.clone())),
+            Expr::Subquery { index: _ } => Ok(DataType::Uint32),
             Expr::ResolvedLiteral {
                 value: _,
                 data_type,

--- a/kuksa_databroker/databroker/src/query/expr.rs
+++ b/kuksa_databroker/databroker/src/query/expr.rs
@@ -18,7 +18,7 @@ pub enum Expr {
     Datapoint {
         name: String,
         data_type: DataType,
-        lag: bool
+        lag: bool,
     },
     Alias {
         expr: Box<Expr>,
@@ -45,7 +45,7 @@ pub enum Expr {
         operator: UnaryOperator,
     },
     Subquery {
-        index: u32
+        index: u32,
     },
     Between {
         expr: Box<Expr>,
@@ -80,7 +80,9 @@ pub enum UnresolvedLiteral {
 impl Expr {
     pub fn get_type(&self) -> Result<DataType, UnresolvedLiteral> {
         match self {
-            Expr::Datapoint { name: _, data_type, .. } => Ok(data_type.clone()),
+            Expr::Datapoint {
+                name: _, data_type, ..
+            } => Ok(data_type.clone()),
             Expr::Alias { expr, alias: _ } => expr.get_type(),
             Expr::Cast { expr: _, data_type } => Ok(data_type.clone()),
             Expr::UnresolvedLiteral { raw } => Err(UnresolvedLiteral::Number(raw.clone())),

--- a/kuksa_databroker/databroker/src/types.rs
+++ b/kuksa_databroker/databroker/src/types.rs
@@ -76,8 +76,6 @@ pub enum DataValue {
     DoubleArray(Vec<f64>),
 }
 
-
-
 #[derive(Debug)]
 pub struct CastError {}
 
@@ -555,22 +553,18 @@ impl DataValue {
                 // TODO: Implement better floating point comparison
                 Ok((value - other_value).abs() < f64::EPSILON)
             }
-            (DataValue::NotAvailable, DataValue::Int32(..)) |
-            (DataValue::NotAvailable, DataValue::Int64(..)) |
-            (DataValue::NotAvailable, DataValue::Uint32(..)) |
-            (DataValue::NotAvailable, DataValue::Uint64(..)) |
-            (DataValue::NotAvailable, DataValue::Float(..)) |
-            (DataValue::NotAvailable, DataValue::Double(..)) => {
-                Ok(false)
-            }
-            (DataValue::Int32(..), DataValue::NotAvailable) |
-            (DataValue::Int64(..), DataValue::NotAvailable) |
-            (DataValue::Uint32(..), DataValue::NotAvailable) |
-            (DataValue::Uint64(..), DataValue::NotAvailable) |
-            (DataValue::Float(..), DataValue::NotAvailable) |
-            (DataValue::Double(..), DataValue::NotAvailable) => {
-                Ok(false)
-            }
+            (DataValue::NotAvailable, DataValue::Int32(..))
+            | (DataValue::NotAvailable, DataValue::Int64(..))
+            | (DataValue::NotAvailable, DataValue::Uint32(..))
+            | (DataValue::NotAvailable, DataValue::Uint64(..))
+            | (DataValue::NotAvailable, DataValue::Float(..))
+            | (DataValue::NotAvailable, DataValue::Double(..)) => Ok(false),
+            (DataValue::Int32(..), DataValue::NotAvailable)
+            | (DataValue::Int64(..), DataValue::NotAvailable)
+            | (DataValue::Uint32(..), DataValue::NotAvailable)
+            | (DataValue::Uint64(..), DataValue::NotAvailable)
+            | (DataValue::Float(..), DataValue::NotAvailable)
+            | (DataValue::Double(..), DataValue::NotAvailable) => Ok(false),
             _ => Err(CastError {}),
         }
     }
@@ -579,7 +573,7 @@ impl DataValue {
 #[derive(Debug)]
 pub struct ExecutionInputImplData {
     pub value: DataValue,
-    pub lag_value: DataValue
+    pub lag_value: DataValue,
 }
 
 #[test]

--- a/kuksa_databroker/databroker/src/types.rs
+++ b/kuksa_databroker/databroker/src/types.rs
@@ -76,6 +76,8 @@ pub enum DataValue {
     DoubleArray(Vec<f64>),
 }
 
+
+
 #[derive(Debug)]
 pub struct CastError {}
 
@@ -553,9 +555,31 @@ impl DataValue {
                 // TODO: Implement better floating point comparison
                 Ok((value - other_value).abs() < f64::EPSILON)
             }
+            (DataValue::NotAvailable, DataValue::Int32(..)) |
+            (DataValue::NotAvailable, DataValue::Int64(..)) |
+            (DataValue::NotAvailable, DataValue::Uint32(..)) |
+            (DataValue::NotAvailable, DataValue::Uint64(..)) |
+            (DataValue::NotAvailable, DataValue::Float(..)) |
+            (DataValue::NotAvailable, DataValue::Double(..)) => {
+                Ok(false)
+            }
+            (DataValue::Int32(..), DataValue::NotAvailable) |
+            (DataValue::Int64(..), DataValue::NotAvailable) |
+            (DataValue::Uint32(..), DataValue::NotAvailable) |
+            (DataValue::Uint64(..), DataValue::NotAvailable) |
+            (DataValue::Float(..), DataValue::NotAvailable) |
+            (DataValue::Double(..), DataValue::NotAvailable) => {
+                Ok(false)
+            }
             _ => Err(CastError {}),
         }
     }
+}
+
+#[derive(Debug)]
+pub struct ExecutionInputImplData {
+    pub value: DataValue,
+    pub lag_value: DataValue
 }
 
 #[test]


### PR DESCRIPTION
Enhancing query engine by:

1. LAG - Lag is now available in query engine - Each datapoint now contains also previous (lag) value. If there is request to feed some datapoint all subrscibers executing query where is possible to check if previous value is different. Than after all subscribes are notified previous lag value becomes the current one.
2. Subquery - SELECT now can use subqueries (check **executor.rs** unit tests)
 - WARNING it is working slightly different than standart SQL, where we can SELECT something from subquery where usually FROM keyword is used and than values are selected from subquery. Here if:
 ```
SELECT 
      Vehicle.Speed as notSubquerySpeed,
      (SELECT Vehicle.Speed WHERE Vehicle.Speed <> LAG(Vehicle.Speed))
```
We will get value if Vehicle.Speed is valid and there is not new feed of this value:
- notQuerySpeed: FloatValue(101.0) at 1699598734

And if there is an change of value query is returning:
- notQuerySpeed: FloatValue(102.0) at 1699598936
- Vehicle.Speed: FloatValue(102.0) at 1699598936

4. Equals comparsion now enables left or right to be NotAvailable, because of LAG of course if there is first datapoint change