### PR TITLE
Expose databroker proto and http::uri

### DIFF
--- a/kuksa_databroker/lib/kuksa/src/lib.rs
+++ b/kuksa_databroker/lib/kuksa/src/lib.rs
@@ -11,10 +11,10 @@
 * SPDX-License-Identifier: Apache-2.0
 ********************************************************************************/
 
-use http::Uri;
+pub use http::Uri;
 use std::collections::HashMap;
 
-use databroker_proto::kuksa::val::{self as proto, v1::DataEntry};
+pub use databroker_proto::kuksa::val::{self as proto, v1::DataEntry};
 
 use kuksa_common::{Client, ClientError};
 


### PR DESCRIPTION
I am working on the Fleet Management. More specifically, the Forwarder. In order to successfully retrieve data from the databroker I must expose the protobuf definitions for Float, Double and DataEntry. Therefore, I added two pub keywords so that I can easily expose them in my project. Would be very glad if you could approve this PR.