### PR TITLE
LOW-5 Malicious JWT access token can crash a thread of the databroker

### DIFF
--- a/kuksa_databroker/databroker/src/authorization/jwt/decoder.rs
+++ b/kuksa_databroker/databroker/src/authorization/jwt/decoder.rs
@@ -130,8 +130,13 @@ impl TryFrom<Claims> for Permissions {
             }
         }
 
-        permissions = permissions
-            .expires_at(std::time::UNIX_EPOCH + std::time::Duration::from_secs(claims.exp));
+        if let Some(expire_date) =
+            std::time::UNIX_EPOCH.checked_add(std::time::Duration::from_secs(claims.exp))
+        {
+            permissions = permissions.expires_at(expire_date);
+        } else {
+            return Err(Error::ClaimsError);
+        }
 
         permissions.build().map_err(|err| match err {
             PermissionsBuildError::BuildError => Error::ClaimsError,


### PR DESCRIPTION
use safe addition ```checked_add``` in decoder.rs to catch overflows and do not ```panic```. Instead returning ```ClaimsError```.