### PR TITLE
Update actions to avoid Node.js 16 actions

### DIFF
--- a/.github/workflows/check_license.yml
+++ b/.github/workflows/check_license.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # required to grab the history of the PR
         fetch-depth: 0

--- a/.github/workflows/kuksa-go.yml
+++ b/.github/workflows/kuksa-go.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout kuksa.val
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run go tests
         run: |
           cd kuksa_go_client

--- a/.github/workflows/kuksa_databroker-cli_build.yml
+++ b/.github/workflows/kuksa_databroker-cli_build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: cargo fmt
         working-directory: ${{github.workspace}}
@@ -55,7 +55,7 @@ jobs:
     needs: check_ghcr_push
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -67,7 +67,7 @@ jobs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         # list of Docker images to use as base name for tags
         images: |
@@ -89,7 +89,7 @@ jobs:
 
     - name: Log in to the Container registry
       if: needs.check_ghcr_push.outputs.push == 'true'
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -98,7 +98,7 @@ jobs:
     - name: Build kuksa.val databroker CLI container and push to ghcr.io (and ttl.sh)
       id: ghcr-build
       if: needs.check_ghcr_push.outputs.push == 'true'
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         platforms: |
           linux/amd64
@@ -115,7 +115,7 @@ jobs:
     - name: Build ephemeral KUKSA Databroker container and push to ttl.sh
       if: needs.check_ghcr_push.outputs.push == 'false'
       id: tmp-build
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         platforms: |
           linux/amd64
@@ -158,7 +158,7 @@ jobs:
     needs: build-container
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Createbom: License check and Dash output generation"
         working-directory: ${{github.workspace}}/kuksa_databroker/createbom

--- a/.github/workflows/kuksa_databroker_build.yml
+++ b/.github/workflows/kuksa_databroker_build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Seems not neccessary on ubuntu-latest runner
       #- uses: dtolnay/rust-toolchain@stable
@@ -92,7 +92,7 @@ jobs:
     needs: check_ghcr_push
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
@@ -104,7 +104,7 @@ jobs:
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         # list of Docker images to use as base name for tags
         images: |
@@ -127,7 +127,7 @@ jobs:
 
     - name: Log in to the Container registry
       if: needs.check_ghcr_push.outputs.push == 'true'
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -136,7 +136,7 @@ jobs:
     - name: Build kuksa.val databroker container container and push to ghcr.io (and ttl.sh)
       id: ghcr-build
       if: needs.check_ghcr_push.outputs.push == 'true'
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         platforms: |
           linux/amd64
@@ -153,7 +153,7 @@ jobs:
     - name: Build ephemeral KUKSA Databroker container and push to ttl.sh
       if: needs.check_ghcr_push.outputs.push == 'false'
       id: tmp-build
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         platforms: |
           linux/amd64
@@ -199,7 +199,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run integration test on AMD64 container
         env:
@@ -228,7 +228,7 @@ jobs:
     needs: build-container
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: "Createbom: License check and Dash output generation"
         working-directory: ${{github.workspace}}/kuksa_databroker/createbom

--- a/.github/workflows/kuksa_val_docker.yml
+++ b/.github/workflows/kuksa_val_docker.yml
@@ -25,13 +25,13 @@ jobs:
     needs: check_ghcr_push
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
 
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@v4
+      uses: docker/metadata-action@v5
       with:
         # list of Docker images to use as base name for tags
         images: |
@@ -46,7 +46,7 @@ jobs:
 
     - name: Log in to the Container registry
       if: needs.check_ghcr_push.outputs.push == 'true'
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -54,7 +54,7 @@ jobs:
 
     - name: Build kuksa.val server container and push to ghcr.io
       if: needs.check_ghcr_push.outputs.push == 'true'
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         platforms: |
           linux/amd64
@@ -69,7 +69,7 @@ jobs:
 
     - name: Build ephemeral KUKSA Server docker and push to ttl.sh
       if: needs.check_ghcr_push.outputs.push == 'false'
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         platforms: |
           linux/amd64

--- a/.github/workflows/kuksa_val_unittest.yml
+++ b/.github/workflows/kuksa_val_unittest.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Unit test

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # required to grab the history of the PR
           fetch-depth: 0


### PR DESCRIPTION
Node.js 16 actions are deprecated.
Please update the following actions to use Node.js 20: actions/checkout@v3, docker/metadata-action@v4, docker/login-action@v2, docker/build-push-action@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.