### PR TITLE
Update and deprecate node-red example

### DIFF
--- a/kuksa_apps/node-red/README.md
+++ b/kuksa_apps/node-red/README.md
@@ -1,5 +1,7 @@
 # Flow for node-red dashboard
 
+**NOTE: This example is deprecated and will reach End-of-Life 2024-12-31!**
+
 This example uses [node-red](https://nodered.org/) but an installation is not required at your machine, as we are using Docker. You can import the json file to receive data from kuksa-val-server. Then you can use the node-red dashboard feature to view data.
 
 ## Dependencies

--- a/kuksa_apps/node-red/mqtt/package-lock.json
+++ b/kuksa_apps/node-red/mqtt/package-lock.json
@@ -1,64 +1,87 @@
 {
     "name": "node-red-project",
     "version": "0.0.1",
-    "lockfileVersion": 1,
+    "lockfileVersion": 3,
     "requires": true,
-    "dependencies": {
-        "@socket.io/component-emitter": {
+    "packages": {
+        "": {
+            "name": "node-red-project",
+            "version": "0.0.1",
+            "dependencies": {
+                "node-red-contrib-web-worldmap": "~4.6.5",
+                "node-red-dashboard": "~3.6.5"
+            }
+        },
+        "node_modules/@socket.io/component-emitter": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
             "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
         },
-        "@types/cookie": {
+        "node_modules/@types/cookie": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
             "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
         },
-        "@types/cors": {
-            "version": "2.8.13",
-            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.13.tgz",
-            "integrity": "sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==",
-            "requires": {
+        "node_modules/@types/cors": {
+            "version": "2.8.17",
+            "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+            "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+            "dependencies": {
                 "@types/node": "*"
             }
         },
-        "@types/node": {
-            "version": "18.11.15",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
-            "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw=="
+        "node_modules/@types/node": {
+            "version": "20.12.3",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.3.tgz",
+            "integrity": "sha512-sD+ia2ubTeWrOu+YMF+MTAB7E+O7qsMqAbMfW7DG3K1URwhZ5hN1pLlRVGbf4wDFzSfikL05M17EyorS86jShw==",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
-        "accepts": {
+        "node_modules/accepts": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
             "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
-            "requires": {
+            "dependencies": {
                 "mime-types": "~2.1.34",
                 "negotiator": "0.6.3"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
-        "base64id": {
+        "node_modules/base64id": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-            "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
+            "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+            "engines": {
+                "node": "^4.5.0 || >= 5.9"
+            }
         },
-        "bytes": {
+        "node_modules/bytes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="
+            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
-        "compressible": {
+        "node_modules/compressible": {
             "version": "2.0.18",
             "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
             "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
-            "requires": {
+            "dependencies": {
                 "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
-        "compression": {
+        "node_modules/compression": {
             "version": "1.7.4",
             "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
             "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
-            "requires": {
+            "dependencies": {
                 "accepts": "~1.3.5",
                 "bytes": "3.0.0",
                 "compressible": "~2.0.16",
@@ -66,697 +89,951 @@
                 "on-headers": "~1.0.2",
                 "safe-buffer": "5.1.2",
                 "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
-        "cookie": {
+        "node_modules/cookie": {
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
-        "cors": {
+        "node_modules/cors": {
             "version": "2.8.5",
             "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
             "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-            "requires": {
+            "dependencies": {
                 "object-assign": "^4",
                 "vary": "^1"
+            },
+            "engines": {
+                "node": ">= 0.10"
             }
         },
-        "debug": {
+        "node_modules/debug": {
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-            "requires": {
+            "dependencies": {
                 "ms": "2.0.0"
             }
         },
-        "depd": {
+        "node_modules/depd": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
-        "destroy": {
+        "node_modules/destroy": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
         },
-        "ee-first": {
+        "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
-        "encodeurl": {
+        "node_modules/encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
-        "engine.io-parser": {
-            "version": "5.0.4",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
-            "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg=="
+        "node_modules/engine.io": {
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.5.4.tgz",
+            "integrity": "sha512-KdVSDKhVKyOi+r5uEabrDLZw2qXStVvCsEB/LN3mw4WFi6Gx50jTyuxYVCwAAC0U46FdnzP/ScKRBTXb/NiEOg==",
+            "dependencies": {
+                "@types/cookie": "^0.4.1",
+                "@types/cors": "^2.8.12",
+                "@types/node": ">=10.0.0",
+                "accepts": "~1.3.4",
+                "base64id": "2.0.0",
+                "cookie": "~0.4.1",
+                "cors": "~2.8.5",
+                "debug": "~4.3.1",
+                "engine.io-parser": "~5.2.1",
+                "ws": "~8.11.0"
+            },
+            "engines": {
+                "node": ">=10.2.0"
+            }
         },
-        "escape-html": {
+        "node_modules/engine.io-parser": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+            "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/engine.io/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/engine.io/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
             "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
         },
-        "etag": {
+        "node_modules/etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
-        "fresh": {
+        "node_modules/fresh": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
-        "gridstack": {
+        "node_modules/gridstack": {
             "version": "0.6.4",
             "resolved": "https://registry.npmjs.org/gridstack/-/gridstack-0.6.4.tgz",
             "integrity": "sha512-4ToCnneNg5Uw+ms3xHtPVvsNXdvwQhngdlyNgGkARwvooQu+gLL6xkwPqLU59TsZP/LVvofb2QhEuXyh/ocL8w==",
-            "requires": {
+            "dependencies": {
                 "jquery": "^1.8 || 2 || 3"
             }
         },
-        "http-errors": {
+        "node_modules/http-errors": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
             "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-            "requires": {
+            "dependencies": {
                 "depd": "2.0.0",
                 "inherits": "2.0.4",
                 "setprototypeof": "1.2.0",
                 "statuses": "2.0.1",
                 "toidentifier": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
             }
         },
-        "inherits": {
+        "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
-        "jquery": {
+        "node_modules/jquery": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.2.tgz",
             "integrity": "sha512-/e7ulNIEEYk1Z/l4X0vpxGt+B/dNsV8ghOPAWZaJs8pkGvsSC0tm33aMGylXcj/U7y4IcvwtMXPMyBFZn/gK9A=="
         },
-        "mime": {
+        "node_modules/mime": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
         },
-        "mime-db": {
+        "node_modules/mime-db": {
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
-        "mime-types": {
+        "node_modules/mime-types": {
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "requires": {
+            "dependencies": {
                 "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
             }
         },
-        "ms": {
+        "node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         },
-        "negotiator": {
+        "node_modules/negotiator": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+            "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
-        "node-red-contrib-web-worldmap": {
-            "version": "2.31.3",
-            "resolved": "https://registry.npmjs.org/node-red-contrib-web-worldmap/-/node-red-contrib-web-worldmap-2.31.3.tgz",
-            "integrity": "sha512-R1inUUDlApJrBcW3JdAFcoMpspBgx0wpXs4ajBv/e6WnItgDgo4F0gFftoq9PT9SItNy7p3e/sv9k3WWmwRqeQ==",
-            "requires": {
+        "node_modules/node-red-contrib-web-worldmap": {
+            "version": "4.6.5",
+            "resolved": "https://registry.npmjs.org/node-red-contrib-web-worldmap/-/node-red-contrib-web-worldmap-4.6.5.tgz",
+            "integrity": "sha512-9vbJS/86+QldmBNIGfb2C60FUSI7H5y+bmXxpLRQEE3MENePt6gERw8IHEivv74oDc+JUWh2Kb2M7uFJTpRbRw==",
+            "bundleDependencies": [
+                "cgi",
+                "compression",
+                "express",
+                "sockjs",
+                "@turf/bezier-spline"
+            ],
+            "dependencies": {
                 "@turf/bezier-spline": "~6.5.0",
                 "cgi": "0.3.1",
                 "compression": "^1.7.4",
-                "express": "^4.18.2",
+                "express": "^4.19.2",
                 "sockjs": "~0.3.24"
             },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/@turf/bezier-spline": {
+            "version": "6.5.0",
+            "inBundle": true,
+            "license": "MIT",
             "dependencies": {
-                "@turf/bezier-spline": {
-                    "version": "6.5.0",
-                    "bundled": true,
-                    "requires": {
-                        "@turf/helpers": "^6.5.0",
-                        "@turf/invariant": "^6.5.0"
-                    }
-                },
-                "@turf/helpers": {
-                    "version": "6.5.0",
-                    "bundled": true
-                },
-                "@turf/invariant": {
-                    "version": "6.5.0",
-                    "bundled": true,
-                    "requires": {
-                        "@turf/helpers": "^6.5.0"
-                    }
-                },
-                "accepts": {
-                    "version": "1.3.8",
-                    "bundled": true,
-                    "requires": {
-                        "mime-types": "~2.1.34",
-                        "negotiator": "0.6.3"
-                    }
-                },
-                "array-flatten": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "body-parser": {
-                    "version": "1.20.1",
-                    "bundled": true,
-                    "requires": {
-                        "bytes": "3.1.2",
-                        "content-type": "~1.0.4",
-                        "debug": "2.6.9",
-                        "depd": "2.0.0",
-                        "destroy": "1.2.0",
-                        "http-errors": "2.0.0",
-                        "iconv-lite": "0.4.24",
-                        "on-finished": "2.4.1",
-                        "qs": "6.11.0",
-                        "raw-body": "2.5.1",
-                        "type-is": "~1.6.18",
-                        "unpipe": "1.0.0"
-                    },
-                    "dependencies": {
-                        "bytes": {
-                            "version": "3.1.2",
-                            "bundled": true
-                        }
-                    }
-                },
-                "bufferjs": {
-                    "version": "3.0.1",
-                    "bundled": true
-                },
-                "bufferlist": {
-                    "version": "0.1.0",
-                    "bundled": true
-                },
-                "bytes": {
-                    "version": "3.0.0",
-                    "bundled": true
-                },
-                "call-bind": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "function-bind": "^1.1.1",
-                        "get-intrinsic": "^1.0.2"
-                    }
-                },
-                "cgi": {
-                    "version": "0.3.1",
-                    "bundled": true,
-                    "requires": {
-                        "debug": "2",
-                        "extend": "~2.0.0",
-                        "header-stack": "~0.0.2",
-                        "stream-stack": "~1.1.1"
-                    }
-                },
-                "compressible": {
-                    "version": "2.0.18",
-                    "bundled": true,
-                    "requires": {
-                        "mime-db": ">= 1.43.0 < 2"
-                    }
-                },
-                "compression": {
-                    "version": "1.7.4",
-                    "bundled": true,
-                    "requires": {
-                        "accepts": "~1.3.5",
-                        "bytes": "3.0.0",
-                        "compressible": "~2.0.16",
-                        "debug": "2.6.9",
-                        "on-headers": "~1.0.2",
-                        "safe-buffer": "5.1.2",
-                        "vary": "~1.1.2"
-                    }
-                },
-                "content-disposition": {
-                    "version": "0.5.4",
-                    "bundled": true,
-                    "requires": {
-                        "safe-buffer": "5.2.1"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.2.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "content-type": {
-                    "version": "1.0.4",
-                    "bundled": true
-                },
-                "cookie": {
-                    "version": "0.5.0",
-                    "bundled": true
-                },
-                "cookie-signature": {
-                    "version": "1.0.6",
-                    "bundled": true
-                },
-                "debug": {
-                    "version": "2.6.9",
-                    "bundled": true,
-                    "requires": {
-                        "ms": "2.0.0"
-                    }
-                },
-                "depd": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "destroy": {
-                    "version": "1.2.0",
-                    "bundled": true
-                },
-                "ee-first": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "encodeurl": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "escape-html": {
-                    "version": "1.0.3",
-                    "bundled": true
-                },
-                "etag": {
-                    "version": "1.8.1",
-                    "bundled": true
-                },
-                "express": {
-                    "version": "4.18.2",
-                    "bundled": true,
-                    "requires": {
-                        "accepts": "~1.3.8",
-                        "array-flatten": "1.1.1",
-                        "body-parser": "1.20.1",
-                        "content-disposition": "0.5.4",
-                        "content-type": "~1.0.4",
-                        "cookie": "0.5.0",
-                        "cookie-signature": "1.0.6",
-                        "debug": "2.6.9",
-                        "depd": "2.0.0",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "etag": "~1.8.1",
-                        "finalhandler": "1.2.0",
-                        "fresh": "0.5.2",
-                        "http-errors": "2.0.0",
-                        "merge-descriptors": "1.0.1",
-                        "methods": "~1.1.2",
-                        "on-finished": "2.4.1",
-                        "parseurl": "~1.3.3",
-                        "path-to-regexp": "0.1.7",
-                        "proxy-addr": "~2.0.7",
-                        "qs": "6.11.0",
-                        "range-parser": "~1.2.1",
-                        "safe-buffer": "5.2.1",
-                        "send": "0.18.0",
-                        "serve-static": "1.15.0",
-                        "setprototypeof": "1.2.0",
-                        "statuses": "2.0.1",
-                        "type-is": "~1.6.18",
-                        "utils-merge": "1.0.1",
-                        "vary": "~1.1.2"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.2.1",
-                            "bundled": true
-                        }
-                    }
-                },
-                "extend": {
-                    "version": "2.0.2",
-                    "bundled": true
-                },
-                "faye-websocket": {
-                    "version": "0.11.4",
-                    "bundled": true,
-                    "requires": {
-                        "websocket-driver": ">=0.5.1"
-                    }
-                },
-                "finalhandler": {
-                    "version": "1.2.0",
-                    "bundled": true,
-                    "requires": {
-                        "debug": "2.6.9",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "on-finished": "2.4.1",
-                        "parseurl": "~1.3.3",
-                        "statuses": "2.0.1",
-                        "unpipe": "~1.0.0"
-                    }
-                },
-                "forwarded": {
-                    "version": "0.2.0",
-                    "bundled": true
-                },
-                "fresh": {
-                    "version": "0.5.2",
-                    "bundled": true
-                },
-                "function-bind": {
-                    "version": "1.1.1",
-                    "bundled": true
-                },
-                "get-intrinsic": {
-                    "version": "1.1.3",
-                    "bundled": true,
-                    "requires": {
-                        "function-bind": "^1.1.1",
-                        "has": "^1.0.3",
-                        "has-symbols": "^1.0.3"
-                    }
-                },
-                "has": {
-                    "version": "1.0.3",
-                    "bundled": true,
-                    "requires": {
-                        "function-bind": "^1.1.1"
-                    }
-                },
-                "has-symbols": {
-                    "version": "1.0.3",
-                    "bundled": true
-                },
-                "header-stack": {
-                    "version": "0.0.2",
-                    "bundled": true,
-                    "requires": {
-                        "bufferjs": ">= 0.2.3",
-                        "bufferlist": ">= 0.0.6",
-                        "stream-stack": ">= 1.1.1"
-                    }
-                },
-                "http-errors": {
-                    "version": "2.0.0",
-                    "bundled": true,
-                    "requires": {
-                        "depd": "2.0.0",
-                        "inherits": "2.0.4",
-                        "setprototypeof": "1.2.0",
-                        "statuses": "2.0.1",
-                        "toidentifier": "1.0.1"
-                    }
-                },
-                "http-parser-js": {
-                    "version": "0.5.8",
-                    "bundled": true
-                },
-                "iconv-lite": {
-                    "version": "0.4.24",
-                    "bundled": true,
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                },
-                "inherits": {
-                    "version": "2.0.4",
-                    "bundled": true
-                },
-                "ipaddr.js": {
-                    "version": "1.9.1",
-                    "bundled": true
-                },
-                "media-typer": {
-                    "version": "0.3.0",
-                    "bundled": true
-                },
-                "merge-descriptors": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "methods": {
-                    "version": "1.1.2",
-                    "bundled": true
-                },
-                "mime": {
-                    "version": "1.6.0",
-                    "bundled": true
-                },
-                "mime-db": {
-                    "version": "1.52.0",
-                    "bundled": true
-                },
-                "mime-types": {
-                    "version": "2.1.35",
-                    "bundled": true,
-                    "requires": {
-                        "mime-db": "1.52.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "bundled": true
-                },
-                "negotiator": {
-                    "version": "0.6.3",
-                    "bundled": true
-                },
-                "object-inspect": {
-                    "version": "1.12.2",
-                    "bundled": true
-                },
-                "on-finished": {
-                    "version": "2.4.1",
-                    "bundled": true,
-                    "requires": {
-                        "ee-first": "1.1.1"
-                    }
-                },
-                "on-headers": {
-                    "version": "1.0.2",
-                    "bundled": true
-                },
-                "parseurl": {
-                    "version": "1.3.3",
-                    "bundled": true
-                },
-                "path-to-regexp": {
-                    "version": "0.1.7",
-                    "bundled": true
-                },
-                "proxy-addr": {
-                    "version": "2.0.7",
-                    "bundled": true,
-                    "requires": {
-                        "forwarded": "0.2.0",
-                        "ipaddr.js": "1.9.1"
-                    }
-                },
-                "qs": {
-                    "version": "6.11.0",
-                    "bundled": true,
-                    "requires": {
-                        "side-channel": "^1.0.4"
-                    }
-                },
-                "range-parser": {
-                    "version": "1.2.1",
-                    "bundled": true
-                },
-                "raw-body": {
-                    "version": "2.5.1",
-                    "bundled": true,
-                    "requires": {
-                        "bytes": "3.1.2",
-                        "http-errors": "2.0.0",
-                        "iconv-lite": "0.4.24",
-                        "unpipe": "1.0.0"
-                    },
-                    "dependencies": {
-                        "bytes": {
-                            "version": "3.1.2",
-                            "bundled": true
-                        }
-                    }
-                },
-                "safe-buffer": {
-                    "version": "5.1.2",
-                    "bundled": true
-                },
-                "safer-buffer": {
-                    "version": "2.1.2",
-                    "bundled": true
-                },
-                "send": {
-                    "version": "0.18.0",
-                    "bundled": true,
-                    "requires": {
-                        "debug": "2.6.9",
-                        "depd": "2.0.0",
-                        "destroy": "1.2.0",
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "etag": "~1.8.1",
-                        "fresh": "0.5.2",
-                        "http-errors": "2.0.0",
-                        "mime": "1.6.0",
-                        "ms": "2.1.3",
-                        "on-finished": "2.4.1",
-                        "range-parser": "~1.2.1",
-                        "statuses": "2.0.1"
-                    },
-                    "dependencies": {
-                        "ms": {
-                            "version": "2.1.3",
-                            "bundled": true
-                        }
-                    }
-                },
-                "serve-static": {
-                    "version": "1.15.0",
-                    "bundled": true,
-                    "requires": {
-                        "encodeurl": "~1.0.2",
-                        "escape-html": "~1.0.3",
-                        "parseurl": "~1.3.3",
-                        "send": "0.18.0"
-                    }
-                },
-                "setprototypeof": {
-                    "version": "1.2.0",
-                    "bundled": true
-                },
-                "side-channel": {
-                    "version": "1.0.4",
-                    "bundled": true,
-                    "requires": {
-                        "call-bind": "^1.0.0",
-                        "get-intrinsic": "^1.0.2",
-                        "object-inspect": "^1.9.0"
-                    }
-                },
-                "sockjs": {
-                    "version": "0.3.24",
-                    "bundled": true,
-                    "requires": {
-                        "faye-websocket": "^0.11.3",
-                        "uuid": "^8.3.2",
-                        "websocket-driver": "^0.7.4"
-                    }
-                },
-                "statuses": {
-                    "version": "2.0.1",
-                    "bundled": true
-                },
-                "stream-stack": {
-                    "version": "1.1.4",
-                    "bundled": true
-                },
-                "toidentifier": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "type-is": {
-                    "version": "1.6.18",
-                    "bundled": true,
-                    "requires": {
-                        "media-typer": "0.3.0",
-                        "mime-types": "~2.1.24"
-                    }
-                },
-                "unpipe": {
-                    "version": "1.0.0",
-                    "bundled": true
-                },
-                "utils-merge": {
-                    "version": "1.0.1",
-                    "bundled": true
-                },
-                "uuid": {
-                    "version": "8.3.2",
-                    "bundled": true
-                },
-                "vary": {
-                    "version": "1.1.2",
-                    "bundled": true
-                },
-                "websocket-driver": {
-                    "version": "0.7.4",
-                    "bundled": true,
-                    "requires": {
-                        "http-parser-js": ">=0.5.1",
-                        "safe-buffer": ">=5.1.0",
-                        "websocket-extensions": ">=0.1.1"
-                    }
-                },
-                "websocket-extensions": {
-                    "version": "0.1.4",
-                    "bundled": true
+                "@turf/helpers": "^6.5.0",
+                "@turf/invariant": "^6.5.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/turf"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/@turf/helpers": {
+            "version": "6.5.0",
+            "inBundle": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/turf"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/@turf/invariant": {
+            "version": "6.5.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "@turf/helpers": "^6.5.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/turf"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/accepts": {
+            "version": "1.3.8",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-types": "~2.1.34",
+                "negotiator": "0.6.3"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/array-flatten": {
+            "version": "1.1.1",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/body-parser": {
+            "version": "1.20.2",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "content-type": "~1.0.5",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "on-finished": "2.4.1",
+                "qs": "6.11.0",
+                "raw-body": "2.5.2",
+                "type-is": "~1.6.18",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/body-parser/node_modules/bytes": {
+            "version": "3.1.2",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/bufferjs": {
+            "version": "3.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.2.0"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/bufferlist": {
+            "version": "0.1.0",
+            "inBundle": true
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/bytes": {
+            "version": "3.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/call-bind": {
+            "version": "1.0.7",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "set-function-length": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/cgi": {
+            "version": "0.3.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "2",
+                "extend": "~2.0.0",
+                "header-stack": "~0.0.2",
+                "stream-stack": "~1.1.1"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/compressible": {
+            "version": "2.0.18",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": ">= 1.43.0 < 2"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/compression": {
+            "version": "1.7.4",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "~1.3.5",
+                "bytes": "3.0.0",
+                "compressible": "~2.0.16",
+                "debug": "2.6.9",
+                "on-headers": "~1.0.2",
+                "safe-buffer": "5.1.2",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/content-disposition": {
+            "version": "0.5.4",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "5.2.1"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/content-disposition/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
                 }
+            ],
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/content-type": {
+            "version": "1.0.5",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
-        "node-red-dashboard": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/node-red-dashboard/-/node-red-dashboard-3.2.0.tgz",
-            "integrity": "sha512-8QmwnC39TDgyy1liF5edH7bvpw+IenDY2Yen/mqklJfpft2/ieInHqR3rSJ3RJBtEjkDf6JNriQssgzZrIyqkw==",
-            "requires": {
-                "compression": "^1.7.4",
-                "gridstack": "^0.6.4",
-                "serve-static": "^1.15.0",
-                "socket.io": "^4.5.2"
+        "node_modules/node-red-contrib-web-worldmap/node_modules/cookie": {
+            "version": "0.6.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
             }
         },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+        "node_modules/node-red-contrib-web-worldmap/node_modules/cookie-signature": {
+            "version": "1.0.6",
+            "inBundle": true,
+            "license": "MIT"
         },
-        "on-finished": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-            "requires": {
-                "ee-first": "1.1.1"
+        "node_modules/node-red-contrib-web-worldmap/node_modules/debug": {
+            "version": "2.6.9",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ms": "2.0.0"
             }
         },
-        "on-headers": {
+        "node_modules/node-red-contrib-web-worldmap/node_modules/define-data-property": {
+            "version": "1.1.4",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/depd": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/destroy": {
+            "version": "1.2.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/ee-first": {
+            "version": "1.1.1",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/encodeurl": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
-        "parseurl": {
+        "node_modules/node-red-contrib-web-worldmap/node_modules/es-define-property": {
+            "version": "1.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-intrinsic": "^1.2.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/es-errors": {
+            "version": "1.3.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/escape-html": {
+            "version": "1.0.3",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/etag": {
+            "version": "1.8.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/express": {
+            "version": "4.19.2",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "accepts": "~1.3.8",
+                "array-flatten": "1.1.1",
+                "body-parser": "1.20.2",
+                "content-disposition": "0.5.4",
+                "content-type": "~1.0.4",
+                "cookie": "0.6.0",
+                "cookie-signature": "1.0.6",
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "finalhandler": "1.2.0",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "merge-descriptors": "1.0.1",
+                "methods": "~1.1.2",
+                "on-finished": "2.4.1",
+                "parseurl": "~1.3.3",
+                "path-to-regexp": "0.1.7",
+                "proxy-addr": "~2.0.7",
+                "qs": "6.11.0",
+                "range-parser": "~1.2.1",
+                "safe-buffer": "5.2.1",
+                "send": "0.18.0",
+                "serve-static": "1.15.0",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "type-is": "~1.6.18",
+                "utils-merge": "1.0.1",
+                "vary": "~1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/express/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/extend": {
+            "version": "2.0.2",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/faye-websocket": {
+            "version": "0.11.4",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "websocket-driver": ">=0.5.1"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/finalhandler": {
+            "version": "1.2.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "2.4.1",
+                "parseurl": "~1.3.3",
+                "statuses": "2.0.1",
+                "unpipe": "~1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/forwarded": {
+            "version": "0.2.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/fresh": {
+            "version": "0.5.2",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/function-bind": {
+            "version": "1.1.2",
+            "inBundle": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/get-intrinsic": {
+            "version": "1.2.4",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/gopd": {
+            "version": "1.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-intrinsic": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/has-proto": {
+            "version": "1.0.3",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/has-symbols": {
+            "version": "1.0.3",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/hasown": {
+            "version": "2.0.2",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/header-stack": {
+            "version": "0.0.2",
+            "inBundle": true,
+            "dependencies": {
+                "bufferjs": ">= 0.2.3",
+                "bufferlist": ">= 0.0.6",
+                "stream-stack": ">= 1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/http-errors": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "depd": "2.0.0",
+                "inherits": "2.0.4",
+                "setprototypeof": "1.2.0",
+                "statuses": "2.0.1",
+                "toidentifier": "1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/http-parser-js": {
+            "version": "0.5.8",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/iconv-lite": {
+            "version": "0.4.24",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/inherits": {
+            "version": "2.0.4",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/media-typer": {
+            "version": "0.3.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/merge-descriptors": {
+            "version": "1.0.1",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/methods": {
+            "version": "1.1.2",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/mime": {
+            "version": "1.6.0",
+            "inBundle": true,
+            "license": "MIT",
+            "bin": {
+                "mime": "cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/mime-db": {
+            "version": "1.52.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/mime-types": {
+            "version": "2.1.35",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "mime-db": "1.52.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/ms": {
+            "version": "2.0.0",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/negotiator": {
+            "version": "0.6.3",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/object-inspect": {
+            "version": "1.13.1",
+            "inBundle": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/on-finished": {
+            "version": "2.4.1",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/on-headers": {
+            "version": "1.0.2",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/parseurl": {
             "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
-        "range-parser": {
+        "node_modules/node-red-contrib-web-worldmap/node_modules/path-to-regexp": {
+            "version": "0.1.7",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/proxy-addr": {
+            "version": "2.0.7",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "forwarded": "0.2.0",
+                "ipaddr.js": "1.9.1"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/qs": {
+            "version": "6.11.0",
+            "inBundle": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "side-channel": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=0.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/range-parser": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.6"
+            }
         },
-        "safe-buffer": {
+        "node_modules/node-red-contrib-web-worldmap/node_modules/raw-body": {
+            "version": "2.5.2",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "bytes": "3.1.2",
+                "http-errors": "2.0.0",
+                "iconv-lite": "0.4.24",
+                "unpipe": "1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/raw-body/node_modules/bytes": {
+            "version": "3.1.2",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/safe-buffer": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "inBundle": true,
+            "license": "MIT"
         },
-        "send": {
+        "node_modules/node-red-contrib-web-worldmap/node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/send": {
             "version": "0.18.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-            "requires": {
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
                 "debug": "2.6.9",
                 "depd": "2.0.0",
                 "destroy": "1.2.0",
@@ -771,126 +1048,424 @@
                 "range-parser": "~1.2.1",
                 "statuses": "2.0.1"
             },
-            "dependencies": {
-                "ms": {
-                    "version": "2.1.3",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-                }
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
-        "serve-static": {
+        "node_modules/node-red-contrib-web-worldmap/node_modules/send/node_modules/ms": {
+            "version": "2.1.3",
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/serve-static": {
             "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
-            "requires": {
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
                 "send": "0.18.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
             }
         },
-        "setprototypeof": {
+        "node_modules/node-red-contrib-web-worldmap/node_modules/set-function-length": {
+            "version": "1.2.2",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/setprototypeof": {
+            "version": "1.2.0",
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/side-channel": {
+            "version": "1.0.6",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.4",
+                "object-inspect": "^1.13.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/sockjs": {
+            "version": "0.3.24",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "faye-websocket": "^0.11.3",
+                "uuid": "^8.3.2",
+                "websocket-driver": "^0.7.4"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/statuses": {
+            "version": "2.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/stream-stack": {
+            "version": "1.1.4",
+            "inBundle": true,
+            "engines": {
+                "node": ">= 0.3.0"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/toidentifier": {
+            "version": "1.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/type-is": {
+            "version": "1.6.18",
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "media-typer": "0.3.0",
+                "mime-types": "~2.1.24"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/unpipe": {
+            "version": "1.0.0",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/utils-merge": {
+            "version": "1.0.1",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/uuid": {
+            "version": "8.3.2",
+            "inBundle": true,
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/vary": {
+            "version": "1.1.2",
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/websocket-driver": {
+            "version": "0.7.4",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "http-parser-js": ">=0.5.1",
+                "safe-buffer": ">=5.1.0",
+                "websocket-extensions": ">=0.1.1"
+            },
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/node-red-contrib-web-worldmap/node_modules/websocket-extensions": {
+            "version": "0.1.4",
+            "inBundle": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/node-red-dashboard": {
+            "version": "3.6.5",
+            "resolved": "https://registry.npmjs.org/node-red-dashboard/-/node-red-dashboard-3.6.5.tgz",
+            "integrity": "sha512-zoTVq13lh3OXzxBdFJByxaiijHLOCdkVfR5eCKXNm0RNFfGFyaqPQ06OoeLPXTmhU6KU/VDINxCKJUtdChg9Iw==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "compression": "^1.7.4",
+                "gridstack": "^0.6.4",
+                "serve-static": "^1.15.0",
+                "socket.io": "^4.7.4"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/parseurl": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/range-parser": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "node_modules/send": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+            "dependencies": {
+                "debug": "2.6.9",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "2.0.0",
+                "mime": "1.6.0",
+                "ms": "2.1.3",
+                "on-finished": "2.4.1",
+                "range-parser": "~1.2.1",
+                "statuses": "2.0.1"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/send/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
+        "node_modules/serve-static": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+            "dependencies": {
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.3",
+                "send": "0.18.0"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/setprototypeof": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
             "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
         },
-        "socket.io": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.6.1.tgz",
-            "integrity": "sha512-KMcaAi4l/8+xEjkRICl6ak8ySoxsYG+gG6/XfRCPJPQ/haCRIJBTL4wIl8YCsmtaBovcAXGLOShyVWQ/FG8GZA==",
-            "requires": {
+        "node_modules/socket.io": {
+            "version": "4.7.5",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.7.5.tgz",
+            "integrity": "sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==",
+            "dependencies": {
                 "accepts": "~1.3.4",
                 "base64id": "~2.0.0",
+                "cors": "~2.8.5",
                 "debug": "~4.3.2",
-                "engine.io": "~6.4.1",
+                "engine.io": "~6.5.2",
                 "socket.io-adapter": "~2.5.2",
-                "socket.io-parser": "~4.2.1"
+                "socket.io-parser": "~4.2.4"
             },
+            "engines": {
+                "node": ">=10.2.0"
+            }
+        },
+        "node_modules/socket.io-adapter": {
+            "version": "2.5.4",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.4.tgz",
+            "integrity": "sha512-wDNHGXGewWAjQPt3pyeYBtpWSq9cLE5UW1ZUPL/2eGK9jtse/FpXib7epSTsz0Q0m+6sg6Y4KtcFTlah1bdOVg==",
             "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "engine.io": {
-                    "version": "6.4.2",
-                    "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.4.2.tgz",
-                    "integrity": "sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==",
-                    "requires": {
-                        "@types/cookie": "^0.4.1",
-                        "@types/cors": "^2.8.12",
-                        "@types/node": ">=10.0.0",
-                        "accepts": "~1.3.4",
-                        "base64id": "2.0.0",
-                        "cookie": "~0.4.1",
-                        "cors": "~2.8.5",
-                        "debug": "~4.3.1",
-                        "engine.io-parser": "~5.0.3",
-                        "ws": "~8.11.0"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                },
-                "socket.io-adapter": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz",
-                    "integrity": "sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==",
-                    "requires": {
-                        "ws": "~8.11.0"
-                    }
-                },
-                "ws": {
-                    "version": "8.11.0",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-                    "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg=="
+                "debug": "~4.3.4",
+                "ws": "~8.11.0"
+            }
+        },
+        "node_modules/socket.io-adapter/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
                 }
             }
         },
-        "socket.io-parser": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.3.tgz",
-            "integrity": "sha512-JMafRntWVO2DCJimKsRTh/wnqVvO4hrfwOqtO7f+uzwsQMuxO6VwImtYxaQ+ieoyshWOTJyV0fA21lccEXRPpQ==",
-            "requires": {
+        "node_modules/socket.io-adapter/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/socket.io-parser": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+            "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+            "dependencies": {
                 "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1"
             },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/socket.io-parser/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "dependencies": {
-                "debug": {
-                    "version": "4.3.4",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
                 }
             }
         },
-        "statuses": {
+        "node_modules/socket.io-parser/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/socket.io/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/socket.io/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/statuses": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
-        "toidentifier": {
+        "node_modules/toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+            "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+            "engines": {
+                "node": ">=0.6"
+            }
         },
-        "vary": {
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+        },
+        "node_modules/vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+            "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         }
     }
 }

--- a/kuksa_apps/node-red/mqtt/package.json
+++ b/kuksa_apps/node-red/mqtt/package.json
@@ -4,7 +4,7 @@
     "version": "0.0.1",
     "private": true,
     "dependencies": {
-        "node-red-contrib-web-worldmap": "~2.31.3",
-        "node-red-dashboard": "~3.2.0"
+        "node-red-contrib-web-worldmap": "~4.6.5",
+        "node-red-dashboard": "~3.6.5"
     }
 }


### PR DESCRIPTION
Update due to a vulnerability
Also make it clear that it is deprecated.
We do not intend to migrate it.

Lock file updated by `npm i --package-lock-only`

Verification done: Checked that we could start NodeRed like below.


![image](https://github.com/eclipse/kuksa.val/assets/30996601/feae80ae-2c31-4dd4-8fd8-f79b337214f8)


