### PR TITLE
Fix new Clippy issues

### DIFF
--- a/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -187,7 +187,7 @@ impl proto::val_server::Val for broker::DataBroker {
 
             // Not sure how to handle the "global error".
             // Fall back to just use the first path specific error if any
-            let error = match errors.get(0) {
+            let error = match errors.first() {
                 Some(first) => first.error.clone(),
                 None => None,
             };

--- a/kuksa_databroker/databroker/src/main.rs
+++ b/kuksa_databroker/databroker/src/main.rs
@@ -84,7 +84,7 @@ async fn add_kuksa_attribute(
             )];
             if let Err(errors) = database.update_entries(ids).await {
                 // There's only one error (since we're only trying to set one)
-                if let Some(error) = errors.get(0) {
+                if let Some(error) = errors.first() {
                     info!("Failed to set value for {}: {:?}", attribute, error.1);
                 }
             }
@@ -143,7 +143,7 @@ async fn read_metadata_file<'a, 'b>(
                     )];
                     if let Err(errors) = database.update_entries(ids).await {
                         // There's only one error (since we're only trying to set one)
-                        if let Some(error) = errors.get(0) {
+                        if let Some(error) = errors.first() {
                             info!("Failed to set default value for {}: {:?}", path, error.1);
                         }
                     }

--- a/kuksa_databroker/databroker/src/query/compiler.rs
+++ b/kuksa_databroker/databroker/src/query/compiler.rs
@@ -79,7 +79,7 @@ pub struct CompiledQuery {
     /// or as part of a condition.
     ///
     /// These needs to be provided in the `input` when
-    /// executing the query.  
+    /// executing the query.
     pub input_spec: HashSet<String>, // Needed datapoints (values) for execution
 }
 
@@ -412,7 +412,7 @@ pub fn compile(
 
     match sqlparser::parser::Parser::parse_sql(&dialect, sql) {
         Ok(ast) => {
-            let select_statement = match &ast.get(0) {
+            let select_statement = match &ast.first() {
                 Some(sqlparser::ast::Statement::Query(q)) => match &q.body {
                     sqlparser::ast::SetExpr::Select(query) => Some(query.clone()),
                     _ => None,

--- a/kuksa_databroker/databroker/src/viss/v2/server.rs
+++ b/kuksa_databroker/databroker/src/viss/v2/server.rs
@@ -189,7 +189,7 @@ impl Viss for Server {
                         ts: SystemTime::now().into(),
                     }),
                     Err(errors) => {
-                        let error = if let Some((_, error)) = errors.get(0) {
+                        let error = if let Some((_, error)) = errors.first() {
                             match error {
                                 UpdateError::NotFound => Error::NotFoundInvalidPath,
                                 UpdateError::WrongType => Error::BadRequest {


### PR DESCRIPTION
Newer clippy does not seem to like `get(0)` but prefer `first()`

(clippy 0.1.75 complained, but not clippy 0.1.73)

This shall fix the failing build on master.