### PR TITLE
Disable sdv.databroker.v1 by default

### DIFF
--- a/kuksa_databroker/databroker-cli/src/cli.rs
+++ b/kuksa_databroker/databroker-cli/src/cli.rs
@@ -52,8 +52,8 @@ pub struct Cli {
     ca_cert: Option<String>,
 
     #[arg(value_enum)]
-    #[clap(long, short = 'p', value_enum, default_value = "sdv-databroker-v1")]
-    protocol: CliAPI,
+    #[clap(long, short = 'p', value_enum, default_value_t = Protocol::KuksaValV1)]
+    protocol: Protocol,
 
     // Sub command
     #[clap(subcommand)]
@@ -77,7 +77,7 @@ impl Cli {
         self.server.clone()
     }
 
-    pub fn get_protocol(&mut self) -> CliAPI {
+    pub fn get_protocol(&mut self) -> Protocol {
         self.protocol
     }
 }
@@ -93,8 +93,10 @@ pub enum Commands {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
-pub enum CliAPI {
+pub enum Protocol {
+    #[clap(name = "kuksa.val.v1")]
     KuksaValV1 = 1,
+    #[clap(name = "sdv.databroker.v1")]
     SdvDatabrokerV1 = 2,
 }
 

--- a/kuksa_databroker/databroker-cli/src/kuksa_cli.rs
+++ b/kuksa_databroker/databroker-cli/src/kuksa_cli.rs
@@ -42,7 +42,7 @@ const CLI_COMMANDS: &[(&str, &str, &str)] = &[
         "<QUERY>",
         "Subscribe to signals with QUERY, if you use kuksa feature comma separated list",
     ),
-    ("feed", "<PATH> <VALUE>", "Publish signal value"),
+    ("publish", "<PATH> <VALUE>", "Publish signal value"),
     (
         "metadata",
         "[PATTERN]",
@@ -369,7 +369,7 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                                 format!("{} is not an actuator.", path),
                                             )?;
                                             cli::print_info(
-                                                "If you want to provide the signal value, use `feed`.",
+                                                "If you want to act as a provider and publish a value, use `publish`.",
                                             )?;
                                             continue;
                                         }
@@ -402,7 +402,7 @@ pub async fn kuksa_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             }
                         }
-                        "feed" => {
+                        "publish" => {
                             interface.add_history_unique(line.clone());
 
                             let (path, value) = cli::split_first_word(args);
@@ -902,7 +902,7 @@ impl<Term: Terminal> Completer<Term> for CliCompleter {
                 Some(compls)
             }
             // Complete command parameters
-            Some("set") | Some("feed") => {
+            Some("set") | Some("publish") => {
                 if words.count() == 0 {
                     self.complete_entry_path(word)
                 } else {

--- a/kuksa_databroker/databroker-cli/src/main.rs
+++ b/kuksa_databroker/databroker-cli/src/main.rs
@@ -12,7 +12,7 @@
 ********************************************************************************/
 
 use clap::Parser;
-use cli::CliAPI;
+use cli::Protocol;
 
 pub mod cli;
 mod kuksa_cli;
@@ -21,19 +21,19 @@ mod sdv_cli;
 #[tokio::main]
 async fn main() {
     let mut cli = cli::Cli::parse();
-    if cli.get_protocol() == CliAPI::SdvDatabrokerV1 {
+    if cli.get_protocol() == Protocol::SdvDatabrokerV1 {
         let err = sdv_cli::sdv_main(cli.clone()).await;
         match err {
             Ok(_) => (),
             Err(e) => eprintln!("Error: {}", e),
         }
-    } else if cli.get_protocol() == CliAPI::KuksaValV1 {
+    } else if cli.get_protocol() == Protocol::KuksaValV1 {
         let err = kuksa_cli::kuksa_main(cli.clone()).await;
         match err {
             Ok(_) => (),
             Err(e) => eprintln!("Error: {}", e),
         }
     } else {
-        println!("Choose one protocol of either kuksa-val-v1 or sdv-databroker-v1")
+        println!("Choose one protocol of either kuksa.val.v1 or sdv.databroker.v1")
     }
 }

--- a/kuksa_databroker/databroker-cli/src/sdv_cli.rs
+++ b/kuksa_databroker/databroker-cli/src/sdv_cli.rs
@@ -42,7 +42,7 @@ const CLI_COMMANDS: &[(&str, &str, &str)] = &[
         "<QUERY>",
         "Subscribe to signals with QUERY, if you use kuksa feature comma separated list",
     ),
-    ("feed", "<PATH> <VALUE>", "Publish signal value"),
+    ("publish", "<PATH> <VALUE>", "Publish signal value"),
     (
         "metadata",
         "[PATTERN]",
@@ -352,7 +352,7 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                         format!("{} is not an actuator.", metadata.name),
                                     )?;
                                     cli::print_info(
-                                        "If you want to provide the signal value, use `feed`.",
+                                        "If you want to act as a provider and publish a value, use `publish`.",
                                     )?;
                                     continue;
                                 }
@@ -404,7 +404,7 @@ pub async fn sdv_main(_cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                                 }
                             }
                         }
-                        "feed" => {
+                        "publish" => {
                             interface.add_history_unique(line.clone());
 
                             let (path, value) = cli::split_first_word(args);
@@ -916,7 +916,7 @@ impl<Term: Terminal> Completer<Term> for CliCompleter {
                 Some(compls)
             }
             // Complete command parameters
-            Some("set") | Some("feed") => {
+            Some("set") | Some("publish") => {
                 if words.count() == 0 {
                     self.complete_entry_path(word)
                 } else {

--- a/kuksa_databroker/databroker/src/main.rs
+++ b/kuksa_databroker/databroker/src/main.rs
@@ -244,6 +244,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .long("disable-authorization")
                 .help("Disable authorization")
                 .action(ArgAction::SetTrue),
+        )
+        .arg(
+            Arg::new("enable-databroker-v1")
+                .display_order(30)
+                .long("enable-databroker-v1")
+                .help("Enable sdv.databroker.v1 (GRPC) service")
+                .action(ArgAction::SetTrue),
         );
 
     #[cfg(feature = "tls")]
@@ -437,11 +444,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    let mut apis = vec![grpc::server::Api::KuksaValV1];
+
+    if args.get_flag("enable-databroker-v1") {
+        apis.push(grpc::server::Api::SdvDatabrokerV1);
+    }
+
     grpc::server::serve(
         addr,
         broker,
         #[cfg(feature = "tls")]
         tls_config,
+        &apis,
         authorization,
         shutdown_handler(),
     )

--- a/kuksa_databroker/databroker/tests/world/mod.rs
+++ b/kuksa_databroker/databroker/tests/world/mod.rs
@@ -232,6 +232,7 @@ impl DataBrokerWorld {
                 data_broker,
                 #[cfg(feature = "tls")]
                 CERTS.server_tls_config(),
+                &[grpc::server::Api::KuksaValV1],
                 _authorization,
                 poll_fn(|cx| {
                     let mut state = owned_state


### PR DESCRIPTION
- Disable `sdv.databroker.v1` by default. It can be enabled by supplying a flag at startup.
- Change databroker-cli to use `kuksa.val.v1` by default.