### PR TITLE
kuksa-client move: Add notice about new location to get updated versions

### DIFF
--- a/kuksa-client/kuksa_client/__main__.py
+++ b/kuksa-client/kuksa_client/__main__.py
@@ -675,6 +675,12 @@ using {'KUKSA GRPC' if config['protocol'] == 'grpc' else 'VISS' } protocol."
 
 
 def main():
+    print(("⚠️ ⚠️ ⚠️  KUKSA client has moved. "
+          "You are using code from an old location that will not be updated anymore. ⚠️ ⚠️ ⚠️"))
+    print("🛠  The current source can be found at https://github.com/eclipse-kuksa/kuksa-python-sdk")
+    print(("💻  Up to date containers for kuksa-client are published at "
+           "ghcr.io/eclipse-kuksa/kuksa-python-sdk/kuksa-client"))
+    print("🐍  PyPI package remains at https://pypi.org/project/kuksa-client/")
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "server",


### PR DESCRIPTION
This is intended to build for master as well as next minor release. It is fully functional, but will warn people that they might update their source location to get updated versions.

PyPi users will never see this (as we will not publish it there), but I added PyPi location as well as "reassurance", i.e. if somebody is using kuksa-client pypi package and also the container

Should look like this

<img width="922" alt="image" src="https://github.com/eclipse/kuksa.val/assets/3707124/dfbd2727-2db5-40c9-9d2d-dfece5087aa6">
