### PR TITLE
Systemd notify support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,6 +601,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
+ "sd-notify",
  "serde",
  "serde_json",
  "sqlparser",
@@ -2557,6 +2558,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sd-notify"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621e3680f3e07db4c9c2c3fb07c6223ab2fab2e54bd3c04c3ae037990f428c32"
 
 [[package]]
 name = "sealed"

--- a/kuksa_databroker/databroker/Cargo.toml
+++ b/kuksa_databroker/databroker/Cargo.toml
@@ -63,6 +63,10 @@ futures = { version = "0.3.28", optional = true }
 chrono = { version = "0.4.31", optional = true, features = ["std"] }
 uuid = { version = "1.4.1", optional = true, features = ["v4"] }
 
+# systemd related dependency, only relevant on linux systems
+[target.'cfg(target_os = "linux")'.dependencies]
+sd-notify = "0.4.1"
+
 [features]
 default = ["tls"]
 tls = ["tonic/tls"]


### PR DESCRIPTION
Experimental support for systemd notify

From the discussion in chat 

![image](https://github.com/eclipse/kuksa.val/assets/3707124/e915095f-4186-4c96-b83f-64908fe86185)

This is not perfect yet, so lets discuss here what is needed for "good enough" level

1. It uses https://crates.io/crates/sd-notify crate. The way that crate is written I assume we do not even need to hide it behind a feature flag: On a non-systemd (maybe even non Linux) it does no harm, as it determines systemd availability by just checking existence of a file. On a a systemd system, even when starting manually on the commandline, a notify doesn't hurt, systemd will just ignore it (I assume that is probably how all notify-enabled dameons work)

2. _When_ to signal ready state: I put the code in the last reachable statement in main _before_ the GRPC socket is up. So strictly speaking there is still a race conditions. As at this point all parsing an dinitlaization is done, I assume for practical reasosn it would solve your issue @g-scott-murray    However anyone knows a "better" place to put this code, i.e. any callback/event when GRPC server is up (strictyl speaking VISS also might not be ready yet, if started in a thread before). I did not find anything obvious. Do you have an idea @argerus , what might work preferably without putting too much infrastructure in?