### PR TITLE
Remove self-hosted dependency for KUKSA Server

### DIFF
--- a/.github/workflows/kuksa_val_docker.yml
+++ b/.github/workflows/kuksa_val_docker.yml
@@ -21,7 +21,7 @@ jobs:
     secrets: inherit
 
   build:
-    runs-on: [ self-hosted ]
+    runs-on: [ ubuntu-latest ]
     needs: check_ghcr_push
 
     steps:
@@ -51,6 +51,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
     - name: Build kuksa.val server container and push to ghcr.io
       if: needs.check_ghcr_push.outputs.push == 'true'


### PR DESCRIPTION
Recent builds on master using self-hosted failed (see https://github.com/eclipse/kuksa.val/actions/workflows/kuksa_val_docker.yml)

With this change it works - but it takes a lot longer time (building grpc, boost, and so on for arm64) - so alternative solutions are welcome. But better than failing builds