### PR TITLE
Add continuous subscription to subscribe method at a specific frequency

### DIFF
--- a/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -445,7 +445,7 @@ impl proto::val_server::Val for broker::DataBroker {
             }
         }
 
-        match broker.subscribe(entries).await {
+        match broker.subscribe(entries, request.frequency_hertz).await {
             Ok(stream) => {
                 let stream = convert_to_proto_stream(stream);
                 Ok(tonic::Response::new(Box::pin(stream)))

--- a/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
+++ b/kuksa_databroker/databroker/src/grpc/kuksa_val_v1/val.rs
@@ -28,7 +28,6 @@ use crate::broker::ReadError;
 use crate::broker::SubscriptionError;
 use crate::glob;
 use crate::permissions::Permissions;
-use crate::types;
 
 #[tonic::async_trait]
 impl proto::val_server::Val for broker::DataBroker {
@@ -410,7 +409,7 @@ impl proto::val_server::Val for broker::DataBroker {
             }
         }
 
-        let mut entries: HashMap<i32, (HashSet<broker::Field>, types::ChangeType)> = HashMap::new();
+        let mut entries: HashMap<i32, HashSet<broker::Field>> = HashMap::new();
 
         if !valid_requests.is_empty() {
             for (path, (regex, fields)) in valid_requests {
@@ -424,10 +423,9 @@ impl proto::val_server::Val for broker::DataBroker {
                             entries
                                 .entry(entry.metadata().id)
                                 .and_modify(|existing_fields| {
-                                    existing_fields.0.extend(fields.clone());
-                                    existing_fields.1 = entry.metadata().change_type.clone();
+                                    existing_fields.extend(fields.clone());
                                 })
-                                .or_insert((fields.clone(), entry.metadata().change_type.clone()));
+                                .or_insert(fields.clone());
 
                             match entry.datapoint() {
                                 Ok(_) => {}

--- a/kuksa_databroker/databroker/src/viss/v2/server.rs
+++ b/kuksa_databroker/databroker/src/viss/v2/server.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 use super::{conversions, types::*};
+pub use crate::types::ChangeType;
 
 #[tonic::async_trait]
 pub(crate) trait Viss: Send + Sync + 'static {
@@ -253,7 +254,15 @@ impl Viss for Server {
         let Some(entries) = broker
             .get_id_by_path(request.path.as_ref())
             .await
-            .map(|id| HashMap::from([(id, HashSet::from([broker::Field::Datapoint]))]))
+            .map(|id| {
+                HashMap::from([(
+                    id,
+                    (
+                        HashSet::from([broker::Field::Datapoint]),
+                        ChangeType::Static,
+                    ),
+                )])
+            })
         else {
             return Err(SubscribeErrorResponse {
                 request_id,

--- a/kuksa_databroker/databroker/src/viss/v2/server.rs
+++ b/kuksa_databroker/databroker/src/viss/v2/server.rs
@@ -262,7 +262,7 @@ impl Viss for Server {
             });
         };
 
-        match broker.subscribe(entries).await {
+        match broker.subscribe(entries, None).await {
             Ok(stream) => {
                 let subscription_id = SubscriptionId::new();
 

--- a/kuksa_databroker/databroker/src/viss/v2/server.rs
+++ b/kuksa_databroker/databroker/src/viss/v2/server.rs
@@ -33,7 +33,6 @@ use crate::{
 };
 
 use super::{conversions, types::*};
-pub use crate::types::ChangeType;
 
 #[tonic::async_trait]
 pub(crate) trait Viss: Send + Sync + 'static {
@@ -254,15 +253,7 @@ impl Viss for Server {
         let Some(entries) = broker
             .get_id_by_path(request.path.as_ref())
             .await
-            .map(|id| {
-                HashMap::from([(
-                    id,
-                    (
-                        HashSet::from([broker::Field::Datapoint]),
-                        ChangeType::Static,
-                    ),
-                )])
-            })
+            .map(|id| HashMap::from([(id, HashSet::from([broker::Field::Datapoint]))]))
         else {
             return Err(SubscribeErrorResponse {
                 request_id,

--- a/kuksa_databroker/lib/kuksa/src/lib.rs
+++ b/kuksa_databroker/lib/kuksa/src/lib.rs
@@ -288,7 +288,10 @@ impl KuksaClient {
             })
         }
 
-        let req = proto::v1::SubscribeRequest { entries };
+        let req = proto::v1::SubscribeRequest {
+            entries,
+            frequency_hertz: None,
+        };
 
         match client.subscribe(req).await {
             Ok(response) => Ok(response.into_inner()),
@@ -321,7 +324,10 @@ impl KuksaClient {
             })
         }
 
-        let req = proto::v1::SubscribeRequest { entries };
+        let req = proto::v1::SubscribeRequest {
+            entries,
+            frequency_hertz: None,
+        };
 
         match client.subscribe(req).await {
             Ok(response) => Ok(response.into_inner()),
@@ -346,7 +352,10 @@ impl KuksaClient {
             })
         }
 
-        let req = proto::v1::SubscribeRequest { entries };
+        let req = proto::v1::SubscribeRequest {
+            entries,
+            frequency_hertz: None,
+        };
 
         match client.subscribe(req).await {
             Ok(response) => Ok(response.into_inner()),

--- a/proto/kuksa/val/v1/val.proto
+++ b/proto/kuksa/val/v1/val.proto
@@ -98,6 +98,7 @@ message SubscribeEntry {
 // Subscribe to changes in datapoints.
 message SubscribeRequest {
   repeated SubscribeEntry entries = 1;
+  optional uint64 frequency_hertz = 2;
 }
 
 // A subscription response


### PR DESCRIPTION
This PR solves https://github.com/eclipse/kuksa.val/issues/652

**How can be tested?**

- Use this test.json file as the VSS input for the broker. It contains the necessary overlays modified to test it with the _ChangeType_ values _Continuous_ and _OnChange_ to verify the expected behavior
[test.json](https://github.com/eclipse/kuksa.val/files/14220629/test.json)

- You can subscribe with databroker-clie to the signals Vehicle.Driver.HeartRate (Continuous update) and Vehicle.Body.Trunk.Front.IsLightOn (OnChange update).

- Kuksa-client seems to have some bugs that need testing for this new feature.

**What to expect?**

- The value for Vehicle.Driver.HeartRate should be set, as well as for Vehicle.Body.Trunk.Front.IsLightOn.
- Subscribe to both paths, and the terminal should display the _Continuous_ values every second and _OnChange_ values only when updated.

**Kuksa client to test it**
https://github.com/eclipse-kuksa/kuksa-python-sdk/pull/21